### PR TITLE
jackmeyer/cf-561-update-the-firefox-extension-link-before

### DIFF
--- a/pkg/granted/browser.go
+++ b/pkg/granted/browser.go
@@ -3,6 +3,7 @@ package granted
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/common-fate/granted/pkg/browsers"
 	"github.com/common-fate/granted/pkg/config"
@@ -29,6 +30,14 @@ var DefaultBrowserCommand = cli.Command{
 			}
 
 			conf.DefaultBrowser = browsers.GetBrowserName(outcome)
+
+			if strings.Contains(strings.ToLower(outcome), "firefox") {
+				err = browsers.RunFirefoxExtensionPrompts()
+
+				if err != nil {
+					return err
+				}
+			}
 
 			conf.Save()
 			alert := color.New(color.Bold, color.FgGreen).SprintFunc()


### PR DESCRIPTION
- Update link
- Update some manual functionality to handle firefox prompts when manually set firefox as default browser