### PR TITLE
Jackmeyer/cf-555 add   service flag which allows the user

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,21 @@
       "mode": "auto",
       "program": "cmd/assume/main.go",
       "env": { "FORCE_NO_ALIAS": true }
+    },
+    {
+      "name": "Run command assume active role",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "cmd/assume/main.go",
+      "args": ["-console", "-active-role"],
+      "env": {
+        "FORCE_NO_ALIAS": true,
+        //will need to manually set these
+        "AWS_ACCESS_KEY_ID": "key",
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "AWS_SESSION_TOKEN": "session token"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,10 +21,7 @@
       "args": ["-console", "-active-role"],
       "env": {
         "FORCE_NO_ALIAS": true,
-        //will need to manually set these
-        "AWS_ACCESS_KEY_ID": "key",
-        "AWS_SECRET_ACCESS_KEY": "secret",
-        "AWS_SESSION_TOKEN": "session token"
+        "AWS_ROLE_PROFILE": "cf-dev"
       }
     }
   ]

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -59,7 +59,7 @@ func assumeCommand(c *cli.Context) error {
 		}
 	}
 	//set the sesh creds using the active role if we have one and the flag is set
-	if c.Bool("active-role") && os.Getenv("AWS_ROLE_PROFILE") != "" {
+	if c.Bool("active-role") && os.Getenv("GRANTED_AWS_ROLE_PROFILE") != "" {
 		//try opening using the active role
 		fmt.Fprintf(os.Stderr, "Attempting to open using active role...\n")
 

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -105,8 +105,9 @@ func assumeCommand(c *cli.Context) error {
 	if openBrower && isIamWithoutAssumedRole {
 		fmt.Fprintf(os.Stderr, "Cannot open a browser session for profile: %s because it does not assume a role", profile.Name)
 	} else if openBrower {
+		service := c.String("service")
 		fmt.Fprintf(os.Stderr, "Opening a console for %s in your browser...", profile.Name)
-		return browsers.LaunchConsoleSession(sess, labels)
+		return browsers.LaunchConsoleSession(sess, labels, service)
 	} else {
 		// DO NOT MODIFY, this like interacts with the shell script that wraps the assume command, the shell script is what configures your shell environment vars
 		fmt.Printf("GrantedAssume %s %s %s", creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken)

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -59,7 +59,7 @@ func assumeCommand(c *cli.Context) error {
 		}
 	}
 	//set the sesh creds using the active role if we have one and the flag is set
-	if c.Bool("active-role") && os.Getenv("AWS_ACCESS_KEY_ID") != "" {
+	if c.Bool("active-role") && os.Getenv("AWS_ROLE_PROFILE") != "" {
 		//try opening using the active role
 		fmt.Fprintf(os.Stderr, "Attempting to open using active role...\n")
 

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -106,8 +106,9 @@ func assumeCommand(c *cli.Context) error {
 		fmt.Fprintf(os.Stderr, "Cannot open a browser session for profile: %s because it does not assume a role", profile.Name)
 	} else if openBrower {
 		service := c.String("service")
+		region := c.String("region")
 		fmt.Fprintf(os.Stderr, "Opening a console for %s in your browser...", profile.Name)
-		return browsers.LaunchConsoleSession(sess, labels, service)
+		return browsers.LaunchConsoleSession(sess, labels, service, region)
 	} else {
 		// DO NOT MODIFY, this like interacts with the shell script that wraps the assume command, the shell script is what configures your shell environment vars
 		fmt.Printf("GrantedAssume %s %s %s", creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken)

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -63,7 +63,7 @@ func assumeCommand(c *cli.Context) error {
 		//try opening using the active role
 		fmt.Fprintf(os.Stderr, "Attempting to open using active role...\n")
 
-		profileName := os.Getenv("AWS_ROLE_PROFILE")
+		profileName := os.Getenv("GRANTED_AWS_ROLE_PROFILE")
 
 		profile = awsProfiles[profileName]
 

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -22,6 +22,7 @@ func GetCliApp() *cli.App {
 		&cli.BoolFlag{Name: "console", Aliases: []string{"c"}, Usage: "Open a web console to the role"},
 		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Specify a service to open the console into"},
 		&cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "Specify a region to open the console into"},
+		&cli.BoolFlag{Name: "active-role", Aliases: []string{"ar"}, Usage: "Open console using active role"},
 		&cli.BoolFlag{Name: "verbose", Usage: "Log debug messages"},
 		&cli.BoolFlag{Name: "banner", Aliases: []string{"b"}, Usage: "Print the assume banner"},
 		&cli.StringFlag{Name: "update-checker-api-url", Value: build.UpdateCheckerApiUrl, EnvVars: []string{"UPDATE_CHECKER_API_URL"}, Hidden: true},

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -20,6 +20,7 @@ func GetCliApp() *cli.App {
 
 	flags := []cli.Flag{
 		&cli.BoolFlag{Name: "console", Aliases: []string{"c"}, Usage: "Open a web console to the role"},
+		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Specify a service to open up to"},
 		&cli.BoolFlag{Name: "verbose", Usage: "Log debug messages"},
 		&cli.BoolFlag{Name: "banner", Aliases: []string{"b"}, Usage: "Print the assume banner"},
 		&cli.StringFlag{Name: "update-checker-api-url", Value: build.UpdateCheckerApiUrl, EnvVars: []string{"UPDATE_CHECKER_API_URL"}, Hidden: true},

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -20,7 +20,8 @@ func GetCliApp() *cli.App {
 
 	flags := []cli.Flag{
 		&cli.BoolFlag{Name: "console", Aliases: []string{"c"}, Usage: "Open a web console to the role"},
-		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Specify a service to open up to"},
+		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Specify a service to open the console into"},
+		&cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "Specify a region to open the console into"},
 		&cli.BoolFlag{Name: "verbose", Usage: "Log debug messages"},
 		&cli.BoolFlag{Name: "banner", Aliases: []string{"b"}, Usage: "Print the assume banner"},
 		&cli.StringFlag{Name: "update-checker-api-url", Value: build.UpdateCheckerApiUrl, EnvVars: []string{"UPDATE_CHECKER_API_URL"}, Hidden: true},

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -191,7 +191,7 @@ const (
 	BrowserDefault
 )
 
-func LaunchConsoleSession(sess Session, labels RoleLabels, service string) error {
+func LaunchConsoleSession(sess Session, labels RoleLabels, service string, region string) error {
 	sessJSON, err := json.Marshal(sess)
 	if err != nil {
 		return err
@@ -230,7 +230,7 @@ func LaunchConsoleSession(sess Session, labels RoleLabels, service string) error
 		Path:   "/federation",
 	}
 
-	dest, err := makeDestinationURL(service)
+	dest, err := makeDestinationURL(service, region)
 
 	if err != nil {
 		return err
@@ -262,15 +262,23 @@ func LaunchConsoleSession(sess Session, labels RoleLabels, service string) error
 	return nil
 }
 
-func makeDestinationURL(service string) (string, error) {
+func makeDestinationURL(service string, region string) (string, error) {
+
+	if region == "" {
+		region = "us-east-1"
+	}
 	prefix := "https://console.aws.amazon.com/"
 
 	serv := ServiceMap[service]
 	if serv == "" {
-		return "", fmt.Errorf("\nservice not found")
+		return "", fmt.Errorf("\nservice not found, please enter a valid service")
 	}
 
 	dest := prefix + serv + "/home"
+
+	if region != "" || serv != "iam" {
+		dest = dest + "?region=" + region
+	}
 
 	return dest, nil
 }

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -276,6 +276,7 @@ func makeDestinationURL(service string, region string) (string, error) {
 
 	dest := prefix + serv + "/home"
 
+	//NOTE here: excluding iam here and possibly others as the region isnt in the uri of the webpage on the console
 	if region != "" || serv != "iam" {
 		dest = dest + "?region=" + region
 	}

--- a/pkg/granted/browser.go
+++ b/pkg/granted/browser.go
@@ -18,35 +18,49 @@ var DefaultBrowserCommand = cli.Command{
 		&cli.BoolFlag{Name: "set", Aliases: []string{"s"}, Usage: "Set browser name"},
 	},
 	Action: func(c *cli.Context) error {
-		outcome, err := browsers.HandleManualBrowserSelection()
-		if err != nil {
-			return err
-		}
 
-		if outcome != "" {
+		if c.Bool("set") {
+			outcome, err := browsers.HandleManualBrowserSelection()
+			if err != nil {
+				return err
+			}
+
+			if outcome != "" {
+				conf, err := config.Load()
+				if err != nil {
+					return err
+				}
+
+				conf.DefaultBrowser = browsers.GetBrowserName(outcome)
+
+				if strings.Contains(strings.ToLower(outcome), "firefox") {
+					err = browsers.RunFirefoxExtensionPrompts()
+
+					if err != nil {
+						return err
+					}
+				}
+
+				err = conf.Save()
+				if err != nil {
+					return err
+				}
+				alert := color.New(color.Bold, color.FgGreen).SprintFunc()
+
+				fmt.Fprintf(os.Stderr, "\n%s\n", alert("✅  Granted web browser set."))
+			}
+			return nil
+
+		} else {
+			//return the default browser that is set
 			conf, err := config.Load()
 			if err != nil {
 				return err
 			}
+			fmt.Fprintf(os.Stderr, "Default: %s\n", conf.DefaultBrowser)
 
-			conf.DefaultBrowser = browsers.GetBrowserName(outcome)
-
-			if strings.Contains(strings.ToLower(outcome), "firefox") {
-				err = browsers.RunFirefoxExtensionPrompts()
-
-				if err != nil {
-					return err
-				}
-			}
-
-			err = conf.Save()
-			if err != nil {
-				return err
-			}
-			alert := color.New(color.Bold, color.FgGreen).SprintFunc()
-
-			fmt.Fprintf(os.Stderr, "\n%s\n", alert("✅  Granted web browser set."))
 		}
 		return nil
+
 	},
 }

--- a/scripts/assume
+++ b/scripts/assume
@@ -41,7 +41,7 @@ if [ "$GRANTED_FLAG" = "GrantedAssume" ]; then
     export AWS_SESSION_TOKEN=${GRANTED_3}
   fi
   if [ ! "${GRANTED_4}" = "None" ]; then
-    export AWS_ROLE_PROFILE=${GRANTED_4}
+    export GRANTED_AWS_ROLE_PROFILE=${GRANTED_4}
   fi
 
   for GRANTED_var in "$@"

--- a/scripts/assume
+++ b/scripts/assume
@@ -14,7 +14,7 @@ fi
 
 GRANTED_OUTPUT=$(assumego "$@")
 GRANTED_STATUS=$?
-read GRANTED_FLAG GRANTED_1 GRANTED_2 GRANTED_3 <<< $(echo $GRANTED_OUTPUT)
+read GRANTED_FLAG GRANTED_1 GRANTED_2 GRANTED_3 GRANTED_4 <<< $(echo $GRANTED_OUTPUT)
 
 # # unset the exported GRANTED_ALIAS_CONFIGURED flag
 unset GRANTED_ALIAS_CONFIGURED
@@ -27,6 +27,7 @@ if [ "$GRANTED_FLAG" = "GrantedAssume" ]; then
   unset AWS_ACCESS_KEY_ID
   unset AWS_SECRET_ACCESS_KEY
   unset AWS_SESSION_TOKEN
+  unset AWS_ROLE_PROFILE
 
   export GRANTED_COMMAND="$@"
 
@@ -38,6 +39,9 @@ if [ "$GRANTED_FLAG" = "GrantedAssume" ]; then
   fi
   if [ ! "${GRANTED_3}" = "None" ]; then
     export AWS_SESSION_TOKEN=${GRANTED_3}
+  fi
+  if [ ! "${GRANTED_4}" = "None" ]; then
+    export AWS_ROLE_PROFILE=${GRANTED_4}
   fi
 
   for GRANTED_var in "$@"
@@ -51,6 +55,9 @@ if [ "$GRANTED_FLAG" = "GrantedAssume" ]; then
       fi
       if [ ! "${GRANTED_3}" = "None" ]; then
         echo export AWS_SESSION_TOKEN=${GRANTED_3}
+      fi
+      if [ ! "${GRANTED_4}" = "None" ]; then
+        echo export AWS_ROLE_PROFILE=${GRANTED_4}
       fi
     fi
   done

--- a/scripts/assume
+++ b/scripts/assume
@@ -27,7 +27,7 @@ if [ "$GRANTED_FLAG" = "GrantedAssume" ]; then
   unset AWS_ACCESS_KEY_ID
   unset AWS_SECRET_ACCESS_KEY
   unset AWS_SESSION_TOKEN
-  unset AWS_ROLE_PROFILE
+  unset GRANTED_AWS_ROLE_PROFILE
 
   export GRANTED_COMMAND="$@"
 


### PR DESCRIPTION
https://linear.app/exponent/issue/CF-563/running-assume-console-without-arguments-should-open-the-console-for
- When a role is actively set running `assume -ar` will open up the console using the active role
https://linear.app/exponent/issue/CF-555/add-service-flag-which-allows-the-user-to-open-the-console-on-a-given
- Opens the console at the specified service with the -service flag
https://linear.app/exponent/issue/CF-554/add-region-flag-which-allows-the-user-to-specify-a-region-to-open-the
- Opens the console with the specified region 
Extra:
Updated browser prompts:
- granted browser: Now returns the current active default browser
- granted browser -set: Runs the change browser wizard 