### PR TITLE
Add password prompt for file backend

### DIFF
--- a/pkg/browsers/detect.go
+++ b/pkg/browsers/detect.go
@@ -154,6 +154,7 @@ func HandleBrowserWizard(ctx *cli.Context) error {
 
 //ConfigureBrowserSelection will verify the existance of the browser executable and promot for a path if it cannot be found
 func ConfigureBrowserSelection(browserName string) error {
+	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 	browserTitle := strings.Title(strings.ToLower(GetBrowserName(browserName)))
 	// We allow users to configure a custom install path is we cannot detect the installation
 	customBrowserPath := ""
@@ -168,7 +169,7 @@ func ConfigureBrowserSelection(browserName string) error {
 
 			bpIn := survey.Input{Message: fmt.Sprintf("Please enter the full path to your browser installation for %s:", browserTitle)}
 			fmt.Fprintln(os.Stderr)
-			err := testable.AskOne(&bpIn, &customBrowserPath)
+			err := testable.AskOne(&bpIn, &customBrowserPath, withStdio)
 			if err != nil {
 				return err
 			}

--- a/pkg/credstore/credstore.go
+++ b/pkg/credstore/credstore.go
@@ -59,8 +59,7 @@ func openKeyring() (keyring.Keyring, error) {
 	credStorePath := path.Join(grantedFolder, "cred-store")
 
 	ring, err := keyring.Open(keyring.Config{
-		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
-		FileDir:         credStorePath,
+		FileDir: credStorePath,
 		FilePasswordFunc: func(s string) (string, error) {
 			in := survey.Password{Message: s}
 			var out string

--- a/pkg/credstore/credstore.go
+++ b/pkg/credstore/credstore.go
@@ -58,7 +58,7 @@ func openKeyring() (keyring.Keyring, error) {
 	// check if the cred-store file exists in the folder
 	credStorePath := path.Join(grantedFolder, "cred-store")
 
-	ring, err := keyring.Open(keyring.Config{
+	return keyring.Open(keyring.Config{
 		FileDir: credStorePath,
 		FilePasswordFunc: func(s string) (string, error) {
 			in := survey.Password{Message: s}
@@ -69,12 +69,4 @@ func openKeyring() (keyring.Keyring, error) {
 		},
 		ServiceName: "granted",
 	})
-	if err != nil {
-		return nil, err
-	}
-	// Ensure this keyring is correctly opened, there have been some issues with ring being nil with no error
-	if ring == nil {
-		return nil, ErrCouldNotOpenKeyring
-	}
-	return ring, err
 }

--- a/pkg/credstore/credstore.go
+++ b/pkg/credstore/credstore.go
@@ -2,13 +2,17 @@ package credstore
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path"
 
 	"github.com/99designs/keyring"
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/common-fate/granted/pkg/config"
-	"github.com/common-fate/granted/pkg/debug"
+	"github.com/common-fate/granted/pkg/testable"
 )
+
+var ErrCouldNotOpenKeyring error = errors.New("keyring not opened successfully")
 
 // returns ring.ErrKeyNotFound if not found
 func Retrieve(key string, target interface{}) error {
@@ -26,7 +30,7 @@ func Retrieve(key string, target interface{}) error {
 func Store(key string, payload interface{}) error {
 	ring, err := openKeyring()
 	if err != nil {
-		return nil
+		return err
 	}
 	b, err := json.Marshal(payload)
 	if err != nil {
@@ -41,7 +45,7 @@ func Store(key string, payload interface{}) error {
 func Clear(key string) error {
 	ring, err := openKeyring()
 	if err != nil {
-		return nil
+		return err
 	}
 	return ring.Remove(key)
 }
@@ -51,24 +55,27 @@ func openKeyring() (keyring.Keyring, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	// check if the cred-store file exists in the folder
 	credStorePath := path.Join(grantedFolder, "cred-store")
-	_, err = os.Stat(credStorePath)
-	fileExists := err == nil
 
-	if !fileExists {
-		debug.Fprintf(debug.VerbosityDebug, os.Stderr, "ℹ️  A cred-store file was not found\n")
-		debug.Fprintf(debug.VerbosityDebug, os.Stderr, "Creating cred-store file at %s\n", credStorePath)
-		_, err = os.Create(credStorePath)
-		if err != nil {
-			return nil, err
-		}
-
-	}
-	return keyring.Open(keyring.Config{
-		FileDir:     path.Join(grantedFolder, "cred-store"),
+	ring, err := keyring.Open(keyring.Config{
+		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
+		FileDir:         credStorePath,
+		FilePasswordFunc: func(s string) (string, error) {
+			in := survey.Password{Message: s}
+			var out string
+			withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+			err := testable.AskOne(&in, &out, withStdio)
+			return out, err
+		},
 		ServiceName: "granted",
 	})
-
+	if err != nil {
+		return nil, err
+	}
+	// Ensure this keyring is correctly opened, there have been some issues with ring being nil with no error
+	if ring == nil {
+		return nil, ErrCouldNotOpenKeyring
+	}
+	return ring, err
 }


### PR DESCRIPTION
Fixes #54 

Implements the password prompt for FileBackend when using keychain secure storage on some systems