### PR TITLE
Fix spacing in PromoteUseFlags

### DIFF
--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -273,21 +273,18 @@ func makeDestinationURL(service string, region string) (string, error) {
 }
 
 func PromoteUseFlags(labels RoleLabels) {
-	var m string
+	var m []string
 
 	if labels.Region == "" {
-		m = " use -r to open a specific region"
+		m = append(m, "use -r to open a specific region")
 	}
 
 	if labels.Service == "" {
-		if labels.Region == "" {
-			m = m + " or "
-		}
-		m = m + " use -s to open a specific service"
+		m = append(m, "use -s to open a specific service")
 	}
 
 	if labels.Region == "" || labels.Service == "" {
-		fmt.Fprintf(os.Stderr, "\nℹ️ %s (https://docs.commonfate.io/granted/usage/console)\n", m)
+		fmt.Fprintf(os.Stderr, "\nℹ️  %s (https://docs.commonfate.io/granted/usage/console)\n", strings.Join(m, " or "))
 
 	}
 }

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -273,22 +273,21 @@ func makeDestinationURL(service string, region string) (string, error) {
 }
 
 func PromoteUseFlags(labels RoleLabels) {
-
-	promotionMsg := ""
+	var m string
 
 	if labels.Region == "" {
-		promotionMsg = promotionMsg + " use -r to open a specific region"
+		m = " use -r to open a specific region"
 	}
 
 	if labels.Service == "" {
 		if labels.Region == "" {
-			promotionMsg = promotionMsg + " or "
+			m = m + " or "
 		}
-		promotionMsg = promotionMsg + "use -s to open a specific service"
+		m = m + " use -s to open a specific service"
 	}
 
 	if labels.Region == "" || labels.Service == "" {
-		fmt.Fprintf(os.Stderr, "\nℹ️ %s (https://docs.commonfate.io/granted/usage/console)\n", promotionMsg)
+		fmt.Fprintf(os.Stderr, "\nℹ️ %s (https://docs.commonfate.io/granted/usage/console)\n", m)
 
 	}
 }


### PR DESCRIPTION
Fixes spacing in the below message

```
ℹ️ use -s to open a specific service (https://docs.commonfate.io/granted/usage/console)
```

when only a single space is used between the emoji and following character, my terminal (iTerm2 on MacOS) doesn't render a space at all.