### PR TITLE
Poc rework to support launching multiple consoles at once

### DIFF
--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -16,6 +16,7 @@ import (
 
 var GlobalFlags = []cli.Flag{
 	&cli.BoolFlag{Name: "console", Aliases: []string{"c"}, Usage: "Open a web console to the role"},
+	&cli.BoolFlag{Name: "multiple", Aliases: []string{"m"}, Usage: "Open a web console for multiple profiles"},
 	&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Specify a service to open the console into"},
 	&cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "Specify a region to open the console into"},
 	&cli.BoolFlag{Name: "active-role", Aliases: []string{"ar"}, Usage: "Open console using active role"},


### PR DESCRIPTION
Allow you to select multiple accounts to launch in the browser with a single command

I think I good feature here would be some way to support groupings of cli args, 

e.g launch a profile to 2 or more services in the same command

Possibly `assume -m cf-dev -s ecs cf-prod -s ecs`