### PR TITLE
Bug fix for global flags

### DIFF
--- a/cmd/granted/main.go
+++ b/cmd/granted/main.go
@@ -10,16 +10,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// To add more commands to the CLI app, add them to pkg/commands/entrypoint.go in GetCliApp
-// this has been abstracted in order to make testing and fish autocompletion work
 func main() {
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Printf("Granted v%s\n", build.Version)
 	}
 	app := granted.GetCliApp()
-
-	//tracing.EnsureConfigured(app, "granted")
-
 	err := app.Run(os.Args)
 	if err != nil {
 		fmt.Printf("%s\n", err)

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -20,7 +20,7 @@ import (
 func AssumeCommand(c *cli.Context) error {
 	// this custom behavious allows flags to be passed on either side of the role arg
 	// to access flags in this command, use assumeFlags.String("region") etc instead of c.String("region")
-	assumeFlags, err := cfflags.New("assumeFlags", GlobalFlags, c)
+	assumeFlags, err := cfflags.New("assumeFlags", GlobalFlags(), c)
 	if err != nil {
 		return err
 	}

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -14,17 +14,21 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var GlobalFlags = []cli.Flag{
-	&cli.BoolFlag{Name: "console", Aliases: []string{"c"}, Usage: "Open a web console to the role"},
-	&cli.BoolFlag{Name: "unset", Aliases: []string{"un"}, Usage: "Unset all environment variables configured by Assume"},
-	&cli.BoolFlag{Name: "url", Aliases: []string{"u"}, Usage: "Get an active console session url"},
-	&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Specify a service to open the console into"},
-	&cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "Specify a region to open the console into"},
-	&cli.StringSliceFlag{Name: "pass-through", Aliases: []string{"pt"}, Usage: "Pass args to proxy assumer"},
-	&cli.BoolFlag{Name: "active-role", Aliases: []string{"ar"}, Usage: "Open console using active role"},
-	&cli.BoolFlag{Name: "verbose", Usage: "Log debug messages"},
-	&cli.StringFlag{Name: "update-checker-api-url", Value: build.UpdateCheckerApiUrl, EnvVars: []string{"UPDATE_CHECKER_API_URL"}, Hidden: true},
-	&cli.StringFlag{Name: "granted-active-aws-role-profile", EnvVars: []string{"AWS_PROFILE"}, Hidden: true},
+// Prevent issues where these flags are initialised in some part of the program then used by another part
+// For our use case, we need fresh copies of these flags in the app and in the assume command
+// we use this to allow flags to be set on either side of the profile arg e.g `assume -c profile-name -r ap-southeast-2`
+func GlobalFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{Name: "console", Aliases: []string{"c"}, Usage: "Open a web console to the role"},
+		&cli.BoolFlag{Name: "unset", Aliases: []string{"un"}, Usage: "Unset all environment variables configured by Assume"},
+		&cli.BoolFlag{Name: "url", Aliases: []string{"u"}, Usage: "Get an active console session url"},
+		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Specify a service to open the console into"},
+		&cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "Specify a region to open the console into"},
+		&cli.StringSliceFlag{Name: "pass-through", Aliases: []string{"pt"}, Usage: "Pass args to proxy assumer"},
+		&cli.BoolFlag{Name: "active-role", Aliases: []string{"ar"}, Usage: "Open console using active role"},
+		&cli.BoolFlag{Name: "verbose", Usage: "Log debug messages"},
+		&cli.StringFlag{Name: "update-checker-api-url", Value: build.UpdateCheckerApiUrl, EnvVars: []string{"UPDATE_CHECKER_API_URL"}, Hidden: true},
+		&cli.StringFlag{Name: "granted-active-aws-role-profile", EnvVars: []string{"AWS_PROFILE"}, Hidden: true}}
 }
 
 func GetCliApp() *cli.App {
@@ -39,7 +43,7 @@ func GetCliApp() *cli.App {
 		UsageText:            "assume [options][Profile]",
 		Version:              build.Version,
 		HideVersion:          false,
-		Flags:                GlobalFlags,
+		Flags:                GlobalFlags(),
 		Action:               updates.WithUpdateCheck(func(c *cli.Context) error { return AssumeCommand(c) }),
 		EnableBashCompletion: true,
 		Before: func(c *cli.Context) error {


### PR DESCRIPTION
The global flags were being mutated due to being pointers, this led to unexpected behaviour and duplication of stringSlice flags values in the assume command