### PR TITLE
Add config for keyring

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,14 @@ type Config struct {
 	// used to override the builtin filepaths for custom installation locations
 	CustomBrowserPath   string
 	LastCheckForUpdates time.Weekday
+	Keyring             *KeyringConfig `toml:",omitempty"`
+}
+
+type KeyringConfig struct {
+	Backend                 *string `toml:",omitempty"`
+	KeychainName            *string `toml:",omitempty"`
+	FileDir                 *string `toml:",omitempty"`
+	LibSecretCollectionName *string `toml:",omitempty"`
 }
 
 // checks and or creates the config folder on startup

--- a/pkg/credstore/credstore.go
+++ b/pkg/credstore/credstore.go
@@ -8,6 +8,7 @@ import (
 	"github.com/99designs/keyring"
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/common-fate/granted/pkg/config"
+	"github.com/common-fate/granted/pkg/debug"
 	"github.com/common-fate/granted/pkg/testable"
 	"github.com/pkg/errors"
 )
@@ -113,6 +114,11 @@ func openKeyring() (keyring.Keyring, error) {
 			err := testable.AskOne(&in, &out, withStdio)
 			return out, err
 		},
+	}
+
+	// enable debug logging if the verbose flag is set in the CLI
+	if debug.CliVerbosity == debug.VerbosityDebug {
+		keyring.Debug = true
 	}
 
 	if cfg.Keyring != nil {

--- a/pkg/credstore/credstore.go
+++ b/pkg/credstore/credstore.go
@@ -2,7 +2,6 @@ package credstore
 
 import (
 	"encoding/json"
-	"errors"
 	"os"
 	"path"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/common-fate/granted/pkg/config"
 	"github.com/common-fate/granted/pkg/testable"
+	"github.com/pkg/errors"
 )
 
 var ErrCouldNotOpenKeyring error = errors.New("keyring not opened successfully")
@@ -72,14 +72,39 @@ func ClearAll() error {
 }
 
 func openKeyring() (keyring.Keyring, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+
 	grantedFolder, err := config.GrantedConfigFolder()
 	if err != nil {
 		return nil, err
 	}
-	// check if the cred-store file exists in the folder
+
 	credStorePath := path.Join(grantedFolder, "cred-store")
 
-	return keyring.Open(keyring.Config{
+	c := keyring.Config{
+		ServiceName: "granted",
+
+		// MacOS keychain
+		KeychainName:             "login",
+		KeychainTrustApplication: true,
+
+		// KDE Wallet
+		KWalletAppID:  "granted",
+		KWalletFolder: "granted",
+
+		// Windows
+		WinCredPrefix: "granted",
+
+		// freedesktop.org's Secret Service
+		LibSecretCollectionName: "granted",
+
+		// Pass (https://www.passwordstore.org/)
+		PassPrefix: "granted",
+
+		// Fallback encrypted file
 		FileDir: credStorePath,
 		FilePasswordFunc: func(s string) (string, error) {
 			in := survey.Password{Message: s}
@@ -88,8 +113,29 @@ func openKeyring() (keyring.Keyring, error) {
 			err := testable.AskOne(&in, &out, withStdio)
 			return out, err
 		},
-		ServiceName: "granted",
-	})
+	}
+
+	if cfg.Keyring != nil {
+		if cfg.Keyring.Backend != nil {
+			c.AllowedBackends = []keyring.BackendType{keyring.BackendType(*cfg.Keyring.Backend)}
+		}
+		if cfg.Keyring.KeychainName != nil {
+			c.KeychainName = *cfg.Keyring.KeychainName
+		}
+		if cfg.Keyring.FileDir != nil {
+			c.FileDir = *cfg.Keyring.FileDir
+		}
+		if cfg.Keyring.LibSecretCollectionName != nil {
+			c.LibSecretCollectionName = *cfg.Keyring.LibSecretCollectionName
+		}
+	}
+
+	k, err := keyring.Open(c)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening keyring")
+	}
+
+	return k, nil
 }
 
 func List() ([]keyring.Item, error) {


### PR DESCRIPTION
Adds optional config for the keyring secrets store that Granted uses to store cached AWS SSO credentials.

Example config (`~/.granted/config`):
```
DefaultBrowser = "FIREFOX"
[Keyring]
Backend="keychain"
```

The above config forces the `keychain` backend for keyring.

For any local testing of this PR, you'll need to update `~/.dgranted/config` rather than the release config file.