### PR TITLE
Adds correct MFA prompt and enforces serial if available

### DIFF
--- a/pkg/cfaws/assumer_aws_iam.go
+++ b/pkg/cfaws/assumer_aws_iam.go
@@ -23,7 +23,14 @@ func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *CFSharedConfig,
 		config.WithSharedConfigProfile(c.Name),
 		config.WithAssumeRoleCredentialOptions(func(aro *stscreds.AssumeRoleOptions) {
 			// set the token provider up
-			aro.TokenProvider = stscreds.StdinTokenProvider
+			aro.TokenProvider = MfaTokenProvider
+
+			// If the mfa_serial is defined on the root profile, we need to set it in this config so that the aws SDK knows to prompt for MFA token
+			if len(c.Parents) > 0 {
+				if c.Parents[0].AWSConfig.MFASerial != "" {
+					aro.SerialNumber = aws.String(c.Parents[0].AWSConfig.MFASerial)
+				}
+			}
 		}),
 	}
 

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -102,7 +102,7 @@ func (c *CFSharedConfig) SSOLogin(ctx context.Context) (aws.Credentials, error) 
 				aro.RoleSessionName = "Granted-" + c.Name
 				if c.AWSConfig.MFASerial != "" {
 					aro.SerialNumber = &c.AWSConfig.MFASerial
-					aro.TokenProvider = stscreds.StdinTokenProvider
+					aro.TokenProvider = MfaTokenProvider
 				}
 
 				// Default Duration set to 1 hour for the final assumed role

--- a/pkg/cfaws/creds.go
+++ b/pkg/cfaws/creds.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ssotypes "github.com/aws/aws-sdk-go-v2/service/sso/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/common-fate/granted/pkg/testable"
 )
 
 func TypeCredsToAwsCreds(c types.Credentials) aws.Credentials {
@@ -40,4 +42,12 @@ func GetCredentialsCreds(ctx context.Context, c *CFSharedConfig) (aws.Credential
 	}
 	return aws.Credentials{}, fmt.Errorf("creds invalid or expired")
 
+}
+
+func MfaTokenProvider() (string, error) {
+	in := survey.Input{Message: "MFA Token"}
+	var out string
+	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+	err := testable.AskOne(&in, &out, withStdio)
+	return out, err
 }


### PR DESCRIPTION
Fixes #103 

This PR fixes an issue with the MFA token provider not using the required Stderr.
Also ensures that if you configure your mfa_serial on the source_profile. Assume will correctly request MFA.

To test this, I have setup an IAM User in AWS which has a Virtual MFA device attached.
I have a role in the same account with a trust relationship that allows the user to assume it, but enforces that MFA token must be provided.

My credentials file has the access-key-id and secret-access-key for the iam user

My config files looks like this

```[profile josh-test]
region = ap-southeast-2
mfa_serial = arn:aws:iam::1234:mfa/josh-test


[profile mfa-test]
region=ap-southeast-2
role_arn=arn:aws:iam::1234:role/test-mfa-user-role
source_profile=josh-test
```

Running `assume mfa-test` will prompt for MFA token then successfully assumes the role