### PR TITLE
Support profiles with (some) special characters

### DIFF
--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -58,7 +58,8 @@ func GetProfilesFromDefaultSharedConfig(ctx context.Context) (CFSharedConfigs, e
 		// Check if the section is prefixed with 'profile ' and that the profile has a name
 		if strings.HasPrefix(section, "profile ") && len(section) > 8 {
 			name := strings.TrimPrefix(section, "profile ")
-			illegalChars := ".,@#$%^&*()+=\\|]}[{;:'\"<>/?"
+			//illegalChars := ".,@#$%^&*()+=\\|]}[{;:'\"<>/?"
+			illegalChars := "" //testing this as a noop
 			if strings.ContainsAny(name, illegalChars) {
 				// The AWS SDK actually fails to parse profiles containing "." however the error it returns is not useful so we need to warn users of this
 				fmt.Fprintf(color.Error, "warning, profile: %s cannot be loaded because it contains one or more of: '%s' in the name, try replacing these with '-'\n", name, illegalChars)

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -58,10 +58,8 @@ func GetProfilesFromDefaultSharedConfig(ctx context.Context) (CFSharedConfigs, e
 		// Check if the section is prefixed with 'profile ' and that the profile has a name
 		if strings.HasPrefix(section, "profile ") && len(section) > 8 {
 			name := strings.TrimPrefix(section, "profile ")
-			//illegalChars := ".,@#$%^&*()+=\\|]}[{;:'\"<>/?"
-			illegalChars := "" //testing this as a noop
+			illegalChars := "\\][;'\"" // These characters break the config file format and should not be usable for profile names
 			if strings.ContainsAny(name, illegalChars) {
-				// The AWS SDK actually fails to parse profiles containing "." however the error it returns is not useful so we need to warn users of this
 				fmt.Fprintf(color.Error, "warning, profile: %s cannot be loaded because it contains one or more of: '%s' in the name, try replacing these with '-'\n", name, illegalChars)
 				continue
 			} else {


### PR DESCRIPTION
It appears that whatever bug this code referred to no longer exists as a problem. I tested assuming the profile named `bsherman-test-dest..,@#$%^&*()+=|}{:<>/?` without any errors. See attached screenshot for proof of this working.

<img width="374" alt="success image" src="https://user-images.githubusercontent.com/80412585/163054621-a8bf2529-46ca-4ba3-825b-bc3e30fed40c.png">
<img width="683" alt="success image2" src="https://user-images.githubusercontent.com/80412585/163055586-491b9579-9854-4d74-8d0c-8b3b7aafc236.png">

