### PR TITLE
split assume process for credential_process

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -106,10 +106,12 @@ func (c *CFSharedConfig) SSOLogin(ctx context.Context, configOpts ConfigOpts) (a
 			stsp := stscreds.NewAssumeRoleProvider(stsClient, p.AWSConfig.RoleARN, func(aro *stscreds.AssumeRoleOptions) {
 				// all configuration goes in here for this profile
 				aro.RoleSessionName = "Granted-" + c.Name
-				if c.AWSConfig.MFASerial != "" {
+				if p.AWSConfig.MFASerial != "" {
+					aro.SerialNumber = &p.AWSConfig.MFASerial
+					aro.TokenProvider = MfaTokenProvider
+				} else if c.AWSConfig.MFASerial != "" {
 					aro.SerialNumber = &c.AWSConfig.MFASerial
 					aro.TokenProvider = MfaTokenProvider
-
 				}
 				aro.Duration = duration
 


### PR DESCRIPTION
Fixes #133 

We recently changed this to use the AWS sdk method for assuming a profile with credentials process, however did not consider the impacts on chained roles.

This PR uses the credential process to get the root credentials, then uses sts assume role to assume subsequent chained roles