### PR TITLE
Adjust session duration implementation

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -112,7 +112,6 @@ func AssumeCommand(c *cli.Context) error {
 
 	configOpts := cfaws.ConfigOpts{Duration: time.Hour}
 	duration := assumeFlags.String("duration")
-	fmt.Fprintln(os.Stderr, duration)
 	if duration != "" {
 		d, err := time.ParseDuration(duration)
 		if err != nil {
@@ -120,8 +119,6 @@ func AssumeCommand(c *cli.Context) error {
 		}
 		configOpts.Duration = d
 	}
-
-	fmt.Fprintf(os.Stderr, "duration: %v\n", duration)
 
 	if len(assumeFlags.StringSlice("pass-through")) > 0 {
 		configOpts.Args = assumeFlags.StringSlice("pass-through")
@@ -131,8 +128,15 @@ func AssumeCommand(c *cli.Context) error {
 	if openBrower {
 		// these are just labels for the tabs so we may need to updates these for the sso role context
 
-		browserOpts := browsers.BrowserOpts{Profile: profile.Name}
-
+		browserOpts := browsers.BrowserOpts{Profile: profile.Name, Duration: time.Hour}
+		bd := assumeFlags.String("browser-duration")
+		if bd != "" {
+			d, err := time.ParseDuration(bd)
+			if err != nil {
+				return err
+			}
+			browserOpts.Duration = d
+		}
 		service := assumeFlags.String("service")
 		if assumeFlags.String("region") != "" {
 			region = assumeFlags.String("region")

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -109,7 +109,19 @@ func AssumeCommand(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	configOpts := cfaws.ConfigOpts{}
+
+	configOpts := cfaws.ConfigOpts{Duration: time.Hour}
+	duration := assumeFlags.String("duration")
+	fmt.Fprintln(os.Stderr, duration)
+	if duration != "" {
+		d, err := time.ParseDuration(duration)
+		if err != nil {
+			return err
+		}
+		configOpts.Duration = d
+	}
+
+	fmt.Fprintf(os.Stderr, "duration: %v\n", duration)
 
 	if len(assumeFlags.StringSlice("pass-through")) > 0 {
 		configOpts.Args = assumeFlags.StringSlice("pass-through")
@@ -120,7 +132,7 @@ func AssumeCommand(c *cli.Context) error {
 		// these are just labels for the tabs so we may need to updates these for the sso role context
 
 		browserOpts := browsers.BrowserOpts{Profile: profile.Name}
-		duration := assumeFlags.String("duration")
+
 		service := assumeFlags.String("service")
 		if assumeFlags.String("region") != "" {
 			region = assumeFlags.String("region")
@@ -128,14 +140,6 @@ func AssumeCommand(c *cli.Context) error {
 
 		browserOpts.Region = region
 		browserOpts.Service = service
-		if duration != "" {
-			d, err := time.ParseDuration(duration)
-			if err != nil {
-				return err
-			}
-			configOpts.Duration = d
-
-		}
 
 		var creds aws.Credentials
 

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -128,15 +128,7 @@ func AssumeCommand(c *cli.Context) error {
 	if openBrower {
 		// these are just labels for the tabs so we may need to updates these for the sso role context
 
-		browserOpts := browsers.BrowserOpts{Profile: profile.Name, Duration: time.Hour}
-		bd := assumeFlags.String("browser-duration")
-		if bd != "" {
-			d, err := time.ParseDuration(bd)
-			if err != nil {
-				return err
-			}
-			browserOpts.Duration = d
-		}
+		browserOpts := browsers.BrowserOpts{Profile: profile.Name}
 		service := assumeFlags.String("service")
 		if assumeFlags.String("region") != "" {
 			region = assumeFlags.String("region")

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -33,7 +33,6 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "auto-configure-shell", Usage: "Configure shell alias without prompts"},
 		&cli.StringFlag{Name: "exec", Usage: "assume a profile then execute this command"},
 		&cli.StringFlag{Name: "duration", Aliases: []string{"d"}, Usage: "Set session duration for your assumed role"},
-		&cli.StringFlag{Name: "browser-duration", Aliases: []string{"bd"}, Usage: "Set session duration for your browser session"},
 	}
 }
 

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -33,6 +33,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "auto-configure-shell", Usage: "Configure shell alias without prompts"},
 		&cli.StringFlag{Name: "exec", Usage: "assume a profile then execute this command"},
 		&cli.StringFlag{Name: "duration", Aliases: []string{"d"}, Usage: "Set session duration for your assumed role"},
+		&cli.StringFlag{Name: "browser-duration", Aliases: []string{"bd"}, Usage: "Set session duration for your browser session"},
 	}
 }
 

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -186,7 +186,7 @@ const (
 	BrowserDefault
 )
 
-func MakeUrl(sess Session, labels BrowserOpts, service string, region string) (string, error) {
+func MakeUrl(sess Session, opts BrowserOpts, service string, region string) (string, error) {
 	sessJSON, err := json.Marshal(sess)
 	if err != nil {
 		return "", err
@@ -234,6 +234,7 @@ func MakeUrl(sess Session, labels BrowserOpts, service string, region string) (s
 	q.Add("Action", "login")
 	q.Add("Issuer", "")
 	q.Add("Destination", dest)
+	q.Add("SessionDuration", fmt.Sprintf("%v", opts.Duration.Seconds()))
 	q.Add("SigninToken", token.SigninToken)
 	u.RawQuery = q.Encode()
 	return u.String(), nil

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -199,6 +199,7 @@ func MakeUrl(sess Session, opts BrowserOpts, service string, region string) (str
 	}
 	q := u.Query()
 	q.Add("Action", "getSigninToken")
+	q.Add("SessionDuration", fmt.Sprintf("%v", opts.Duration.Seconds()))
 	q.Add("Session", string(sessJSON))
 	u.RawQuery = q.Encode()
 
@@ -234,7 +235,6 @@ func MakeUrl(sess Session, opts BrowserOpts, service string, region string) (str
 	q.Add("Action", "login")
 	q.Add("Issuer", "")
 	q.Add("Destination", dest)
-	q.Add("SessionDuration", fmt.Sprintf("%v", opts.Duration.Seconds()))
 	q.Add("SigninToken", token.SigninToken)
 	u.RawQuery = q.Encode()
 	return u.String(), nil

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/common-fate/granted/pkg/config"
@@ -147,10 +146,9 @@ func SessionFromCredentials(creds aws.Credentials) Session {
 
 type BrowserOpts struct {
 	// the name of the role
-	Profile  string
-	Region   string
-	Service  string
-	Duration time.Duration
+	Profile string
+	Region  string
+	Service string
 }
 
 func (r *BrowserOpts) MakeExternalFirefoxTitle() string {
@@ -199,7 +197,6 @@ func MakeUrl(sess Session, opts BrowserOpts, service string, region string) (str
 	}
 	q := u.Query()
 	q.Add("Action", "getSigninToken")
-	q.Add("SessionDuration", fmt.Sprintf("%v", opts.Duration.Seconds()))
 	q.Add("Session", string(sessJSON))
 	u.RawQuery = q.Encode()
 

--- a/pkg/cfaws/assumer_aws_credential_process.go
+++ b/pkg/cfaws/assumer_aws_credential_process.go
@@ -2,7 +2,6 @@ package cfaws
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -29,10 +28,6 @@ func loadCredProcessCreds(ctx context.Context, c *CFSharedConfig) (aws.Credentia
 }
 
 func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
-	duration := time.Hour
-	if configOpts.Duration != 0 {
-		duration = configOpts.Duration
-	}
 	// if the profile has parents, then we need to first use credentail process to assume the root profile.
 	// then assume each of the chained profiles
 	if len(c.Parents) != 0 {
@@ -55,7 +50,7 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *CFSh
 					aro.SerialNumber = &c.AWSConfig.MFASerial
 					aro.TokenProvider = MfaTokenProvider
 				}
-				aro.Duration = duration
+				aro.Duration = configOpts.Duration
 			})
 			creds, err = stsp.Retrieve(ctx)
 			if err != nil {
@@ -72,7 +67,7 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *CFSh
 				aro.SerialNumber = &c.AWSConfig.MFASerial
 				aro.TokenProvider = MfaTokenProvider
 			}
-			aro.Duration = duration
+			aro.Duration = configOpts.Duration
 		})
 		return stsp.Retrieve(ctx)
 	}

--- a/pkg/cfaws/assumer_aws_iam.go
+++ b/pkg/cfaws/assumer_aws_iam.go
@@ -2,7 +2,6 @@ package cfaws
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -19,19 +18,13 @@ type AwsIamAssumer struct {
 // For launching the console there is an extra step GetFederationToken that happens after this to get a session token
 func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
 
-	duration := time.Hour
-
-	if configOpts.Duration != 0 {
-		duration = configOpts.Duration
-	}
-
 	opts := []func(*config.LoadOptions) error{
 		// load the config profile
 		config.WithSharedConfigProfile(c.Name),
 		config.WithAssumeRoleCredentialOptions(func(aro *stscreds.AssumeRoleOptions) {
 			// set the token provider up
 			aro.TokenProvider = MfaTokenProvider
-			aro.Duration = duration
+			aro.Duration = configOpts.Duration
 
 			// If the mfa_serial is defined on the root profile, we need to set it in this config so that the aws SDK knows to prompt for MFA token
 			if len(c.Parents) > 0 {

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -87,11 +87,6 @@ func (c *CFSharedConfig) SSOLogin(ctx context.Context, configOpts ConfigOpts) (a
 	credProvider := &CredProv{rootCreds}
 
 	if requiresAssuming {
-		duration := time.Hour
-
-		if configOpts.Duration != 0 {
-			duration = configOpts.Duration
-		}
 
 		// return creds, nil
 		toAssume := append([]*CFSharedConfig{}, c.Parents[1:]...)
@@ -113,13 +108,7 @@ func (c *CFSharedConfig) SSOLogin(ctx context.Context, configOpts ConfigOpts) (a
 					aro.SerialNumber = &c.AWSConfig.MFASerial
 					aro.TokenProvider = MfaTokenProvider
 				}
-				aro.Duration = duration
-
-				// Default Duration set to 1 hour for the final assumed role
-				// In future when we support passing session duration as a flag, set it here
-				if i < len(toAssume)-1 {
-					aro.Duration = time.Hour
-				}
+				aro.Duration = configOpts.Duration
 			})
 			stsCreds, err := stsp.Retrieve(ctx)
 			if err != nil {


### PR DESCRIPTION
I found the the implementation of session duration had some issues.

One of which is that some AWS sso roles have a maximum session duration configured in AWS and cannot be extended. However when launching a browser session, we can specify a longer duration than the duration for the session credentials.

So in this PR I have added

`--duration` which configures the duration for session credentials in the terminal
`--browser-duration` which configures the browser session duration

