### PR TITLE
added settings option for ordering of profiles

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -75,7 +75,17 @@ func AssumeCommand(c *cli.Context) error {
 
 	if profile == nil {
 
+		//load config to check frecency enabled
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
 		fr, profiles := awsProfiles.GetFrecentProfiles()
+
+		if cfg.Ordering == "Alphabetical" {
+			profiles = awsProfiles.GetAlphabeticalProfiles()
+		}
 		fmt.Fprintln(color.Error, "")
 		// Replicate the logic from original assume fn.
 		in := survey.Select{

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -84,7 +84,7 @@ func AssumeCommand(c *cli.Context) error {
 		fr, profiles := awsProfiles.GetFrecentProfiles()
 
 		if cfg.Ordering == "Alphabetical" {
-			profiles = awsProfiles.GetAlphabeticalProfiles()
+			profiles = awsProfiles.ProfileNames()
 		}
 		fmt.Fprintln(color.Error, "")
 		// Replicate the logic from original assume fn.

--- a/pkg/cfaws/frecent_profiles.go
+++ b/pkg/cfaws/frecent_profiles.go
@@ -46,6 +46,12 @@ func UpdateFrecencyCache(selectedProfile string) {
 	}
 }
 
+func (c CFSharedConfigs) GetAlphabeticalProfiles() []string {
+	profileNames := c.ProfileNames()
+	return profileNames
+
+}
+
 // loads the frecency cache and generates a list of profiles with frecently used profiles first, followed by alphabetically sorted profiles that have not been used with assume
 // this method returns a FrecentProfiles pointer which should be used after selecting a profile to update the cache, it will also remove any entries which no longer exist in the aws config
 func (c CFSharedConfigs) GetFrecentProfiles() (*FrecentProfiles, []string) {

--- a/pkg/cfaws/frecent_profiles.go
+++ b/pkg/cfaws/frecent_profiles.go
@@ -46,12 +46,6 @@ func UpdateFrecencyCache(selectedProfile string) {
 	}
 }
 
-func (c CFSharedConfigs) GetAlphabeticalProfiles() []string {
-	profileNames := c.ProfileNames()
-	return profileNames
-
-}
-
 // loads the frecency cache and generates a list of profiles with frecently used profiles first, followed by alphabetically sorted profiles that have not been used with assume
 // this method returns a FrecentProfiles pointer which should be used after selecting a profile to update the cache, it will also remove any entries which no longer exist in the aws config
 func (c CFSharedConfigs) GetFrecentProfiles() (*FrecentProfiles, []string) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	CustomBrowserPath   string
 	LastCheckForUpdates time.Weekday
 	Keyring             *KeyringConfig `toml:",omitempty"`
+	Ordering            string
 }
 
 type KeyringConfig struct {

--- a/pkg/granted/settings/frecency.go
+++ b/pkg/granted/settings/frecency.go
@@ -11,9 +11,27 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var ProfileOrderingCommand = cli.Command{
+	Name:        "profile-order",
+	Usage:       "Update profile ordering when assuming",
+	Subcommands: []*cli.Command{&SetProfileOrderingCommand},
+	Action: func(c *cli.Context) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		green := color.New(color.FgGreen)
+
+		green.Fprintln(color.Error, "Current profile ordering method: ", cfg.Ordering)
+		return nil
+
+	},
+}
+
 var SetProfileOrderingCommand = cli.Command{
-	Name:  "set-order",
-	Usage: "Update profile ordering when assuming",
+	Name:  "set",
+	Usage: "Sets the method of ordering IAM profiles in the assume method",
 	Action: func(c *cli.Context) error {
 		cfg, err := config.Load()
 		if err != nil {

--- a/pkg/granted/settings/frecency.go
+++ b/pkg/granted/settings/frecency.go
@@ -1,0 +1,46 @@
+package settings
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/common-fate/granted/pkg/config"
+	"github.com/common-fate/granted/pkg/testable"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
+)
+
+var SetProfileOrderingCommand = cli.Command{
+	Name:  "set-order",
+	Usage: "Update profile ordering when assuming",
+	Action: func(c *cli.Context) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+		in := survey.Select{
+			Message: "Select filter type",
+			Options: []string{"Frecency", "Alphabetical"},
+		}
+		var selection string
+		fmt.Fprintln(color.Error)
+		err = testable.AskOne(&in, &selection, withStdio)
+		if err != nil {
+			return err
+		}
+
+		cfg.Ordering = selection
+		err = cfg.Save()
+		if err != nil {
+			return err
+		}
+
+		green := color.New(color.FgGreen)
+
+		green.Fprintln(color.Error, "Set profile ordering to: ", selection)
+		return nil
+
+	},
+}

--- a/pkg/granted/settings/settings.go
+++ b/pkg/granted/settings/settings.go
@@ -7,6 +7,6 @@ import (
 var SettingsCommand = cli.Command{
 	Name:        "settings",
 	Usage:       "Manage Granted settings",
-	Subcommands: []*cli.Command{&PrintCommand, &SetProfileOrderingCommand},
+	Subcommands: []*cli.Command{&PrintCommand, &ProfileOrderingCommand},
 	Action:      PrintCommand.Action,
 }

--- a/pkg/granted/settings/settings.go
+++ b/pkg/granted/settings/settings.go
@@ -7,6 +7,6 @@ import (
 var SettingsCommand = cli.Command{
 	Name:        "settings",
 	Usage:       "Manage Granted settings",
-	Subcommands: []*cli.Command{&PrintCommand},
+	Subcommands: []*cli.Command{&PrintCommand, &SetProfileOrderingCommand},
 	Action:      PrintCommand.Action,
 }


### PR DESCRIPTION
`granted settings set-order`
To choose either Frecency or Alphabetical for profile orderings when running `assume`

fixes #140 