### PR TITLE
Add support for other aws partitions by tokenizing regions

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -116,7 +116,6 @@ func AssumeCommand(c *cli.Context) error {
 	defer wg.Wait()
 
 	region, _, err := profile.Region(c.Context)
-
 	if err != nil {
 		return err
 	}
@@ -160,7 +159,7 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 		if assumeFlags.Bool("url") || cfg.DefaultBrowser == browsers.StdoutKey || cfg.DefaultBrowser == browsers.FirefoxStdoutKey {
-			url, err := browsers.MakeUrl(browsers.SessionFromCredentials(creds), browserOpts, service, region, browsers.Default)
+			url, err := browsers.MakeUrl(browsers.SessionFromCredentials(creds), browserOpts, service, region)
 			if err != nil {
 				return err
 			}
@@ -175,7 +174,7 @@ func AssumeCommand(c *cli.Context) error {
 		} else {
 			browsers.PromoteUseFlags(browserOpts)
 			fmt.Fprintf(color.Error, "\nOpening a console for %s in your browser...\n", profile.Name)
-			return browsers.LaunchConsoleSession(browsers.SessionFromCredentials(creds), browserOpts, service, region, browsers.Default)
+			return browsers.LaunchConsoleSession(browsers.SessionFromCredentials(creds), browserOpts, service, region)
 		}
 
 	} else {

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -106,6 +106,7 @@ func AssumeCommand(c *cli.Context) error {
 	defer wg.Wait()
 
 	region, _, err := profile.Region(c.Context)
+
 	if err != nil {
 		return err
 	}
@@ -149,7 +150,7 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 		if assumeFlags.Bool("url") || cfg.DefaultBrowser == browsers.StdoutKey || cfg.DefaultBrowser == browsers.FirefoxStdoutKey {
-			url, err := browsers.MakeUrl(browsers.SessionFromCredentials(creds), browserOpts, service, region)
+			url, err := browsers.MakeUrl(browsers.SessionFromCredentials(creds), browserOpts, service, region, browsers.Default)
 			if err != nil {
 				return err
 			}
@@ -164,7 +165,7 @@ func AssumeCommand(c *cli.Context) error {
 		} else {
 			browsers.PromoteUseFlags(browserOpts)
 			fmt.Fprintf(color.Error, "\nOpening a console for %s in your browser...\n", profile.Name)
-			return browsers.LaunchConsoleSession(browsers.SessionFromCredentials(creds), browserOpts, service, region)
+			return browsers.LaunchConsoleSession(browsers.SessionFromCredentials(creds), browserOpts, service, region, browsers.Default)
 		}
 
 	} else {

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/common-fate/granted/pkg/config"
+	"github.com/common-fate/granted/pkg/debug"
 	"github.com/fatih/color"
 	"github.com/pkg/browser"
 )
@@ -233,7 +234,7 @@ func (p PartitionHost) ConsoleHostString() string {
 		return "https://console.amazonaws.cn/"
 	}
 	// Note: we're not handling the ISO and ISOB cases, I don't think they are supported by a public AWS console
-	return "console.aws.amazon.com"
+	return "https://console.aws.amazon.com/"
 }
 
 func GetPartitionFromRegion(region string) PartitionHost {
@@ -262,8 +263,7 @@ func MakeUrl(sess Session, opts BrowserOpts, service string, region string) (str
 	}
 
 	partition := GetPartitionFromRegion(region)
-	// couldn't figure out how to flag this based on the '--verbose' setting
-	//fmt.Fprintf(color.Error, "Partition is detected as %s for region %s...\n", partition, region)
+	debug.Fprintf(debug.VerbosityDebug, color.Error, "Partition is detected as %s for region %s...\n", partition, region)
 
 	u := url.URL{
 		Scheme: "https",

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -221,6 +221,7 @@ func (p PartitionHost) HostString() string {
 	case Cn:
 		return "signin.amazonaws.cn"
 	}
+	// Note: we're not handling the ISO and ISOB cases, I don't think they are supported by a public AWS console
 	return "signin.aws.amazon.com"
 }
 
@@ -341,8 +342,8 @@ func MakeUrl(sess Session, labels BrowserOpts, service string, region string) (s
 	return u.String(), nil
 }
 
-func LaunchConsoleSession(sess Session, opts BrowserOpts, service string, region string, partition PartitionHost) error {
-	url, err := MakeUrl(sess, opts, service, region, partition)
+func LaunchConsoleSession(sess Session, opts BrowserOpts, service string, region string) error {
+	url, err := MakeUrl(sess, opts, service, region)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Based off @jordiup 's work on adding partition support:
* Tokenizes the region and determines partition based on that. I think this will be more future proof than a static list of regions.
* Fixes the console URL, which differs by partition.

Tested and appears functional. Gets me a valid console in both govcloud and commercial. I am unable to test china or the ISOs.

Supercedes #146 to solve #138 