### PR TITLE
Adds --env flag to export credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
+	github.com/joho/godotenv v1.4.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -134,7 +134,7 @@ func AssumeCommand(c *cli.Context) error {
 		configOpts.Args = assumeFlags.StringSlice("pass-through")
 	}
 
-	openBrower := assumeFlags.Bool("console") || assumeFlags.Bool("active-role") || assumeFlags.Bool("url")
+	openBrower := !assumeFlags.Bool("env") && (assumeFlags.Bool("console") || assumeFlags.Bool("active-role") || assumeFlags.Bool("url"))
 	if openBrower {
 		// these are just labels for the tabs so we may need to updates these for the sso role context
 
@@ -189,6 +189,13 @@ func AssumeCommand(c *cli.Context) error {
 			green.Fprintf(color.Error, "\n[%s](%s) session credentials will expire %s\n", profile.Name, region, creds.Expires.Local().String())
 		} else {
 			green.Fprintf(color.Error, "\n[%s](%s) session credentials ready\n", profile.Name, region)
+		}
+		if assumeFlags.Bool("env") {
+			err = cfaws.WriteCredentialsToDotenv(region, creds)
+			if err != nil {
+				return err
+			}
+			green.Fprintln(color.Error, "Exported credentials to .env file successfully")
 		}
 		if assumeFlags.String("exec") != "" {
 			return RunExecCommandWithCreds(assumeFlags.String("exec"), creds, region)

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -21,6 +21,7 @@ import (
 func GlobalFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{Name: "console", Aliases: []string{"c"}, Usage: "Open a web console to the role"},
+		&cli.BoolFlag{Name: "env", Aliases: []string{"e"}, Usage: "export credentials to a .env file"},
 		&cli.BoolFlag{Name: "unset", Aliases: []string{"un"}, Usage: "Unset all environment variables configured by Assume"},
 		&cli.BoolFlag{Name: "url", Aliases: []string{"u"}, Usage: "Get an active console session url"},
 		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Specify a service to open the console into"},

--- a/pkg/cfaws/env.go
+++ b/pkg/cfaws/env.go
@@ -1,0 +1,51 @@
+package cfaws
+
+import (
+	"fmt"
+
+	"os"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/common-fate/granted/pkg/testable"
+	"github.com/fatih/color"
+	"github.com/joho/godotenv"
+)
+
+// WriteCredentialsToDotenv will check if a .env file exists and prompt to create one if it does not.
+// After the file exists, it will be opened, credentaisl added and then written to disc
+func WriteCredentialsToDotenv(region string, creds aws.Credentials) error {
+	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+	if _, err := os.Stat("./.env"); os.IsNotExist(err) {
+		ans := false
+		err = testable.AskOne(&survey.Confirm{Message: "No .env file found in the current directory, would you like to create one?"}, &ans, withStdio)
+		if err != nil {
+			return err
+		}
+		if ans {
+			f, err := os.Create("./.env")
+			if err != nil {
+				return err
+			}
+			err = f.Close()
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(color.Error, "Created .env file.")
+		} else {
+			return fmt.Errorf(".env file does not exist and creation was aborted")
+		}
+	}
+
+	myEnv, err := godotenv.Read()
+	if err != nil {
+		return err
+	}
+
+	myEnv["AWS_ACCESS_KEY_ID"] = creds.AccessKeyID
+	myEnv["AWS_SECRET_ACCESS_KEY"] = creds.SecretAccessKey
+	myEnv["AWS_SESSION_TOKEN"] = creds.SessionToken
+	myEnv["AWS_REGION"] = region
+
+	return godotenv.Write(myEnv, "./.env")
+}


### PR DESCRIPTION
This proposal adds a --env flag, the purpose is to automatically export credentials to a .env file when assuming in the terminal.

This can be useful when using editors like vs-code with debugging features.

<img width="597" alt="image" src="https://user-images.githubusercontent.com/14214200/166224854-cbbef342-2e5b-4bc1-aa40-19bd0e478bcb.png">

exports these to a .env
If the .env does not exist it will prompt to create one
```
	AWS_ACCESS_KEY_ID=
	AWS_SECRET_ACCESS_KEY=
	AWS_SESSION_TOKEN=
	AWS_REGION=
```