### PR TITLE
Load default profile from ~/.aws/config

### DIFF
--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -64,7 +64,7 @@ func GetProfilesFromDefaultSharedConfig(ctx context.Context) (CFSharedConfigs, e
 			continue
 		}
 		// Check if the section is prefixed with 'profile ' and that the profile has a name
-		if strings.HasPrefix(section, "profile ") && len(section) > 8 {
+		if (strings.HasPrefix(section, "profile ") && len(section) > 8) || section == "default" {
 			name := strings.TrimPrefix(section, "profile ")
 			illegalChars := "\\][;'\"" // These characters break the config file format and should not be usable for profile names
 			if strings.ContainsAny(name, illegalChars) {

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/bigkevmcd/go-configparser"
+	"github.com/common-fate/granted/pkg/debug"
 	"github.com/fatih/color"
 )
 
@@ -91,7 +92,13 @@ func GetProfilesFromDefaultSharedConfig(ctx context.Context) (CFSharedConfigs, e
 
 	initialisedProfiles := make(map[string]*CFSharedConfig)
 	for k, profile := range profiles {
-		initialisedProfiles[k] = profile.CFSharedConfig
+		// if the profile type is not set, it means there was an error with a source profile
+		// We exclude it from the profile list so it cannot be assumed
+		if profile.ProfileType != "" {
+			initialisedProfiles[k] = profile.CFSharedConfig
+		} else {
+			debug.Fprintf(debug.VerbosityDebug, color.Error, "failed to identify profile type for profile: %s", k)
+		}
 	}
 	return initialisedProfiles, nil
 }


### PR DESCRIPTION
Previously, our profile loader would only load profile prefixed with "profile" e.g

[profile hello]
region = us-west-1

Though this is incorrect as it should also load the default profile as an option

Additionally, the effect of this was that any profile that listed default as its source profile would get a nil pointer exception if you try to assume it due to there being no assumer type configured.