### PR TITLE
don't prefix with GrantedOutput if env var is set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/BurntSushi/toml v1.0.0
 	github.com/alvaroloes/enumer v1.1.2
-	github.com/aws/aws-sdk-go-v2/credentials v1.8.0 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.8.0
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.10.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.3.0 // indirect
@@ -66,5 +66,5 @@ require (
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
 	golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.3.7
 )

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -192,10 +192,10 @@ func AssumeCommand(c *cli.Context) error {
 		green := color.New(color.FgGreen)
 		if creds.CanExpire {
 			sessionExpiration = creds.Expires.Format(time.RFC3339)
-
-			green.Fprintf(color.Error, "\n[%s](%s) session credentials will expire %s\n", profile.Name, region, creds.Expires.Local().String())
-
-		} else {
+			if os.Getenv("GRANTED_NO_STDERR") != "true" {
+				green.Fprintf(color.Error, "\n[%s](%s) session credentials will expire %s\n", profile.Name, region, creds.Expires.Local().String())
+			}
+		} else if os.Getenv("GRANTED_NO_STDERR") != "true" {
 			green.Fprintf(color.Error, "\n[%s](%s) session credentials ready\n", profile.Name, region)
 		}
 		if assumeFlags.Bool("env") {

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -192,10 +192,10 @@ func AssumeCommand(c *cli.Context) error {
 		green := color.New(color.FgGreen)
 		if creds.CanExpire {
 			sessionExpiration = creds.Expires.Format(time.RFC3339)
-			if os.Getenv("GRANTED_NO_STDERR") != "true" {
+			if os.Getenv("GRANTED_QUIET") != "true" {
 				green.Fprintf(color.Error, "\n[%s](%s) session credentials will expire %s\n", profile.Name, region, creds.Expires.Local().String())
 			}
-		} else if os.Getenv("GRANTED_NO_STDERR") != "true" {
+		} else if os.Getenv("GRANTED_QUIET") != "true" {
 			green.Fprintf(color.Error, "\n[%s](%s) session credentials ready\n", profile.Name, region)
 		}
 		if assumeFlags.Bool("env") {

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -265,6 +265,9 @@ func EnvKeys(creds aws.Credentials, region string) []string {
 // Currently in windows, the grantedoutput is handled differently, as linux and mac support the exec cli flag whereas windows does not yet have support
 // this method may be changed in future if we implement support for "--exec" in windows
 func MakeGrantedOutput(s string) string {
+	if os.Getenv("NO_GRANTED_OUTPUT_PREFIX") == "true" {
+		return ""
+	}
 	out := "GrantedOutput"
 	if runtime.GOOS != "windows" {
 		out += "\n"

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -265,7 +265,11 @@ func EnvKeys(creds aws.Credentials, region string) []string {
 // Currently in windows, the grantedoutput is handled differently, as linux and mac support the exec cli flag whereas windows does not yet have support
 // this method may be changed in future if we implement support for "--exec" in windows
 func MakeGrantedOutput(s string) string {
-	if os.Getenv("NO_GRANTED_OUTPUT_PREFIX") == "true" {
+	// if the GRANTED_ALIAS_CONFIGURED env variable isn't set,
+	// we aren't running in the context of the `assume` shell script.
+	// If this is the case, don't add a prefix to the output as we don't have the
+	// wrapper shell script to parse it.
+	if os.Getenv("GRANTED_ALIAS_CONFIGURED") != "true" {
 		return ""
 	}
 	out := "GrantedOutput"


### PR DESCRIPTION
if NO_GRANTED_OUTPUT_PREFIX is true, don't put "GrantedOutput"
before the stdout of executed commands