### PR TITLE
Add service shortcuts

### DIFF
--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -52,6 +52,11 @@ var ServiceMap = map[string]string{
 	"iam":            "iamv2",
 	"waf":            "wafv2",
 	"rds":            "rds",
+	"dms":            "dms/v2",
+	"mwaa":           "mwaa",
+	"redshift":       "redshiftv2",
+	"sagemaker":      "sagemaker",
+	"ssm":            "systems-manager",	
 }
 
 var globalServiceMap = map[string]bool{

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -54,6 +54,7 @@ var ServiceMap = map[string]string{
 	"rds":            "rds",
 	"dms":            "dms/v2",
 	"mwaa":           "mwaa",
+	"param":          "systems-manager/parameters",
 	"redshift":       "redshiftv2",
 	"sagemaker":      "sagemaker",
 	"ssm":            "systems-manager",	


### PR DESCRIPTION
Add these AWS services for the `-s` flag
* Database Migration Service (DMS)
* Managed Workflows for Apache Airflow
* Parameter Store
* Redshift
* Sagemaker
* Systems Manager