### PR TITLE
Support arbitrary service names

### DIFF
--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -362,6 +362,7 @@ func makeDestinationURL(service string, region string) (string, error) {
 
 	serv := ServiceMap[service]
 	if serv == "" {
+		color.New(color.FgYellow).Fprintf(color.Error, "[warning] we don't recognize service %s but we'll try and open it anyway (you may receive a 404 page)", service)
 		serv = service
 	}
 

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -26,8 +25,14 @@ var ServiceMap = map[string]string{
 	"":               "console",
 	"ec2":            "ec2/v2",
 	"sso":            "singlesignon",
+ 	"ecs":            "ecs",
+	"eks":            "eks",
+	"athena":         "athena",
+	"cloudmap":       "cloudmap",
 	"c9":             "cloud9",
 	"cfn":            "cloudformation",
+	"cloudformation": "cloudformation",
+	"cloudwatch":     "cloudwatch",
 	"gd":             "guardduty",
 	"l":              "lambda",
 	"cw":             "cloudwatch",
@@ -36,13 +41,21 @@ var ServiceMap = map[string]string{
 	"ddb":            "dynamodbv2",
 	"eb":             "elasticbeanstalk",
 	"ebs":            "elasticbeanstalk",
+	"ecr":            "ecr",
+	"grafana":        "grafana",
+	"lambda":         "lambda",
 	"route53":        "route53/v2",
 	"r53":            "route53/v2",
+	"s3":             "s3",
+	"secretsmanager": "secretsmanager",
 	"iam":            "iamv2",
 	"waf":            "wafv2",
+	"rds":            "rds",
 	"dms":            "dms/v2",
+	"mwaa":           "mwaa",
 	"param":          "systems-manager/parameters",
 	"redshift":       "redshiftv2",
+	"sagemaker":      "sagemaker",
 	"ssm":            "systems-manager",	
 }
 

--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -26,14 +26,8 @@ var ServiceMap = map[string]string{
 	"":               "console",
 	"ec2":            "ec2/v2",
 	"sso":            "singlesignon",
-	"ecs":            "ecs",
-	"eks":            "eks",
-	"athena":         "athena",
-	"cloudmap":       "cloudmap",
 	"c9":             "cloud9",
 	"cfn":            "cloudformation",
-	"cloudformation": "cloudformation",
-	"cloudwatch":     "cloudwatch",
 	"gd":             "guardduty",
 	"l":              "lambda",
 	"cw":             "cloudwatch",
@@ -42,21 +36,13 @@ var ServiceMap = map[string]string{
 	"ddb":            "dynamodbv2",
 	"eb":             "elasticbeanstalk",
 	"ebs":            "elasticbeanstalk",
-	"ecr":            "ecr",
-	"grafana":        "grafana",
-	"lambda":         "lambda",
 	"route53":        "route53/v2",
 	"r53":            "route53/v2",
-	"s3":             "s3",
-	"secretsmanager": "secretsmanager",
 	"iam":            "iamv2",
 	"waf":            "wafv2",
-	"rds":            "rds",
 	"dms":            "dms/v2",
-	"mwaa":           "mwaa",
 	"param":          "systems-manager/parameters",
 	"redshift":       "redshiftv2",
-	"sagemaker":      "sagemaker",
 	"ssm":            "systems-manager",	
 }
 
@@ -376,17 +362,7 @@ func makeDestinationURL(service string, region string) (string, error) {
 
 	serv := ServiceMap[service]
 	if serv == "" {
-		var validServices []string
-		for s := range ServiceMap {
-			validServices = append(validServices, s)
-		}
-		// present the strings in alphabetical order.
-		// Yes, this is a bit of computation - but our arrays are quite small
-		// and this avoids the need to keep the ServiceMap alphabetically sorted when developing Granted.
-		sort.Strings(validServices)
-
-		return "", fmt.Errorf("\nservice %s not found, please enter a valid service shortcut \nValid service shortcuts: [%s]\n", service, strings.Join(validServices, ", "))
-
+		serv = service
 	}
 
 	dest := prefix + serv + "/home"


### PR DESCRIPTION
Allow users to use arbitrary names for AWS console services.

There's still an optional mapping step, useful for a) services that have unusual URLs, and b) nicknames.