### PR TITLE
reduce loading times by deferring initialisation of profile

### DIFF
--- a/pkg/assume/completion.go
+++ b/pkg/assume/completion.go
@@ -21,8 +21,8 @@ func Completion(ctx *cli.Context) {
 		cli.DefaultAppComplete(ctx)
 	} else {
 		// Ignore errors from this function. Tab completion handles graceful degradation back to listing files.
-		awsProfiles, _ := cfaws.GetProfilesFromDefaultSharedConfig(ctx.Context)
+		awsProfiles, _ := cfaws.LoadProfiles()
 		// Tab completion script requires each option to be separated by a newline
-		fmt.Println(strings.Join(awsProfiles.ProfileNamesSorted(), "\n"))
+		fmt.Println(strings.Join(awsProfiles.ProfileNames, "\n"))
 	}
 }

--- a/pkg/cfaws/assumer_aws_azure_login.go
+++ b/pkg/cfaws/assumer_aws_azure_login.go
@@ -20,7 +20,7 @@ type AwsAzureLoginAssumer struct {
 //https://github.com/sportradar/aws-azure-login
 
 // then fetch them from the environment for use
-func (aal *AwsAzureLoginAssumer) AssumeTerminal(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (aal *AwsAzureLoginAssumer) AssumeTerminal(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	//check to see if the creds are already exported
 	creds, err := GetCredentialsCreds(ctx, c)
 
@@ -51,7 +51,7 @@ func (aal *AwsAzureLoginAssumer) AssumeTerminal(ctx context.Context, c *CFShared
 	return aws.NewCredentialsCache(cfg.Credentials).Retrieve(ctx)
 }
 
-func (aal *AwsAzureLoginAssumer) AssumeConsole(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (aal *AwsAzureLoginAssumer) AssumeConsole(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	return aal.AssumeTerminal(ctx, c, configOpts)
 }
 

--- a/pkg/cfaws/assumer_aws_credential_process.go
+++ b/pkg/cfaws/assumer_aws_credential_process.go
@@ -15,7 +15,7 @@ import (
 type CredentialProcessAssumer struct {
 }
 
-func loadCredProcessCreds(ctx context.Context, c *CFSharedConfig) (aws.Credentials, error) {
+func loadCredProcessCreds(ctx context.Context, c *Profile) (aws.Credentials, error) {
 	var credProcessCommand string
 	for k, v := range c.RawConfig {
 		if k == "credential_process" {
@@ -27,7 +27,7 @@ func loadCredProcessCreds(ctx context.Context, c *CFSharedConfig) (aws.Credentia
 	return p.Retrieve(ctx)
 }
 
-func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	// if the profile has parents, then we need to first use credentail process to assume the root profile.
 	// then assume each of the chained profiles
 	if len(c.Parents) != 0 {
@@ -37,7 +37,7 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *CFSh
 			return creds, err
 		}
 		for _, p := range c.Parents[1:] {
-			region, _, err := p.Region(ctx)
+			region, err := p.Region(ctx)
 			if err != nil {
 				return aws.Credentials{}, err
 			}
@@ -57,7 +57,7 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *CFSh
 				return creds, err
 			}
 		}
-		region, _, err := c.Region(ctx)
+		region, err := c.Region(ctx)
 		if err != nil {
 			return aws.Credentials{}, err
 		}
@@ -76,7 +76,7 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *CFSh
 
 }
 
-func (cpa *CredentialProcessAssumer) AssumeConsole(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (cpa *CredentialProcessAssumer) AssumeConsole(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	return cpa.AssumeTerminal(ctx, c, configOpts)
 }
 

--- a/pkg/cfaws/assumer_aws_google_auth.go
+++ b/pkg/cfaws/assumer_aws_google_auth.go
@@ -19,7 +19,7 @@ type AwsGoogleAuthAssumer struct {
 
 // launch the aws-google-auth utility to generate the credentials
 // then fetch them from the environment for use
-func (aia *AwsGoogleAuthAssumer) AssumeTerminal(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (aia *AwsGoogleAuthAssumer) AssumeTerminal(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	cmd := exec.Command("aws-google-auth", fmt.Sprintf("--profile=%s", c.Name))
 
 	cmd.Stdout = color.Error
@@ -36,7 +36,7 @@ func (aia *AwsGoogleAuthAssumer) AssumeTerminal(ctx context.Context, c *CFShared
 	return creds, nil
 }
 
-func (aia *AwsGoogleAuthAssumer) AssumeConsole(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (aia *AwsGoogleAuthAssumer) AssumeConsole(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	return aia.AssumeTerminal(ctx, c, configOpts)
 }
 

--- a/pkg/cfaws/assumer_aws_iam.go
+++ b/pkg/cfaws/assumer_aws_iam.go
@@ -16,7 +16,7 @@ type AwsIamAssumer struct {
 
 // Default behaviour is to use the sdk to retrieve the credentials from the file
 // For launching the console there is an extra step GetFederationToken that happens after this to get a session token
-func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 
 	opts := []func(*config.LoadOptions) error{
 		// load the config profile
@@ -50,7 +50,7 @@ func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *CFSharedConfig,
 
 // if required will get a FederationToken to be used to launch the console
 // This is required is the iam profile does not assume a role using sts.AssumeRole
-func (aia *AwsIamAssumer) AssumeConsole(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (aia *AwsIamAssumer) AssumeConsole(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	if c.AWSConfig.RoleARN == "" {
 		return getFederationToken(ctx, c)
 	} else {
@@ -85,7 +85,7 @@ var allowAllPolicy = `{
 // GetFederationToken is used when launching a console session with longlived IAM credentials profiles
 // GetFederation token uses an allow all IAM policy so that the console session will be able to access everything
 // If this is not provided, the session cannot do anything in the console
-func getFederationToken(ctx context.Context, c *CFSharedConfig) (aws.Credentials, error) {
+func getFederationToken(ctx context.Context, c *Profile) (aws.Credentials, error) {
 	opts := []func(*config.LoadOptions) error{
 		// load the config profile
 		config.WithSharedConfigProfile(c.Name),

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -26,11 +26,11 @@ import (
 type AwsSsoAssumer struct {
 }
 
-func (asa *AwsSsoAssumer) AssumeTerminal(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (asa *AwsSsoAssumer) AssumeTerminal(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	return c.SSOLogin(ctx, configOpts)
 }
 
-func (asa *AwsSsoAssumer) AssumeConsole(ctx context.Context, c *CFSharedConfig, configOpts ConfigOpts) (aws.Credentials, error) {
+func (asa *AwsSsoAssumer) AssumeConsole(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	return c.SSOLogin(ctx, configOpts)
 }
 
@@ -43,7 +43,7 @@ func (asa *AwsSsoAssumer) ProfileMatchesType(rawProfile configparser.Dict, parse
 	return parsedProfile.SSOAccountID != ""
 }
 
-func (c *CFSharedConfig) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Credentials, error) {
+func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Credentials, error) {
 
 	rootProfile := c
 	requiresAssuming := false
@@ -91,10 +91,10 @@ func (c *CFSharedConfig) SSOLogin(ctx context.Context, configOpts ConfigOpts) (a
 	if requiresAssuming {
 
 		// return creds, nil
-		toAssume := append([]*CFSharedConfig{}, c.Parents[1:]...)
+		toAssume := append([]*Profile{}, c.Parents[1:]...)
 		toAssume = append(toAssume, c)
 		for i, p := range toAssume {
-			region, _, err := c.Region(ctx)
+			region, err := c.Region(ctx)
 			if err != nil {
 				return aws.Credentials{}, err
 			}
@@ -134,7 +134,7 @@ func (c *CFSharedConfig) SSOLogin(ctx context.Context, configOpts ConfigOpts) (a
 }
 
 // SSODeviceCodeFlow contains all the steps to complete a device code flow to retrieve an sso token
-func SSODeviceCodeFlow(ctx context.Context, cfg aws.Config, rootProfile *CFSharedConfig) (*SSOToken, error) {
+func SSODeviceCodeFlow(ctx context.Context, cfg aws.Config, rootProfile *Profile) (*SSOToken, error) {
 	ssooidcClient := ssooidc.NewFromConfig(cfg)
 
 	register, err := ssooidcClient.RegisterClient(ctx, &ssooidc.RegisterClientInput{

--- a/pkg/cfaws/assumers.go
+++ b/pkg/cfaws/assumers.go
@@ -13,9 +13,9 @@ import (
 //EG. assume role-a -pt --mode -pt gui (Run the proxy login with a gui rather than in cli. Example taken from aws-azure-login)
 type Assumer interface {
 	// AssumeTerminal should follow the required process for it implemetation and return aws credentials ready to be exported to the terminal environment
-	AssumeTerminal(context.Context, *CFSharedConfig, ConfigOpts) (aws.Credentials, error)
+	AssumeTerminal(context.Context, *Profile, ConfigOpts) (aws.Credentials, error)
 	// AssumeConsole should follow any console specific credentials processes, this may be the same as AssumeTerminal under the hood
-	AssumeConsole(context.Context, *CFSharedConfig, ConfigOpts) (aws.Credentials, error)
+	AssumeConsole(context.Context, *Profile, ConfigOpts) (aws.Credentials, error)
 	// A unique key which identifies this assumer e.g AWS-SSO or GOOGLE-AWS-AUTH
 	Type() string
 	// ProfileMatchesType takes a list of strings which are the lines in an aw config profile and returns true if this profile is the assumers type

--- a/pkg/cfaws/creds.go
+++ b/pkg/cfaws/creds.go
@@ -32,7 +32,7 @@ func GetEnvCredentials(ctx context.Context) aws.Credentials {
 	return aws.Credentials{AccessKeyID: os.Getenv("AWS_ACCESS_KEY_ID"), SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"), SessionToken: os.Getenv("AWS_SESSION_TOKEN")}
 }
 
-func GetCredentialsCreds(ctx context.Context, c *CFSharedConfig) (aws.Credentials, error) {
+func GetCredentialsCreds(ctx context.Context, c *Profile) (aws.Credentials, error) {
 	//check to see if the creds are already exported
 	creds, _ := aws.NewCredentialsCache(&CredProv{Credentials: c.AWSConfig.Credentials}).Retrieve(ctx)
 


### PR DESCRIPTION
Fixes #172 

This PR improves the performance of the assume command by deferring initialisation of an AWSProfile parent tree until after a profile is selected.

In my testing with 150 profiles, this reduced the time to prompt in the assume command from 1.7s to 7ms as it is effectively just a few file reads.

The effect is that autocomplete and assume with no profile should take ms to load rather than seconds for large configs.
Only the selected profile will be parsed for type and parents before assuming.