### PR TITLE
adding check for credentials file not existing before erroring out

### DIFF
--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -84,6 +85,9 @@ func (p *Profiles) loadDefaultConfigFile() error {
 	configPath := config.DefaultSharedConfigFilename()
 	configFile, err := configparser.NewConfigParserFromFile(configPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Currently with 0.2.3+, `assume` will always error out if you do not have an `~/.aws/credentials` file present despite it not being required.

This patch tests the error for [os.ErrNotExist](https://github.com/golang/go/blob/master/src/os/error.go#L24) by way of the [os.IsNotExist](https://github.com/golang/go/blob/master/src/os/error.go#L92) err utility func.