### PR TITLE
Fix error being returned if credentials file doesn't exist

### DIFF
--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -123,6 +123,9 @@ func (p *Profiles) loadDefaultCredentialsFile() error {
 	credsPath := config.DefaultSharedCredentialsFilename()
 	credsFile, err := configparser.NewConfigParserFromFile(credsPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -84,6 +85,9 @@ func (p *Profiles) loadDefaultConfigFile() error {
 	configPath := config.DefaultSharedConfigFilename()
 	configFile, err := configparser.NewConfigParserFromFile(configPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Extends on #197 and adds a check to `loadCredentialsFile` to avoid throwing an error if the file doesn't exist. 

Tested manually and verified that this solves the problem where `~/.aws/credentials` doesn't exist.