### PR TITLE
The -s flag now assumes -c

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -147,7 +147,7 @@ func AssumeCommand(c *cli.Context) error {
 		configOpts.Args = assumeFlags.StringSlice("pass-through")
 	}
 
-	openBrower := !assumeFlags.Bool("env") && (assumeFlags.Bool("console") || assumeFlags.Bool("active-role") || len(assumeFlags.String("service")) > 0 || assumeFlags.Bool("url"))
+	openBrower := !assumeFlags.Bool("env") && (assumeFlags.Bool("console") || assumeFlags.Bool("active-role") || assumeFlags.String("service") != "" || assumeFlags.Bool("url"))
 	if openBrower {
 		// these are just labels for the tabs so we may need to updates these for the sso role context
 

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -147,7 +147,7 @@ func AssumeCommand(c *cli.Context) error {
 		configOpts.Args = assumeFlags.StringSlice("pass-through")
 	}
 
-	openBrower := !assumeFlags.Bool("env") && (assumeFlags.Bool("console") || assumeFlags.Bool("active-role") || assumeFlags.Bool("url"))
+	openBrower := !assumeFlags.Bool("env") && (assumeFlags.Bool("console") || assumeFlags.Bool("active-role") || len(assumeFlags.String("service")) > 0 || assumeFlags.Bool("url"))
 	if openBrower {
 		// these are just labels for the tabs so we may need to updates these for the sso role context
 

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -25,7 +25,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "export", Aliases: []string{"ex"}, Usage: "export credentials to a ~.aws/credentials file"},
 		&cli.BoolFlag{Name: "unset", Aliases: []string{"un"}, Usage: "Unset all environment variables configured by Assume"},
 		&cli.BoolFlag{Name: "url", Aliases: []string{"u"}, Usage: "Get an active console session url"},
-		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Console service to open"},
+		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Like --c, but opens to a specified service"},
 		&cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "region to launch the console or export to the terminal"},
 		&cli.StringSliceFlag{Name: "pass-through", Aliases: []string{"pt"}, Usage: "Pass args to proxy assumer"},
 		&cli.BoolFlag{Name: "active-role", Aliases: []string{"ar"}, Usage: "Open console using active role"},


### PR DESCRIPTION
This is a fix for issue #201.
Boolean logic for opening browser now checks that service flag length is > 0
Updated help page to clarify what --c does