### PR TITLE
Localize datetime for session token expiration

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -195,7 +195,7 @@ func AssumeCommand(c *cli.Context) error {
 		sessionExpiration := ""
 		green := color.New(color.FgGreen)
 		if creds.CanExpire {
-			sessionExpiration = creds.Expires.Format(time.RFC3339)
+			sessionExpiration = creds.Expires.Local().Format(time.RFC3339)
 			if os.Getenv("GRANTED_QUIET") != "true" {
 				green.Fprintf(color.Error, "\n[%s](%s) session credentials will expire %s\n", profile.Name, region, creds.Expires.Local().String())
 			}


### PR DESCRIPTION
This fixes https://github.com/common-fate/granted/issues/205 by forcing session tokens to always use local time when writing output from the assume command.