### PR TITLE
Fix conflicting exported names

### DIFF
--- a/pkg/cfaws/cred-exporter.go
+++ b/pkg/cfaws/cred-exporter.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/bigkevmcd/go-configparser"
+	gconfig "github.com/common-fate/granted/pkg/config"
+
 	"github.com/fatih/color"
 )
 
@@ -33,6 +35,15 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 	credFile, err := configparser.NewConfigParserFromFile(credPath)
 	if err != nil {
 		return err
+	}
+
+	cfg, err := gconfig.Load()
+	if err != nil {
+		return err
+	}
+
+	if cfg.ExportCredentialSuffix != "" {
+		profileName = profileName + "-" + cfg.ExportCredentialSuffix
 	}
 
 	if credFile.HasSection(profileName) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,11 +19,12 @@ import (
 type Config struct {
 	DefaultBrowser string
 	// used to override the builtin filepaths for custom installation locations
-	CustomBrowserPath    string
-	CustomSSOBrowserPath string
-	LastCheckForUpdates  time.Weekday
-	Keyring              *KeyringConfig `toml:",omitempty"`
-	Ordering             string
+	CustomBrowserPath      string
+	CustomSSOBrowserPath   string
+	LastCheckForUpdates    time.Weekday
+	Keyring                *KeyringConfig `toml:",omitempty"`
+	Ordering               string
+	ExportCredentialSuffix string
 }
 
 type KeyringConfig struct {

--- a/pkg/granted/settings/export.go
+++ b/pkg/granted/settings/export.go
@@ -13,7 +13,7 @@ import (
 
 var ExportSettingsCommand = cli.Command{
 	Name:        "export-suffix",
-	Usage:       "sets a exported profile name with a user specified suffix",
+	Usage:       "suffix to be added when exporting credentials using granteds --export flag.",
 	Subcommands: []*cli.Command{&SetExportSettingsCommand},
 	Action: func(c *cli.Context) error {
 		cfg, err := config.Load()
@@ -31,7 +31,7 @@ var ExportSettingsCommand = cli.Command{
 
 var SetExportSettingsCommand = cli.Command{
 	Name:  "set",
-	Usage: "Sets the prefix",
+	Usage: "sets a suffix to be added when exporting credentials using granteds --export flag.",
 	Action: func(c *cli.Context) error {
 		cfg, err := config.Load()
 		if err != nil {
@@ -39,7 +39,7 @@ var SetExportSettingsCommand = cli.Command{
 		}
 		withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 		in := survey.Input{
-			Message: "Exported credential suffix",
+			Message: "Exported credential suffix:",
 		}
 		var selection string
 		fmt.Fprintln(color.Error)

--- a/pkg/granted/settings/export.go
+++ b/pkg/granted/settings/export.go
@@ -1,0 +1,63 @@
+package settings
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/common-fate/granted/pkg/config"
+	"github.com/common-fate/granted/pkg/testable"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
+)
+
+var ExportSettingsCommand = cli.Command{
+	Name:        "export-suffix",
+	Usage:       "sets a exported profile name with a user specified suffix",
+	Subcommands: []*cli.Command{&SetExportSettingsCommand},
+	Action: func(c *cli.Context) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		green := color.New(color.FgGreen)
+
+		green.Fprintln(color.Error, "Current suffix: ", cfg.ExportCredentialSuffix)
+		return nil
+
+	},
+}
+
+var SetExportSettingsCommand = cli.Command{
+	Name:  "set",
+	Usage: "Sets the prefix",
+	Action: func(c *cli.Context) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+		in := survey.Input{
+			Message: "Exported credential suffix",
+		}
+		var selection string
+		fmt.Fprintln(color.Error)
+		err = testable.AskOne(&in, &selection, withStdio)
+		if err != nil {
+			return err
+		}
+
+		cfg.ExportCredentialSuffix = selection
+		err = cfg.Save()
+		if err != nil {
+			return err
+		}
+
+		green := color.New(color.FgGreen)
+
+		green.Fprintln(color.Error, "Set export credential suffix to: ", selection)
+		return nil
+
+	},
+}

--- a/pkg/granted/settings/settings.go
+++ b/pkg/granted/settings/settings.go
@@ -7,6 +7,6 @@ import (
 var SettingsCommand = cli.Command{
 	Name:        "settings",
 	Usage:       "Manage Granted settings",
-	Subcommands: []*cli.Command{&PrintCommand, &ProfileOrderingCommand},
+	Subcommands: []*cli.Command{&PrintCommand, &ProfileOrderingCommand, &ExportSettingsCommand},
 	Action:      PrintCommand.Action,
 }


### PR DESCRIPTION
Fixes #207 
Added Granted config field which adds suffix to exported credentials.
eg. Setting a suffix of `exported`
When exporting the credentials for a role 'test-role' will save them under a profile [test-tole-exported] in ~/.aws/credentials