### PR TITLE
Use `role_session_name` from AWS config if defined instead of unique generated ID

### DIFF
--- a/pkg/cfaws/assumer_aws_credential_process.go
+++ b/pkg/cfaws/assumer_aws_credential_process.go
@@ -42,7 +42,11 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *Prof
 				return aws.Credentials{}, err
 			}
 			stsp := stscreds.NewAssumeRoleProvider(sts.New(sts.Options{Credentials: aws.NewCredentialsCache(&CredProv{creds}), Region: region}), p.AWSConfig.RoleARN, func(aro *stscreds.AssumeRoleOptions) {
-				aro.RoleSessionName = sessionName()
+				if p.AWSConfig.RoleSessionName != "" {
+					aro.RoleSessionName = p.AWSConfig.RoleSessionName
+				} else {
+					aro.RoleSessionName = sessionName()
+				}
 				if p.AWSConfig.MFASerial != "" {
 					aro.SerialNumber = &p.AWSConfig.MFASerial
 					aro.TokenProvider = MfaTokenProvider
@@ -62,7 +66,11 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *Prof
 			return aws.Credentials{}, err
 		}
 		stsp := stscreds.NewAssumeRoleProvider(sts.New(sts.Options{Credentials: aws.NewCredentialsCache(&CredProv{creds}), Region: region}), c.AWSConfig.RoleARN, func(aro *stscreds.AssumeRoleOptions) {
-			aro.RoleSessionName = sessionName()
+			if c.AWSConfig.RoleSessionName != "" {
+				aro.RoleSessionName = c.AWSConfig.RoleSessionName
+			} else {
+				aro.RoleSessionName = sessionName()
+			}
 			if c.AWSConfig.MFASerial != "" {
 				aro.SerialNumber = &c.AWSConfig.MFASerial
 				aro.TokenProvider = MfaTokenProvider

--- a/pkg/cfaws/assumer_aws_iam.go
+++ b/pkg/cfaws/assumer_aws_iam.go
@@ -33,7 +33,11 @@ func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *Profile, config
 
 				}
 			}
-			aro.RoleSessionName = sessionName()
+			if c.AWSConfig.RoleSessionName != "" {
+				aro.RoleSessionName = c.AWSConfig.RoleSessionName
+			} else {
+				aro.RoleSessionName = sessionName()
+			}
 		}),
 	}
 

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -102,7 +102,11 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 			stsClient := sts.New(sts.Options{Credentials: aws.NewCredentialsCache(credProvider), Region: region})
 			stsp := stscreds.NewAssumeRoleProvider(stsClient, p.AWSConfig.RoleARN, func(aro *stscreds.AssumeRoleOptions) {
 				// all configuration goes in here for this profile
-				aro.RoleSessionName = sessionName()
+				if p.AWSConfig.RoleSessionName != "" {
+					aro.RoleSessionName = p.AWSConfig.RoleSessionName
+				} else {
+					aro.RoleSessionName = sessionName()
+				}
 				if p.AWSConfig.MFASerial != "" {
 					aro.SerialNumber = &p.AWSConfig.MFASerial
 					aro.TokenProvider = MfaTokenProvider
@@ -199,7 +203,7 @@ type PollingConfig struct {
 	TimeoutAfter  time.Duration
 }
 
-//PollToken will poll for a token and return it once the authentication/authorization flow has been completed in the browser
+// PollToken will poll for a token and return it once the authentication/authorization flow has been completed in the browser
 func PollToken(ctx context.Context, c *ssooidc.Client, clientSecret string, clientID string, deviceCode string, cfg PollingConfig) (*ssooidc.CreateTokenOutput, error) {
 	start := time.Now()
 	for {


### PR DESCRIPTION
Resolves #199 