### PR TITLE
Add automatic reassume functionality for zsh

### DIFF
--- a/scripts/assume
+++ b/scripts/assume
@@ -12,7 +12,7 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
 fi
 
 # in some cases such as github actions, the SHELL env var is not available to the program
-# so here we set it explicitly 
+# so here we set it explicitly
 GRANTED_OUTPUT=$(assumego "$@")
 GRANTED_STATUS=$?
 read GRANTED_FLAG GRANTED_1 GRANTED_2 GRANTED_3 GRANTED_4 GRANTED_5 GRANTED_6<<< $(echo $GRANTED_OUTPUT)
@@ -86,8 +86,44 @@ if [ "$GRANTED_FLAG" = "GrantedAssume" ]; then
   done
 fi
 
+# Mark: Automatically re-assume when credentials expire.
+_is_assume_expired() {
+  if [[ -z "${AWS_PROFILE}" ]]; then return 1; fi
 
-# The GrantedOutput flag should be followed by a newline, then the output. 
+  # Note: this must remain compatible with both BSD and GNU date.
+  # TODO: This should probably run a few minutes (configurable) before it expires.
+  local current_time="$(date -Iseconds)"
+  local expiry="$AWS_SESSION_EXPIRATION"
+  [[ "${current_time}" > "${expiry}" ]]
+}
+
+granted_auto_reassume() {
+  # Nothing to do, we can't reassume a profile that we don't know.
+  if [[ -z "${AWS_PROFILE}" ]]; then return 0; fi
+
+  if ! _is_assume_expired; then return 0; fi
+
+  if [[ "${GRANTED_QUIET}" != "true" ]]
+  then
+    echo "granted session expired; reassuming ${AWS_PROFILE}." >&2
+  fi
+  assume "${AWS_PROFILE}"
+}
+
+if [[ -n "${ZSH_NAME}" ]]
+then
+  if [[ "${GRANTED_ENABLE_AUTO_REASSUME}" = "true" ]]
+  then
+    if ! [[ " ${preexec_functions[*]} " =~ " granted_auto_reassume " ]]
+    then
+      autoload -Uz add-zsh-hook
+      add-zsh-hook preexec granted_auto_reassume
+    fi
+  fi
+fi
+
+
+# The GrantedOutput flag should be followed by a newline, then the output.
 # This way, the shell script can omit the first line containing the flag and return the unaltered output to the stdout
 # This is great as it works well with the -exec flag
 if [ "$GRANTED_FLAG" = "GrantedOutput" ];then


### PR DESCRIPTION
Partially fixes issue #129. Scope limited to zsh.

This script is crude, and has several shortcomings, but the solutions are nontrivial and it should work as-is.

I previously implemented this as a profile, so it has some rough edges from the conversion. Since the hook should only be added once, it needed extra logic to test that, which I have not yet scrutinized.

The date logic is tricky, and limited by the need to maintain compatibility with both GNU and BSD `date` implementations. 