### PR TITLE
Add granted sso populate/generate commands

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -135,6 +135,10 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 
 // SSODeviceCodeFlow contains all the steps to complete a device code flow to retrieve an sso token
 func SSODeviceCodeFlow(ctx context.Context, cfg aws.Config, rootProfile *Profile) (*SSOToken, error) {
+	return SSODeviceCodeFlowFromStartUrl(ctx, cfg, rootProfile.AWSConfig.SSOStartURL)
+}
+
+func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl string) (*SSOToken, error) {
 	ssooidcClient := ssooidc.NewFromConfig(cfg)
 
 	register, err := ssooidcClient.RegisterClient(ctx, &ssooidc.RegisterClientInput{
@@ -151,7 +155,7 @@ func SSODeviceCodeFlow(ctx context.Context, cfg aws.Config, rootProfile *Profile
 
 		ClientId:     register.ClientId,
 		ClientSecret: register.ClientSecret,
-		StartUrl:     aws.String(rootProfile.AWSConfig.SSOStartURL),
+		StartUrl:     aws.String(startUrl),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/granted/entrypoint.go
+++ b/pkg/granted/entrypoint.go
@@ -29,7 +29,7 @@ func GetCliApp() *cli.App {
 		UsageText:            "granted [global options] command [command options] [arguments...]",
 		Version:              build.Version,
 		HideVersion:          false,
-		Commands:             []*cli.Command{&DefaultBrowserCommand, &settings.SettingsCommand, &CompletionCommand, &TokenCommand, &UninstallCommand},
+		Commands:             []*cli.Command{&DefaultBrowserCommand, &settings.SettingsCommand, &CompletionCommand, &TokenCommand, &UninstallCommand, &SSOCommand},
 		EnableBashCompletion: true,
 		Before: func(c *cli.Context) error {
 			if c.Bool("verbose") {

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -1,0 +1,259 @@
+package granted
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sso"
+	"github.com/bigkevmcd/go-configparser"
+	"github.com/common-fate/granted/pkg/cfaws"
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
+)
+
+var SSOCommand = cli.Command{
+	Name:        "sso",
+	Usage:       "Manage AWS Config from information available in AWS SSO",
+	Subcommands: []*cli.Command{&GenerateCommand, &PopulateCommand},
+}
+
+var GenerateCommand = cli.Command{
+	Name:      "generate",
+	Usage:     "Outputs an AWS Config with profiles from accounts and roles available in AWS SSO",
+	UsageText: "granted [global options] sso generate [command options] [sso-start-url]",
+	Flags:     []cli.Flag{&cli.StringFlag{Name: "prefix", Usage: "Specify a prefix for all generated profile names"}, &cli.StringFlag{Name: "region", Usage: "Specify the SSO region", DefaultText: "us-east-1"}},
+	Action: func(c *cli.Context) error {
+		options, err := parseCliOptions(c)
+		if err != nil {
+			return err
+		}
+
+		ssoProfiles, err := listSSOProfiles(c.Context, ListSSOProfilesInput{
+			StartUrl:  options.StartUrl,
+			SSORegion: options.SSORegion,
+		})
+		if err != nil {
+			return err
+		}
+
+		config := configparser.New()
+
+		err = mergeSSOProfiles(config, options.Prefix, ssoProfiles)
+		if err != nil {
+			return err
+		}
+
+		// configparser can't create a string so we can print the config
+		// to the screen, so we work our way through the sections and
+		// section items manually.
+		for sectionIdx, sectionName := range config.Sections() {
+			if sectionIdx != 0 {
+				fmt.Fprintln(color.Output)
+			}
+
+			fmt.Fprintln(color.Output, "["+sectionName+"]")
+			items, err := config.Items(sectionName)
+			if err != nil {
+				return nil
+			}
+
+			for key, value := range items {
+				fmt.Fprintln(color.Output, key+" = "+value)
+			}
+		}
+
+		return nil
+	},
+}
+
+var PopulateCommand = cli.Command{
+	Name:      "populate",
+	Usage:     "Populate your AWS Config with profiles from accounts and roles available in AWS SSO",
+	UsageText: "granted [global options] sso populate [command options] [sso-start-url]",
+	Flags:     []cli.Flag{&cli.StringFlag{Name: "prefix", Usage: "Specify a prefix for all generated profile names"}, &cli.StringFlag{Name: "region", Usage: "Specify the SSO region", DefaultText: "us-east-1"}},
+	Action: func(c *cli.Context) error {
+		options, err := parseCliOptions(c)
+		if err != nil {
+			return err
+		}
+
+		ssoProfiles, err := listSSOProfiles(c.Context, ListSSOProfilesInput{
+			StartUrl:  options.StartUrl,
+			SSORegion: options.SSORegion,
+		})
+		if err != nil {
+			return err
+		}
+
+		configFilename := config.DefaultSharedConfigFilename()
+
+		// Use the existing config or create if it doesn't exist.
+		config, err := configparser.NewConfigParserFromFile(configFilename)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			config = configparser.New()
+		}
+
+		if err := mergeSSOProfiles(config, options.Prefix, ssoProfiles); err != nil {
+			return err
+		}
+
+		config.SaveWithDelimiter(configFilename, "=")
+
+		return nil
+	},
+}
+
+func parseCliOptions(c *cli.Context) (*SSOCommonOptions, error) {
+	prefix := c.String("prefix")
+	match, err := regexp.MatchString("^[A-Za-z0-9_-]*$", prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	if match == false {
+		return nil, fmt.Errorf("--prefix flag must be alpha-numeric, underscores or hyphens")
+	}
+
+	ssoRegion, err := cfaws.ExpandRegion(c.String("region"))
+	if err != nil {
+		return nil, err
+	}
+
+	if c.Args().Len() != 1 {
+		return nil, fmt.Errorf("Please provide an sso start url")
+	}
+
+	startUrl := c.Args().First()
+
+	options := SSOCommonOptions{
+		Prefix:    prefix,
+		StartUrl:  startUrl,
+		SSORegion: ssoRegion,
+	}
+
+	return &options, nil
+}
+
+type SSOCommonOptions struct {
+	Prefix    string
+	StartUrl  string
+	SSORegion string
+}
+
+type ListSSOProfilesInput struct {
+	SSORegion string
+	StartUrl  string
+}
+
+type SSOProfile struct {
+	// SSO details
+	StartUrl  string
+	SSORegion string
+	// Account and role details
+	AccountId   string
+	AccountName string
+	RoleName    string
+}
+
+func listSSOProfiles(ctx context.Context, input ListSSOProfilesInput) ([]SSOProfile, error) {
+	cfg := aws.NewConfig()
+	cfg.Region = input.SSORegion
+
+	ssoToken, err := cfaws.SSODeviceCodeFlowFromStartUrl(ctx, *cfg, input.StartUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	ssoClient := sso.NewFromConfig(*cfg)
+
+	var ssoProfiles []SSOProfile
+
+	listAccountsNextToken := ""
+	for {
+		listAccountsInput := sso.ListAccountsInput{AccessToken: &ssoToken.AccessToken}
+		if listAccountsNextToken != "" {
+			listAccountsInput.NextToken = &listAccountsNextToken
+		}
+
+		listAccountsOutput, err := ssoClient.ListAccounts(ctx, &listAccountsInput)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, account := range listAccountsOutput.AccountList {
+			listAccountRolesNextToken := ""
+			for {
+				listAccountRolesInput := sso.ListAccountRolesInput{
+					AccessToken: &ssoToken.AccessToken,
+					AccountId:   account.AccountId,
+				}
+				if listAccountRolesNextToken != "" {
+					listAccountRolesInput.NextToken = &listAccountRolesNextToken
+				}
+
+				listAccountRolesOutput, err := ssoClient.ListAccountRoles(ctx, &listAccountRolesInput)
+				if err != nil {
+					return nil, err
+				}
+
+				for _, role := range listAccountRolesOutput.RoleList {
+					ssoProfiles = append(ssoProfiles, SSOProfile{
+						StartUrl:    input.StartUrl,
+						SSORegion:   input.SSORegion,
+						AccountId:   *role.AccountId,
+						AccountName: *account.AccountName,
+						RoleName:    *role.RoleName,
+					})
+				}
+
+				if listAccountRolesOutput.NextToken == nil {
+					break
+				}
+
+				listAccountRolesNextToken = *listAccountRolesOutput.NextToken
+			}
+		}
+
+		if listAccountsOutput.NextToken == nil {
+			break
+		}
+
+		listAccountsNextToken = *listAccountsOutput.NextToken
+	}
+
+	return ssoProfiles, nil
+}
+
+func mergeSSOProfiles(config *configparser.ConfigParser, prefix string, ssoProfiles []SSOProfile) error {
+	for _, ssoProfile := range ssoProfiles {
+		sectionName := "profile " + prefix + normalizeAccountName(ssoProfile.AccountName) + "-" + ssoProfile.RoleName
+
+		if config.HasSection(sectionName) {
+			config.RemoveSection(sectionName)
+		}
+
+		if err := config.AddSection(sectionName); err != nil {
+			return err
+		}
+
+		config.Set(sectionName, "sso_start_url", ssoProfile.StartUrl)
+		config.Set(sectionName, "sso_region", ssoProfile.SSORegion)
+		config.Set(sectionName, "sso_account_id", ssoProfile.AccountId)
+		config.Set(sectionName, "sso_role_name", ssoProfile.RoleName)
+	}
+
+	return nil
+}
+
+func normalizeAccountName(accountName string) string {
+	return strings.ReplaceAll(accountName, " ", "-")
+}


### PR DESCRIPTION
This change introduces two new `granted` commands to help users manage their AWS Config with accounts and roles found through AWS SSO:

**`granted sso generate [--prefix <prefix>] [--region <region>] <start url>`**

This command finds a list of accounts and roles available in AWS SSO and outputs an AWS Config with generated profile names and SSO configurations to the standard output. This is useful for users who want to copy and paste or post-process the generated AWS Config.

This command allows the user to specify an optional `--prefix` so that the generated profile names begin with the given prefix, reducing profile naming conflicts for users who must regularly log into many different SSOs. This command also allows the user to specify the region in which AWS SSO is deployed with `--region`.

```shell
$ granted sso generate --prefix sso1- https://example.awsapps.com/start/
If browser is not opened automatically, please open link:
https://device.sso.us-east-1.amazonaws.com/?user_code=LNBT-NHNW

Awaiting authentication in the browser...
[profile sso1-Root-AWSAdministratorAccess]
sso_start_url = https://example.awsapps.com/start/
sso_region = us-east-1
sso_account_id = 9999999999999
sso_role_name = AWSAdministratorAccess

[profile sso1-Root-AWSPowerUserAccess]
sso_start_url = https://example.awsapps.com/start/
sso_region = us-east-1
sso_account_id = 9999999999999
sso_role_name = AWSPowerUserAccess

[profile sso1-Sandbox-Developer-Name-AWSAdministratorAccess]
sso_start_url = https://example.awsapps.com/start/
sso_region = us-east-1
sso_account_id = 9999999999999
sso_role_name = AWSAdministratorAccess
```

> Note: The instructions and status messages shown above are in stderr, so they are not included in piped or redirected output by default.

**`granted sso populate [--prefix <prefix>] [--region <region>] <start url>`**

Similar to `granted sso generate`, this command finds a list of accounts and roles available in AWS SSO, but after, it merges the profiles into the user's existing AWS Config file, replacing conflicting old profiles with new profiles.

Fixes #173
