### PR TITLE
Add a shortcut for Cost Explorer

### DIFF
--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -30,6 +30,7 @@ var ServiceMap = map[string]string{
 	"athena":         "athena",
 	"cloudmap":       "cloudmap",
 	"c9":             "cloud9",
+	"ce":             "cost-management",
 	"cfn":            "cloudformation",
 	"cloudformation": "cloudformation",
 	"cloudwatch":     "cloudwatch",


### PR DESCRIPTION
This adds a shortcut for Cost Explorer (shortcut: `ce`).