### PR TITLE
fix assume script not printing output properly on linux

### DIFF
--- a/scripts/assume
+++ b/scripts/assume
@@ -138,7 +138,7 @@ fi
 # This way, the shell script can omit the first line containing the flag and return the unaltered output to the stdout
 # This is great as it works well with the -exec flag
 if [ "$GRANTED_FLAG" = "GrantedOutput" ];then
-  echo ${GRANTED_OUTPUT} | sed -n '1!p'
+  echo "${GRANTED_OUTPUT}" | sed -n '1!p'
 fi
 
 if [ "$GRANTED_RETURN_STATUS" = "true" ]; then


### PR DESCRIPTION
Fixes #255.

Sometimes Granted needs to print to stdout. Our `assume` wrapper script needs to capture Granted's output in a specific format, so we prepend anything that needs to be printed with `GrantedOutput`. `assume` then chops the `GrantedOutput` prefix off and prints the rest to stdout.

For running commands like `assume my-profile --exec "echo hello world"`, the output that the `assumego` Go binary creates is:
```
GrantedOutput
hello world
```

Which is then interpreted by the `assume` wrapper, and finally printed to the console as
```
hello world
```

## the problem

Bash on Ubuntu was printing 
```
GrantedOutput <URL>
```
Whereas the `assume` script requires the output to look like

```
GrantedOutput
<URL>
```
with a newline in between.