### PR TITLE
Add AWS Glue Service to browser ServiceMap

### DIFF
--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -43,6 +43,7 @@ var ServiceMap = map[string]string{
 	"eb":             "elasticbeanstalk",
 	"ebs":            "elasticbeanstalk",
 	"ecr":            "ecr",
+	"glue":           "glue",
 	"grafana":        "grafana",
 	"lambda":         "lambda",
 	"route53":        "route53/v2",


### PR DESCRIPTION
`https://us-west-2.console.aws.amazon.com/glue/` for example