### PR TITLE
use xdg-open on linux rather than open

### DIFF
--- a/pkg/browser/opencmd.go
+++ b/pkg/browser/opencmd.go
@@ -1,0 +1,22 @@
+package browser
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// OpenCommand returns the terminal command to open a browser.
+// This is system dependent - for MacOS we use 'open',
+// whereas for Linux we use 'xdg-open', 'x-www-browser', or 'www-browser'.
+func OpenCommand() string {
+	if runtime.GOOS == "linux" {
+		cmds := []string{"xdg-open", "x-www-browser", "www-browser"}
+		for _, c := range cmds {
+			if _, err := exec.LookPath(c); err == nil {
+				return c
+			}
+		}
+	}
+
+	return "open"
+}

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	"github.com/bigkevmcd/go-configparser"
+	"github.com/common-fate/granted/pkg/browser"
 	grantedConfig "github.com/common-fate/granted/pkg/config"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -193,13 +194,13 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 		return nil, err
 	}
 
-	browserCommand := "open" // we default to running 'open <URL>'
+	browserCommand := browser.OpenCommand() // we default to running 'open <URL>'
 
 	if config.CustomSSOBrowserPath != "" {
 		// replace the 'open' command with a call to the custom browser path.
 		browserCommand = config.CustomSSOBrowserPath
 	}
-	cmd := exec.Command(browserCommand, url) // TODO:CHR why do we need the spaces around the URL?
+	cmd := exec.Command(browserCommand, url)
 	err = cmd.Start()
 	if err != nil {
 		return nil, err

--- a/pkg/launcher/open.go
+++ b/pkg/launcher/open.go
@@ -1,10 +1,13 @@
 package launcher
 
+import "github.com/common-fate/granted/pkg/browser"
+
 // Open calls the 'open' command to open a URL.
 // This is the same command as when you run 'open https://commonfate.io'
 // in your own terminal.
 type Open struct{}
 
 func (l Open) LaunchCommand(url string, profile string) []string {
-	return []string{"open", url}
+	cmd := browser.OpenCommand()
+	return []string{cmd, url}
 }


### PR DESCRIPTION
Linux-based systems don't have `open`, but rather use `xdg-open`, `x-www-browser`, or `www-browser` to launch a web browser.

As part of improving process forking in #252 we dropped the [github.com/pkg/browser](https://github.com/pkg/browser) dependency, as it doesn't have enough flexibility over setting the UID/GID of the launched process.