### PR TITLE
Revert to using browser.OpenURL for SSO flow default

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -259,7 +259,6 @@ func AssumeCommand(c *cli.Context) error {
 
 		// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
 		args := l.LaunchCommand(consoleURL, con.Profile)
-
 		cmd, err := forkprocess.New(args...)
 		if err != nil {
 			return err

--- a/pkg/forkprocess/forkprocess_windows.go
+++ b/pkg/forkprocess/forkprocess_windows.go
@@ -4,8 +4,6 @@ package forkprocess
 
 import (
 	"os/exec"
-	"os/user"
-	"strconv"
 
 	"github.com/pkg/errors"
 )
@@ -20,22 +18,7 @@ type Process struct {
 // New creates a new Process with the current user's user and group ID.
 // Call Start() on the returned process to actually it.
 func New(args ...string) (*Process, error) {
-	u, err := user.Current()
-	if err != nil {
-		return nil, errors.Wrap(err, "getting current user")
-	}
-	uid, err := strconv.ParseUint(u.Uid, 10, 32)
-	if err != nil {
-		return nil, errors.Wrapf(err, "parsing uid (%s)", u.Uid)
-	}
-	gid, err := strconv.ParseUint(u.Gid, 10, 32)
-	if err != nil {
-		return nil, errors.Wrapf(err, "parsing gid (%s)", u.Uid)
-	}
-
 	p := Process{
-		UID:  uint32(uid),
-		GID:  uint32(gid),
 		Args: args,
 	}
 	return &p, nil


### PR DESCRIPTION
This PR fixes issues with SSO flows on windows by reverting a recent change where we switched from using the browser package for launching the SSO login prompts.

It also fixes a bug with the forkprocess implementation for Windows.

This has been tested on Windows and Mac