### PR TITLE
Update assumer_aws_sso.go

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"os/exec"
 	"time"
 
@@ -97,7 +96,7 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 						if err != nil {
 							return aws.Credentials{}, err
 						}
-						fmt.Fprintln(os.Stderr, requestURLMsg)
+						return aws.Credentials{}, errors.New(serr.Error() + "\n" + requestURLMsg)
 					}
 				}
 			}


### PR DESCRIPTION
Reverses the ordering of Access Request/Error prompts for `credential_process` 👇 

```
operation error SSO: GetRoleCredentials, https response error StatusCode: 403, RequestID: , api error ForbiddenException: No access
You need to request access to this role:
https://google.com/access?accountId=09876543212&permissionSetArn.label=Role&type=commonfate%2Faws-sso
```