### PR TITLE
Fix tiny typo in help and error message

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -314,7 +314,7 @@ func AssumeCommand(c *cli.Context) error {
 				yellow.Fprintln(color.Error, "No credential suffix found. This can cause issues with using exported credentials if conflicting profiles exist. Run `granted settings export-suffix set` to set one.")
 			}
 
-			green.Fprintln(color.Error, fmt.Sprintf("Exported credentials to ~.aws/credentials file as %s successfully", profileName))
+			green.Fprintln(color.Error, fmt.Sprintf("Exported credentials to ~/.aws/credentials file as %s successfully", profileName))
 		}
 		if assumeFlags.String("exec") != "" {
 			return RunExecCommandWithCreds(assumeFlags.String("exec"), creds, region)

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -22,7 +22,7 @@ func GlobalFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{Name: "console", Aliases: []string{"c"}, Usage: "Open a web console to the role"},
 		&cli.BoolFlag{Name: "env", Aliases: []string{"e"}, Usage: "Export credentials to a .env file"},
-		&cli.BoolFlag{Name: "export", Aliases: []string{"ex"}, Usage: "Export credentials to a ~.aws/credentials file"},
+		&cli.BoolFlag{Name: "export", Aliases: []string{"ex"}, Usage: "Export credentials to a ~/.aws/credentials file"},
 		&cli.BoolFlag{Name: "unset", Aliases: []string{"un"}, Usage: "Unset all environment variables configured by Assume"},
 		&cli.BoolFlag{Name: "url", Aliases: []string{"u"}, Usage: "Get an active console session url"},
 		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Like --c, but opens to a specified service"},


### PR DESCRIPTION
They show `~.aws/credentials` as the path to export credentials to, instead of `~/.aws/credentials`