### PR TITLE
fix chrome profile resetting when '-r' is used

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -229,22 +229,22 @@ func AssumeCommand(c *cli.Context) error {
 		case browser.ChromeKey:
 			l = launcher.ChromeProfile{
 				ExecutablePath: browserPath,
-				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "1"), // held over for backwards compatibility, "1" indicates Chrome profiles
+				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "chrome"),
 			}
 		case browser.BraveKey:
 			l = launcher.ChromeProfile{
 				ExecutablePath: browserPath,
-				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "2"), // held over for backwards compatibility, "2" indicates Brave profiles
+				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "brave"),
 			}
 		case browser.EdgeKey:
 			l = launcher.ChromeProfile{
 				ExecutablePath: browserPath,
-				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "3"), // held over for backwards compatibility, "3" indicates Edge profiles
+				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "edge"),
 			}
 		case browser.ChromiumKey:
 			l = launcher.ChromeProfile{
 				ExecutablePath: browserPath,
-				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "4"), // held over for backwards compatibility, "4" indicates Chromium profiles
+				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "chromium"),
 			}
 		case browser.FirefoxKey:
 			l = launcher.Firefox{

--- a/pkg/launcher/chrome_profile.go
+++ b/pkg/launcher/chrome_profile.go
@@ -1,8 +1,7 @@
 package launcher
 
 import (
-	"fmt"
-	"hash/fnv"
+	"strings"
 )
 
 type ChromeProfile struct {
@@ -15,21 +14,13 @@ type ChromeProfile struct {
 }
 
 func (l ChromeProfile) LaunchCommand(url string, profile string) []string {
-	profileName := chromeProfileName(profile)
+	profile = strings.ReplaceAll(profile, " ", "_")
 	return []string{
 		l.ExecutablePath,
 		"--user-data-dir=" + l.UserDataPath,
-		"--profile-directory=" + profileName,
+		"--profile-directory=granted-profile-" + profile,
 		"--no-first-run",
 		"--no-default-browser-check",
 		url,
 	}
-}
-
-func chromeProfileName(profile string) string {
-	h := fnv.New32a()
-	h.Write([]byte(profile))
-
-	hash := fmt.Sprint(h.Sum32())
-	return hash
 }


### PR DESCRIPTION
Fixes #289. I can't tell *why* it works though.

Previously we hashed the profile names when setting up a Chrome profile folder.

You'd end up with a file structure looking like this:

```
~/.granted
├── aws_profiles_frecency
├── chromium-profiles
│   └── 1
│       ├── 2731494339
│       ├── AutofillStates
│       ├── CertificateRevocation
│       ├── ClientSidePhishing
│       ├── Crowd Deny
│       ├── DesktopSharingHub
│       ├── FileTypePolicies
│       ├── FirstPartySetsPreloaded
│       ├── GrShaderCache
│       ├── Last Version
│       ├── Local State
│       ├── MEIPreload
│       ├── OnDeviceHeadSuggestModel
│       ├── OptimizationHints
│       ├── OriginTrials
│       ├── PKIMetadata
│       ├── RecoveryImproved
│       ├── SSLErrorAssistant
│       ├── Safe Browsing
│       ├── SafetyTips
│       ├── ShaderCache
│       ├── Subresource Filter
│       ├── System Profile
│       ├── UrlParamClassifications
│       ├── Variations
│       ├── Webstore Downloads
│       ├── WidevineCdm
│       ├── ZxcvbnData
│       ├── chrome_shutdown_ms.txt
│       └── persisted_first_party_sets.json
└── config
```

Where `2731494339` is a Chrome profile:

```
~/.granted/chromium-profiles/1/2731494339/
├── AutofillStrikeDatabase
├── BudgetDatabase
├── Cache
├── Code Cache
├── Download Service
├── Extension Rules
├── Extensions
├── Feature Engagement Tracker
├── GCM Store
├── IndexedDB
├── LOCK
├── LOG
├── Network Action Predictor
├── Network Action Predictor-journal
├── Network Persistent State
├── Preferences
├── Search Logos
├── Secure Preferences
├── Segmentation Platform
├── Service Worker
├── Sessions
├── Shortcuts
├── Shortcuts-journal
├── Storage
├── TransportSecurity
├── WebStorage
├── databases
├── optimization_guide_hint_cache_store
├── optimization_guide_model_metadata_store
└── optimization_guide_prediction_model_downloads

20 directories, 10 files
```

This PR switches the profile folder to be `granted-profile-<PROFILE_NAME>`. This is easier to understand and also seems to fix the problem - when running a dev build I was able to swap between regions without the Chrome extensions being corrupted.

I would have expected the hash to be different, based on the `-r` flag, but it is the same each time:

```
❯ dassume -c demo-sandbox1

ℹ️  use -s to open a specific service (https://docs.commonfate.io/granted/usage/console)

Opening a console for demo-sandbox1 in your browser...
hash: 2731494339

❯ dassume -c demo-sandbox1 -r us-west-2

ℹ️  use -s to open a specific service (https://docs.commonfate.io/granted/usage/console)

Opening a console for demo-sandbox1 in your browser...
hash: 2731494339
```