### PR TITLE
CLI-43 Throw error for mismatching profile in granted credential-process 

### DIFF
--- a/pkg/cfaws/granted_config.go
+++ b/pkg/cfaws/granted_config.go
@@ -55,7 +55,7 @@ func ParseGrantedSSOProfile(ctx context.Context, profile *Profile) (*config.Shar
 		return nil, err
 	}
 
-	err = parseCredentialProcess(item.Value(), profile.Name)
+	err = validateCredentialProcess(item.Value(), profile.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -85,12 +85,12 @@ func hasGrantedSSOPrefix(rawConfig *ini.Section) bool {
 	return false
 }
 
-// parseCredentialProcess checks whether the granted_ prefixed AWS profiles
+// validateCredentialProcess checks whether the granted_ prefixed AWS profiles
 // are correctly using the granted credential-process override or not.
 // also check whether the provided flag to 'granted credential-process --profile pname'
 // matches the AWS config profile name. If it doesn't then return an err
 // as the user will certainly run into unexpected behaviour.
-func parseCredentialProcess(arg string, awsProfileName string) error {
+func validateCredentialProcess(arg string, awsProfileName string) error {
 	regex := regexp.MustCompile(`^(\s+)?granted\s+credential-process.*--profile\s+(?P<PName>([^\s]+))`)
 
 	if regex.MatchString(arg) {

--- a/pkg/cfaws/granted_config.go
+++ b/pkg/cfaws/granted_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -48,6 +49,17 @@ func ParseGrantedSSOProfile(ctx context.Context, profile *Profile) (*config.Shar
 	}
 
 	cfg.SSOStartURL = item.Value()
+
+	item, err = profile.RawConfig.GetKey("credential_process")
+	if err != nil {
+		return nil, err
+	}
+
+	err = parseCredentialProcess(item.Value(), profile.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	return &cfg, err
 }
 
@@ -71,4 +83,33 @@ func hasGrantedSSOPrefix(rawConfig *ini.Section) bool {
 		}
 	}
 	return false
+}
+
+// parseCredentialProcess checks whether the granted_ prefixed AWS profiles
+// are correctly using the granted credential-process override or not.
+// also check whether the provided flag to 'granted credential-process --profile pname'
+// matches the AWS config profile name. If it doesn't then return an err
+// as the user will certainly run into unexpected behaviour.
+func parseCredentialProcess(arg string, awsProfileName string) error {
+	regex := regexp.MustCompile(`^(\s+)?granted\s+credential-process.*--profile\s+(?P<PName>([^\s]+))`)
+
+	if regex.MatchString(arg) {
+		matches := regex.FindStringSubmatch(arg)
+		pNameIndex := regex.SubexpIndex("PName")
+
+		profileName := matches[pNameIndex]
+
+		if profileName == "" {
+			return fmt.Errorf("profile name not provided. Try adding profile name like 'granted credential-process --profile <profile-name>'")
+		}
+
+		// if matches then do nth.
+		if profileName == awsProfileName {
+			return nil
+		}
+
+		return fmt.Errorf("unmatched profile names. The profile name '%s' provided to 'granted credential-process' doesnot match AWS profile name '%s'", profileName, awsProfileName)
+	}
+
+	return fmt.Errorf("unable to parse 'credential_process'. Looks like your credential_process isn't configured correctly. \n You need to add 'granted credential-process --profile <profile-name>'")
 }

--- a/pkg/cfaws/granted_config_test.go
+++ b/pkg/cfaws/granted_config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestParseCredentialProcess(t *testing.T) {
+func TestValidateCredentialProcess(t *testing.T) {
 	tests := []struct {
 		name        string
 		arg         string
@@ -33,7 +33,7 @@ func TestParseCredentialProcess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			err := parseCredentialProcess(tt.arg, tt.profileName)
+			err := validateCredentialProcess(tt.arg, tt.profileName)
 			if err != nil {
 				if err.Error() != tt.wantErr {
 					t.Fatal(err)

--- a/pkg/cfaws/granted_config_test.go
+++ b/pkg/cfaws/granted_config_test.go
@@ -1,0 +1,44 @@
+package cfaws
+
+import (
+	"testing"
+)
+
+func TestParseCredentialProcess(t *testing.T) {
+	tests := []struct {
+		name        string
+		arg         string
+		profileName string
+		wantErr     string
+	}{
+		{
+			name:        "valid argument with correct profile name",
+			arg:         "  granted credential-process   --profile develop",
+			profileName: "develop",
+		},
+		{
+			name:        "valid argument without incorrect profile name",
+			arg:         "granted credential-process --profile abc",
+			profileName: "develop",
+			wantErr:     "unmatched profile names. The profile name 'abc' provided to 'granted credential-process' doesnot match AWS profile name 'develop'",
+		},
+		{
+			name:        "invalid argument",
+			arg:         "aws-sso-util --profile abc",
+			profileName: "apple",
+			wantErr:     "unable to parse 'credential_process'. Looks like your credential_process isn't configured correctly. \n You need to add 'granted credential-process --profile <profile-name>'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			err := parseCredentialProcess(tt.arg, tt.profileName)
+			if err != nil {
+				if err.Error() != tt.wantErr {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary 
Throw error for mismatching profile names in AWS config profile and `granted credential-process` for `granted_` prefixed configurations