### PR TITLE
provide configured color and icon to granted-containers (#156)

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -127,9 +127,9 @@ func AssumeCommand(c *cli.Context) error {
 				var description string
 				p, _ := profiles.Profile(pn)
 
-				if p != nil && p.Description() != "" {
+				if p != nil && p.CustomGrantedProperty("description") != "" {
 					hasDescriptions = true
-					description = p.Description()
+					description = p.CustomGrantedProperty("description")
 				}
 
 				stringKey := fmt.Sprintf("%-"+strconv.Itoa(longestProfileNameLength)+"s%s", pn, lightBlack(description))
@@ -265,7 +265,7 @@ func AssumeCommand(c *cli.Context) error {
 
 		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey {
 			// tranform the URL into the Firefox Tab Container format.
-			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s", profile.Name, url.QueryEscape(consoleURL))
+			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", profile.Name, url.QueryEscape(consoleURL), profile.CustomGrantedProperty("color"), profile.CustomGrantedProperty("icon"))
 		}
 
 		justPrintURL := assumeFlags.Bool("url") || cfg.DefaultBrowser == browser.StdoutKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -56,9 +56,9 @@ func (p *Profiles) HasProfile(profile string) bool {
 	return ok
 }
 
-// if the profile has a granted_description key, the value is returned. else an empty string
-func (p *Profile) Description() string {
-	key, err := p.RawConfig.GetKey("granted_description")
+// if the profile has a "granted_${name}" key, the value is returned. else an empty string
+func (p *Profile) CustomGrantedProperty(name string) string {
+	key, err := p.RawConfig.GetKey(fmt.Sprintf("granted_%s", name))
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
After using granted & granted-containers for a bit, not having configurable colors and icons has been a pain point (e.g. development and production containers sometimes have the same color). While #156 notes that the color/icon can be configured after launch, having these defined in config helps keep things consistent between developers and machines.

Related PR: https://github.com/common-fate/granted-containers/pull/7