### PR TITLE
Use slash to separate account and role name in `sso generate`

### DIFF
--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -219,7 +219,7 @@ func listSSOProfiles(ctx context.Context, input ListSSOProfilesInput) ([]SSOProf
 
 func mergeSSOProfiles(config *ini.File, prefix string, ssoProfiles []SSOProfile) error {
 	for _, ssoProfile := range ssoProfiles {
-		sectionName := "profile " + prefix + normalizeAccountName(ssoProfile.AccountName) + "-" + ssoProfile.RoleName
+		sectionName := "profile " + prefix + normalizeAccountName(ssoProfile.AccountName) + "/" + ssoProfile.RoleName
 
 		config.DeleteSection(sectionName)
 		section, err := config.NewSection(sectionName)


### PR DESCRIPTION
Currently a dash is used both in the normalized AWS Account Name and to separate it from the role name.

Using a slash to separate the account and role names makes the generated profile names easier to parse, both visually and also for customizing the generated file using a regexp.

Currently:
```[profile Long-AWS-Account-Name-Long-Role-Name]```

After this PR:
```[profile Long-AWS-Account-Name/Long-Role-Name]```