### PR TITLE
Better logging around waiting for the browser

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -183,8 +183,7 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 	}
 	// trigger OIDC login. open browser to login. close tab once login is done. press enter to continue
 	url := aws.ToString(deviceAuth.VerificationUriComplete)
-	clio.Info("If the browser does not open automatically, please open this link:")
-	clio.Info(url)
+	clio.Info("If the browser does not open automatically, please open this link: " + url)
 
 	//check if sso browser path is set
 	config, err := grantedConfig.Load()
@@ -214,7 +213,7 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 		}
 	}
 
-	clio.Info("Awaiting authentication in the browser...")
+	clio.Info("Awaiting browser authentication, this may take up to 2 minutes...")
 	token, err := PollToken(ctx, ssooidcClient, *register.ClientSecret, *register.ClientId, *deviceAuth.DeviceCode, PollingConfig{CheckInterval: time.Second * 2, TimeoutAfter: time.Minute * 2})
 	if err != nil {
 		return nil, err

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -213,7 +213,9 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 		}
 	}
 
-	clio.Info("Awaiting browser authentication, this may take up to 2 minutes...")
+	clio.Info("Awaiting AWS authentication in the browser")
+	clio.Info("You will be prompted to authenticate with AWS in the browser, then you will be prompted to 'Allow'")
+	clio.Info("Once you press 'Allow', the sign in process will complete in a few seconds")
 	token, err := PollToken(ctx, ssooidcClient, *register.ClientSecret, *register.ClientId, *deviceAuth.DeviceCode, PollingConfig{CheckInterval: time.Second * 2, TimeoutAfter: time.Minute * 2})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It can take a long time for the browser authentication piece to finish, and some users get antsy and will kill the process. This PR attempts to give them some confidence that things are still happening in the background and that they should be patient.