### PR TITLE
CF-351 check if profile rawConfig is nil or not

### DIFF
--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -87,6 +87,12 @@ func (p *Profiles) HasProfile(profile string) bool {
 
 // if the profile has a "granted_${name}" key, the value is returned. else an empty string
 func (p *Profile) CustomGrantedProperty(name string) string {
+	// rawConfig can be nil when all the required paraments are pass as arguments
+	// like assume --sso --sso_start-url ...
+	if p.RawConfig == nil {
+		return ""
+	}
+
 	key, err := p.RawConfig.GetKey(fmt.Sprintf("granted_%s", name))
 	if err != nil {
 		return ""


### PR DESCRIPTION
### Summary 
When all the required credentials were passed as arguments instead of defining in `config` file for firefox, we didn't have `profile.RawConfig` thus go panicked. 