### PR TITLE
Add missing registry setup cmd

### DIFF
--- a/pkg/granted/registry/registry_cmd.go
+++ b/pkg/granted/registry/registry_cmd.go
@@ -9,7 +9,7 @@ var ProfileRegistryCommand = cli.Command{
 	Name:        "registry",
 	Usage:       "Manage Profile Registries",
 	Description: "Profile Registries allow you to easily share AWS profile configuration in a team.",
-	Subcommands: []*cli.Command{&AddCommand, &SyncCommand, &RemoveCommand, &MigrateCommand},
+	Subcommands: []*cli.Command{&AddCommand, &SyncCommand, &RemoveCommand, &MigrateCommand, &SetupCommand},
 	Action: func(c *cli.Context) error {
 		registries, err := GetProfileRegistries()
 		if err != nil {


### PR DESCRIPTION
## Describe your changes
`granted registry setup` cmd was missed in the current release. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
