### PR TITLE
Make sso generate/populate expected behaviour clearer

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -215,7 +215,7 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 
 	clio.Info("Awaiting AWS authentication in the browser")
 	clio.Info("You will be prompted to authenticate with AWS in the browser, then you will be prompted to 'Allow'")
-	clio.Info("Once you press 'Allow', the sign in process will complete in a few seconds")
+	clio.Info("Once you press 'Allow', the sign in process and account fetching should complete in a few seconds (can take longer if SSO has many accounts)")
 	token, err := PollToken(ctx, ssooidcClient, *register.ClientSecret, *register.ClientId, *deviceAuth.DeviceCode, PollingConfig{CheckInterval: time.Second * 2, TimeoutAfter: time.Minute * 2})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Describe your changes

Update log line to make it clearer to first time users of `granted sso generate` or `granted sso populate` that it's not just signing in but it's also downloading accounts/creating profiles at could take longer than a few seconds.

Before: `[i] Once you press 'Allow', the sign in process will complete in a few seconds`
After: `[i] Once you press 'Allow', the sign in process and account fetching should complete in a few seconds (can take longer if SSO has many accounts)`

PS. I'm not precious about the wording feel free to edit it and push changes to the PR 🤗 

### Why tho?

When running `granted sso generate` or `granted sso populate` after clicking `Allow` in AWS on my browser I thought `granted` was broken because the login took longer than _"a few seconds"_ as mentioned by the log - it was stuck there for 5-10 seconds before I would `Ctrl+c` and kill the `granted` process.

I kept doing this until one time I waited 20+ seconds and it actually worked 🫠
_This is for 160 AWS accounts by the way 👀_

![image](https://user-images.githubusercontent.com/10026538/211917152-09a3aebf-f042-4fe3-9732-1c97d0940bbf.png)

## Type of change

Updating a log statement 🤓

## Issue and Documentation

See above 🤷 

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.

1. Run `granted sso generate --region eu-west-1 https://example.awsapps.com/start` with your SSO URL and region
2. (Optional) Log in to AWS via newly launched browser
3. Look at terminal to see new log message ✨ 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] ~I have commented my code, particularly in hard-to-understand areas.~
- [x] ~I have added tests that prove my fix is effective or that my feature works.~
- [x] ~Do analytics need to be implemented?~
- [x] ~I have made corresponding changes to the documentation, docs PR has been linked.~
- [x] New and existing unit tests pass with my changes.
- [x] ~Any dependent changes have been merged and published in downstream modules.~

![image](https://user-images.githubusercontent.com/10026538/211920189-efb80325-b298-4e96-ad72-a21d4fde5a12.png)