### PR TITLE
if a profile has a session token, use it for the console

### DIFF
--- a/pkg/cfaws/assumer_aws_iam.go
+++ b/pkg/cfaws/assumer_aws_iam.go
@@ -74,7 +74,10 @@ func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *Profile, config
 // if required will get a FederationToken to be used to launch the console
 // This is required is the iam profile does not assume a role using sts.AssumeRole
 func (aia *AwsIamAssumer) AssumeConsole(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
-	if c.AWSConfig.RoleARN == "" {
+	if c.AWSConfig.Credentials.SessionToken != "" {
+		clio.Debug("found existing session token in credentials for IAM profile, using this to launch the console")
+		return c.AWSConfig.Credentials, nil
+	} else if c.AWSConfig.RoleARN == "" {
 		return getFederationToken(ctx, c)
 	} else {
 		// profile assume a role


### PR DESCRIPTION
## Describe your changes

- Use existing credentials to launch the console of they exist on an IAM profile


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Issue and Documentation

- Fixes #273 

## Testing

1. run assume --export 
2. change the name of the profile in ~/.aws/credentials to something unique
3. run assume --verbose --c <the name of your new profile>

You should see that the browser launched and a debug log shows that existing credentials were used

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
