### PR TITLE
Bugfix sso generate matching whitespace in templates

### DIFF
--- a/pkg/granted/sso_test.go
+++ b/pkg/granted/sso_test.go
@@ -1,0 +1,52 @@
+package granted
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSOGenerateParseFlags(t *testing.T) {
+
+	type testcase struct {
+		name         string
+		giveTemplate string
+		wantErr      error
+	}
+
+	testcases := []testcase{
+		{
+			name:         "default passes",
+			giveTemplate: defaultProfileNameTemplate,
+		},
+		{
+			name:         "valid template passes",
+			giveTemplate: "{{ .AccountName }}.hello",
+		},
+		{
+			name:         "invalid template fails whitespace",
+			giveTemplate: "{{ .AccountName }}. ",
+			wantErr:      errors.New(`--profile-template flag must not contain any of these illegal characters ( \][;'")`),
+		},
+		{
+			name:         "invalid template fails ;",
+			giveTemplate: "{{ .AccountName }}.;",
+			wantErr:      errors.New(`--profile-template flag must not contain any of these illegal characters ( \][;'")`),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := cliOptions{
+				profileTemplate: tc.giveTemplate,
+				args:            []string{"demo"},
+			}
+			_, err := parseCliOptions(c)
+			if tc.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.wantErr.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes

- Fixes the validation of profile section templates for the `granted sso` commands.
- The previous release included a bug by which whitespace in the go template sections e.g {{ .AccountName }} was being incorrectly detected as invalid.

This fix now only check for invalid characters outside of the template sections e.g `{{ .AccountName }} {{ .Region }}` would be invalid because there is whitespace between the template sections but this is valid `{{ .AccountName }}.{{ .Region }}`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Issue and Documentation

- Fixes #336 

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.

1. I have added unit tests to cover this behaviour
2. to see that the issue is resolved. in version 0.7.0 running `granted sso generate` would fail immediately with a validation error about the template.
3. in this version, it does not fail for the default template

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [x] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
