### PR TITLE
copy any none profile section from config file in Profile Registry

### DIFF
--- a/pkg/granted/registry/sections.go
+++ b/pkg/granted/registry/sections.go
@@ -153,16 +153,11 @@ func getNonGrantedProfiles(config *ini.File) []*ini.Section {
 	return nonGrantedProfiles
 }
 
-func generateNewRegistrySection(r *Registry, configFile *ini.File, clonedFile *ini.File, opts syncOpts) error {
+func generateNewRegistrySection(r *Registry, configFile *ini.File, clonedFile *ini.File, gconf *grantedConfig.Config, opts syncOpts) error {
 	sectionName := r.Config.Name
 	clio.Debugf("generating section %s", sectionName)
 
-	gconf, err := grantedConfig.Load()
-	if err != nil {
-		return err
-	}
-
-	err = configFile.NewSections(fmt.Sprintf("granted_registry_start %s", sectionName))
+	err := configFile.NewSections(fmt.Sprintf("granted_registry_start %s", sectionName))
 	if err != nil {
 		return err
 	}

--- a/pkg/granted/registry/sections.go
+++ b/pkg/granted/registry/sections.go
@@ -183,6 +183,10 @@ func generateNewRegistrySection(r *Registry, configFile *ini.File, clonedFile *i
 			continue
 		}
 
+		// All section that starts with 'profile' prefix will be considered as AWS profile and will be verified
+		// 1. if they have a correct profile name
+		// 2. if they have duplicate profile names i.e if the new profile name already exists on the aws config file
+		// For any other section, copy the content as it is.
 		if strings.Contains(sec.Name(), "profile") {
 			if cfaws.IsLegalProfileName(strings.TrimPrefix(sec.Name(), "profile ")) {
 

--- a/pkg/granted/registry/sections.go
+++ b/pkg/granted/registry/sections.go
@@ -183,70 +183,89 @@ func generateNewRegistrySection(r *Registry, configFile *ini.File, clonedFile *i
 			continue
 		}
 
-		// We only care about the non default sections for the credentials file (no profile prefix either)
-		if cfaws.IsLegalProfileName(strings.TrimPrefix(sec.Name(), "profile ")) {
+		if strings.Contains(sec.Name(), "profile") {
+			if cfaws.IsLegalProfileName(strings.TrimPrefix(sec.Name(), "profile ")) {
 
-			if gconf.ProfileRegistry.PrefixAllProfiles || r.Config.PrefixAllProfiles {
-				f, err := configFile.NewSection(appendNamespaceToDuplicateSections(sec.Name(), namespace))
-				if err != nil {
-					return err
+				if gconf.ProfileRegistry.PrefixAllProfiles || r.Config.PrefixAllProfiles {
+					f, err := configFile.NewSection(appendNamespaceToDuplicateSections(sec.Name(), namespace))
+					if err != nil {
+						return err
+					}
+
+					err = copySectionContent(r, sec, f)
+					if err != nil {
+						return err
+					}
+
+					continue
 				}
 
-				err = copySectionContent(r, sec, f)
-				if err != nil {
-					return err
-				}
+				if Contains(currentProfiles, sec.Name()) {
+					// check global config to see if we should prefix all duplicate profiles for this registry.
+					if !gconf.ProfileRegistry.PrefixDuplicateProfiles {
+						// check registry level config to see if we should prefix the duplicate profiles
+						if !r.Config.PrefixDuplicateProfiles {
 
-				continue
-			}
+							// automatically add prefix to duplicate profiles without prompting users.
+							clio.Warnf("profile duplication found for '%s'", sec.Name())
+							if opts.promptUserIfProfileDuplication {
 
-			if Contains(currentProfiles, sec.Name()) {
-				// check global config to see if we should prefix all duplicate profiles for this registry.
-				if !gconf.ProfileRegistry.PrefixDuplicateProfiles {
-					// check registry level config to see if we should prefix the duplicate profiles
-					if !r.Config.PrefixDuplicateProfiles {
+								const (
+									DUPLICATE = "Add registry name as prefix to all duplicate profiles for this registry"
+									ABORT     = "Abort, I will manually fix this"
+								)
 
-						// automatically add prefix to duplicate profiles without prompting users.
-						clio.Warnf("profile duplication found for '%s'", sec.Name())
-						if opts.promptUserIfProfileDuplication {
+								options := []string{DUPLICATE, ABORT}
 
-							const (
-								DUPLICATE = "Add registry name as prefix to all duplicate profiles for this registry"
-								ABORT     = "Abort, I will manually fix this"
-							)
-
-							options := []string{DUPLICATE, ABORT}
-
-							in := survey.Select{Message: "Please select which option would you like to choose to resolve: ", Options: options}
-							var selected string
-							err = testable.AskOne(&in, &selected)
-							if err != nil {
-								return err
-							}
-
-							if selected == ABORT {
-								return fmt.Errorf("aborting sync for registry %s", sectionName)
-							}
-						}
-
-						r.Config.PrefixDuplicateProfiles = true
-
-						for i, configRegistry := range gconf.ProfileRegistry.Registries {
-							if configRegistry.Name == r.Config.Name {
-								configRegistry.PrefixDuplicateProfiles = true
-								gconf.ProfileRegistry.Registries[i] = configRegistry
-
-								err := gconf.Save()
+								in := survey.Select{Message: "Please select which option would you like to choose to resolve: ", Options: options}
+								var selected string
+								err = testable.AskOne(&in, &selected)
 								if err != nil {
 									return err
+								}
+
+								if selected == ABORT {
+									return fmt.Errorf("aborting sync for registry %s", sectionName)
+								}
+							}
+
+							r.Config.PrefixDuplicateProfiles = true
+
+							for i, configRegistry := range gconf.ProfileRegistry.Registries {
+								if configRegistry.Name == r.Config.Name {
+									configRegistry.PrefixDuplicateProfiles = true
+									gconf.ProfileRegistry.Registries[i] = configRegistry
+
+									err := gconf.Save()
+									if err != nil {
+										return err
+									}
 								}
 							}
 						}
 					}
+
+					clio.Debugf("Prefixing %s to avoid collision.", sec.Name())
+					f, err := configFile.NewSection(appendNamespaceToDuplicateSections(sec.Name(), namespace))
+					if err != nil {
+						return err
+					}
+
+					err = copySectionContent(r, sec, f)
+					if err != nil {
+						return err
+					}
+
+					if f.Comment == "" {
+						f.Comment = "# profile name has been prefixed due to duplication"
+					} else {
+						f.Comment = "# profile name has been prefixed due to duplication. \n" + sec.Comment
+					}
+
+					continue
 				}
 
-				clio.Debugf("Prefixing %s to avoid collision.", sec.Name())
-				f, err := configFile.NewSection(appendNamespaceToDuplicateSections(sec.Name(), namespace))
+				f, err := configFile.NewSection(sec.Name())
 				if err != nil {
 					return err
 				}
@@ -256,15 +275,11 @@ func generateNewRegistrySection(r *Registry, configFile *ini.File, clonedFile *i
 					return err
 				}
 
-				if f.Comment == "" {
-					f.Comment = "# profile name has been prefixed due to duplication"
-				} else {
-					f.Comment = "# profile name has been prefixed due to duplication. \n" + sec.Comment
-				}
-
-				continue
+				f.Comment = sec.Comment
 			}
 
+		} else {
+			// any other section is copied as it is.
 			f, err := configFile.NewSection(sec.Name())
 			if err != nil {
 				return err

--- a/pkg/granted/registry/sections_test.go
+++ b/pkg/granted/registry/sections_test.go
@@ -224,13 +224,17 @@ func TestGenerateNewRegistrySection(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			r := NewProfileRegistry(registryOptions{})
+			r := NewProfileRegistry(registryOptions{
+				prefixAllProfiles: true,
+			})
 
 			r.Config = config.Registry{
 				Name: "registry-one",
 			}
 
-			err = generateNewRegistrySection(&r, f, c, syncOpts{})
+			gconf := config.Config{}
+
+			err = generateNewRegistrySection(&r, f, c, &gconf, syncOpts{isFirstSection: false})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/granted/registry/sync.go
+++ b/pkg/granted/registry/sync.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/common-fate/clio"
+	grantedConfig "github.com/common-fate/granted/pkg/config"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/ini.v1"
 )
@@ -147,8 +148,13 @@ func Sync(r *Registry, awsConfigFile *ini.File, opts syncOpts) error {
 		return err
 	}
 
+	gconf, err := grantedConfig.Load()
+	if err != nil {
+		return err
+	}
+
 	// return custom error that should be catched and skipped.
-	err = generateNewRegistrySection(r, awsConfigFile, clonedFile, opts)
+	err = generateNewRegistrySection(r, awsConfigFile, clonedFile, gconf, opts)
 	if err != nil {
 		return &SyncError{
 			Err:          err,


### PR DESCRIPTION
## Describe your changes
While syncing Profiles in Profile Registry, we were checking if the passed profiles are valid AWS profiles This was troublesome because now you cannot add `[sso-session abc]` section in your config file. This change will sync any content that is not an AWS profile as it is. 

Will only warn if the AWS config with `profile` prefix have any invalid characters in it.  

- Fixes: https://github.com/common-fate/granted/issues/338
 
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue and Documentation
 https://github.com/common-fate/granted/issues/338

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.

1. Add any section without `[profile abc]` in your remote registry. 
2. run `granted registry add/sync` cmd 
3.  Should see the content in your local aws config file.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [x] New and existing unit tests pass with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
