### PR TITLE
adds command output hint

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -55,6 +55,8 @@ func AssumeCommand(c *cli.Context) error {
 	}
 	activeRoleProfile := assumeFlags.String("active-aws-profile")
 	activeRoleFlag := assumeFlags.Bool("active-role")
+
+	showRerunCommand := false
 	var profile *cfaws.Profile
 	if assumeFlags.Bool("sso") {
 		profile, err = SSOProfileFromFlags(c)
@@ -103,6 +105,8 @@ func AssumeCommand(c *cli.Context) error {
 
 		// if profile is still "" here, then prompt to select a profile
 		if profileName == "" {
+			// will print a command output for the user so it's easier for them to re run later or learn the commands
+			showRerunCommand = true
 			//load config to check frecency enabled
 			cfg, err := config.Load()
 			if err != nil {
@@ -245,6 +249,11 @@ func AssumeCommand(c *cli.Context) error {
 	// if getConsoleURL is true, we'll use the AWS federated login to retrieve a URL to access the console.
 	// depending on how Granted is configured, this is then printed to the terminal or a browser is launched at the URL automatically.
 	getConsoleURL := !assumeFlags.Bool("env") && (assumeFlags.Bool("console") || assumeFlags.Bool("active-role") || assumeFlags.String("service") != "" || assumeFlags.Bool("url"))
+
+	// this makes it easy for users to copy the actuall command and avoid needing to lookup profiles
+	if showRerunCommand {
+		clio.Infof("To assume this profile again later without needing to select it, run this command:\n> assume %s %s", profile.Name, strings.Join(os.Args[1:], " "))
+	}
 
 	if getConsoleURL {
 		con := console.AWS{


### PR DESCRIPTION
## Describe your changes

- when no profile argument is provider, assume will print the full command for the user that they can run directly next time


```bash
> assume --env        

? Please select the profile you would like to assume: demo-sandbox1      
[i] To assume this profile again later without needing to select it, run this command:
> assume demo-sandbox1 --env

```
## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Issue and Documentation

- fixes #341 

## Testing

1. run assume with no argument, expect the message
2. run assume with profile argument, expect no message

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
