### PR TITLE
Use MkdirAll before Create to create all parent directory

### DIFF
--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -10,6 +10,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	// permission for user to read/write/execute.
+	USER_READ_WRITE_PERM = 0700
+)
+
 var AddCommand = cli.Command{
 	Name:        "add",
 	Description: "Add a Profile Registry that you want to sync with aws config file",
@@ -106,7 +111,7 @@ var AddCommand = cli.Command{
 
 		if _, err := os.Stat(awsConfigPath); os.IsNotExist(err) {
 			clio.Debugf("%s file does not exist. Creating an empty file\n", awsConfigPath)
-			_, err := os.Create(awsConfigPath)
+			err := os.MkdirAll(awsConfigPath, USER_READ_WRITE_PERM)
 			if err != nil {
 				return fmt.Errorf("unable to create : %s", err)
 			}

--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/common-fate/clio"
 	grantedConfig "github.com/common-fate/granted/pkg/config"
@@ -38,7 +39,7 @@ var AddCommand = cli.Command{
 
 		name := c.String("name")
 		gitURL := c.String("url")
-		path := c.String("path")
+		pathFlag := c.String("path")
 		configFileName := c.String("filename")
 		ref := c.String("ref")
 		prefixAllProfiles := c.Bool("prefix-all-profiles")
@@ -56,7 +57,7 @@ var AddCommand = cli.Command{
 
 		registry := NewProfileRegistry(registryOptions{
 			name:                    name,
-			path:                    path,
+			path:                    pathFlag,
 			configFileName:          configFileName,
 			url:                     gitURL,
 			ref:                     ref,
@@ -111,7 +112,14 @@ var AddCommand = cli.Command{
 
 		if _, err := os.Stat(awsConfigPath); os.IsNotExist(err) {
 			clio.Debugf("%s file does not exist. Creating an empty file\n", awsConfigPath)
-			err := os.MkdirAll(awsConfigPath, USER_READ_WRITE_PERM)
+
+			// create all parent directory if necessary.
+			err := os.MkdirAll(path.Dir(awsConfigPath), USER_READ_WRITE_PERM)
+			if err != nil {
+				return err
+			}
+
+			_, err = os.Create(awsConfigPath)
 			if err != nil {
 				return fmt.Errorf("unable to create : %s", err)
 			}


### PR DESCRIPTION
## Describe your changes
-  #355 https://github.com/common-fate/granted/issues/355 mentions that if `.aws` folder was unavailable then Granted Registry was failing.  That was because `os.Create()` couldn't find the parent folders`. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
