### PR TITLE
Fix cli help command typos

### DIFF
--- a/pkg/granted/credentials.go
+++ b/pkg/granted/credentials.go
@@ -244,7 +244,7 @@ func promptCredentials() (credentials aws.Credentials, err error) {
 	if err != nil {
 		return
 	}
-	in2 := survey.Password{Message: "Secret Sccess Key:"}
+	in2 := survey.Password{Message: "Secret Access Key:"}
 	err = testable.AskOne(&in2, &credentials.SecretAccessKey)
 	if err != nil {
 		return

--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -30,7 +30,7 @@ var AddCommand = cli.Command{
 		&cli.BoolFlag{Name: "prefix-all-profiles", Aliases: []string{"pap"}, Usage: "provide this flag if you want to append registry name to all profiles"},
 		&cli.BoolFlag{Name: "prefix-duplicate-profiles", Aliases: []string{"pdp"}, Usage: "provide this flag if you want to append registry name to duplicate profiles"},
 		&cli.StringSliceFlag{Name: "required-key", Aliases: []string{"r", "requiredKey"}, Usage: "used to bypass the prompt or override user specific values"}},
-	ArgsUsage: "<repository url> --name <registry_name> --url <git-url>",
+	ArgsUsage: "--name <registry_name> --url <git-url>",
 	Action: func(c *cli.Context) error {
 		gConf, err := grantedConfig.Load()
 		if err != nil {

--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -30,7 +30,7 @@ var AddCommand = cli.Command{
 		&cli.BoolFlag{Name: "prefix-all-profiles", Aliases: []string{"pap"}, Usage: "provide this flag if you want to append registry name to all profiles"},
 		&cli.BoolFlag{Name: "prefix-duplicate-profiles", Aliases: []string{"pdp"}, Usage: "provide this flag if you want to append registry name to duplicate profiles"},
 		&cli.StringSliceFlag{Name: "required-key", Aliases: []string{"r", "requiredKey"}, Usage: "used to bypass the prompt or override user specific values"}},
-	ArgsUsage: "--name <registry_name> --url <git-url>",
+	ArgsUsage: "--name <registry_name> --url <repository_url>",
 	Action: func(c *cli.Context) error {
 		gConf, err := grantedConfig.Load()
 		if err != nil {


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fix two errors in CLI command prompts
  1. Access was misspelled Sccess
  2. In `granted registry add`, `<repository url>` is now `--url <repository-url>`, but the previous hint was not removed

## Type of change

<!-- Please delete options that are not relevant. -->

[X] Bug fix (non-breaking change which fixes an issue)

## Issue and Documentation

<!-- Please link the appropriate Linear/GitHub issues as well as any supporting documentation or video explainers. Also include a link to the documentation PR if relevant. -->

1. https://github.com/common-fate/docs/pull/192
2. Docs already match
  - https://docs.commonfate.io/granted/usage/profile-registry#:~:text=the%20following%20command%3A-,granted,-registry%20add%20%2Dname

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.

1.

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [X] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
