### PR TITLE
enhancement: default Y/n for firefox, minor typos/grammar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ The CLI should now be available on your PATH as `dgranted` and `dassume`.
 
 ## Creating a bug report
 
-Receiving bug reports is great, its helps us the identify and patch issues in the application so that the users have as good experience as possible. But it's important to include the necessary information in the bug report so that the maintainers are able to get to the bottom of the problem with as much context as possible.
+Receiving bug reports is great, it helps us identify and patch issues in the application so that the users have the best possible experience. But it's important to include the necessary information in the bug report so that the maintainers are able to get to the bottom of the problem with as much context as possible.
 
 When opening a bug report we ask that you please include the following information:
 

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -67,7 +67,7 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 
-		// save the profile to the AWS config file, if the user requested it.
+		// save the profile to the AWS config file if the user requested it.
 		saveProfileName := assumeFlags.String("save-to")
 		if saveProfileName != "" {
 			configFilename := awsconfig.DefaultSharedConfigFilename()
@@ -148,9 +148,9 @@ func AssumeCommand(c *cli.Context) error {
 
 		// if profile is still "" here, then prompt to select a profile
 		if profileName == "" {
-			// will print a command output for the user so it's easier for them to re run later or learn the commands
+			// will print a command output for the user so it's easier for them to re-run later or learn the commands
 			showRerunCommand = true
-			//load config to check frecency enabled
+			// load config to check frecency enabled
 			cfg, err := config.Load()
 			if err != nil {
 				return err
@@ -221,6 +221,7 @@ func AssumeCommand(c *cli.Context) error {
 			if len(profileKeys) == 0 {
 				return clierr.New("Granted couldn't find any AWS profiles in your config file or your credentials file",
 					clierr.Info("You can add profiles to your AWS config by following our guide: "),
+					// TODO: this is a broken link, where should it point to?
 					clierr.Info("https://granted.dev/awsconfig"),
 				)
 			}
@@ -241,7 +242,7 @@ func AssumeCommand(c *cli.Context) error {
 		}
 		// ensure that frecency has finished updating before returning from this function
 		defer wg.Wait()
-		//finally, load the profile and initialise it, this builds the parent tree structure
+		// finally, load the profile and initialise it, this builds the parent tree structure
 		profile, err = profiles.LoadInitialisedProfile(c.Context, profileName)
 		if err != nil {
 			return err
@@ -266,7 +267,7 @@ func AssumeCommand(c *cli.Context) error {
 
 	configOpts := cfaws.ConfigOpts{Duration: time.Hour}
 
-	//attempt to get session duration from profile
+	// attempt to get session duration from profile
 	if profile.AWSConfig.RoleDurationSeconds != nil {
 		configOpts.Duration = *profile.AWSConfig.RoleDurationSeconds
 	}
@@ -293,7 +294,7 @@ func AssumeCommand(c *cli.Context) error {
 	// depending on how Granted is configured, this is then printed to the terminal or a browser is launched at the URL automatically.
 	getConsoleURL := !assumeFlags.Bool("env") && (assumeFlags.Bool("console") || assumeFlags.Bool("active-role") || assumeFlags.String("service") != "" || assumeFlags.Bool("url"))
 
-	// this makes it easy for users to copy the actuall command and avoid needing to lookup profiles
+	// this makes it easy for users to copy the actual command and avoid needing to lookup profiles
 	if showRerunCommand {
 		clio.Infof("To assume this profile again later without needing to select it, run this command:\n> assume %s %s", profile.Name, strings.Join(os.Args[1:], " "))
 	}
@@ -316,7 +317,7 @@ func AssumeCommand(c *cli.Context) error {
 		}
 
 		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey {
-			// tranform the URL into the Firefox Tab Container format.
+			// transform the URL into the Firefox Tab Container format.
 			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", profile.Name, url.QueryEscape(consoleURL), profile.CustomGrantedProperty("color"), profile.CustomGrantedProperty("icon"))
 		}
 
@@ -433,7 +434,7 @@ func AssumeCommand(c *cli.Context) error {
 		}
 		// DO NOT REMOVE, this interacts with the shell script that wraps the assume command, the shell script is what configures your shell environment vars
 		// to export more environment variables, add then in the assume and assume.fish scripts then append them to this output preparation function
-		// the shell script treats "None" as an emprty string and will not set a value for that positional output
+		// the shell script treats "None" as an empty string and will not set a value for that positional output
 		if assumeFlags.Bool("sso") {
 			output := PrepareStringsForShellScript([]string{creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken, "", region, sessionExpiration, "true", profile.AWSConfig.SSOStartURL, profile.AWSConfig.SSORoleName, profile.AWSConfig.SSORegion, profile.AWSConfig.SSOAccountID})
 			fmt.Printf("GrantedAssume %s %s %s %s %s %s %s %s %s %s %s", output...)
@@ -460,8 +461,8 @@ func PrepareStringsForShellScript(in []string) []interface{} {
 	return out
 }
 
-// RunExecCommandWithCreds takes in a command, which may be a program and arguments sperated by spaces
-// it splits these then runs the command with teh credentials as the environment.
+// RunExecCommandWithCreds takes in a command, which may be a program and arguments separated by spaces
+// it splits these then runs the command with the credentials as the environment.
 // The output of this is returned via the assume script to stdout so it may be processed further by piping
 func RunExecCommandWithCreds(cmd string, creds aws.Credentials, region string) error {
 	fmt.Print(assumeprint.SafeOutput(""))

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -221,7 +221,6 @@ func AssumeCommand(c *cli.Context) error {
 			if len(profileKeys) == 0 {
 				return clierr.New("Granted couldn't find any AWS profiles in your config file or your credentials file",
 					clierr.Info("You can add profiles to your AWS config by following our guide: "),
-					// TODO: this is a broken link, where should it point to?
 					clierr.Info("https://docs.commonfate.io/granted/getting-started#set-up-your-aws-profile-file"),
 				)
 			}

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -222,7 +222,7 @@ func AssumeCommand(c *cli.Context) error {
 				return clierr.New("Granted couldn't find any AWS profiles in your config file or your credentials file",
 					clierr.Info("You can add profiles to your AWS config by following our guide: "),
 					// TODO: this is a broken link, where should it point to?
-					clierr.Info("https://granted.dev/awsconfig"),
+					clierr.Info("https://docs.commonfate.io/granted/getting-started#set-up-your-aws-profile-file"),
 				)
 			}
 

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -94,7 +94,7 @@ func GetCliApp() *cli.App {
 					return err
 				}
 
-				//see if they want to set their sso browser the same as their granted default
+				// see if they want to set their sso browser the same as their granted default
 				err = browser.SSOBrowser(browserName)
 				if err != nil {
 					return err

--- a/pkg/assume/unset.go
+++ b/pkg/assume/unset.go
@@ -9,7 +9,7 @@ import (
 
 func UnsetAction(c *cli.Context) error {
 	clio.Success("Environment variables cleared")
-	//interacts with scripts to unset all the aws environment variables
+	// interacts with scripts to unset all the aws environment variables
 	fmt.Print("GrantedDesume")
 	return nil
 }

--- a/pkg/assumeprint/output.go
+++ b/pkg/assumeprint/output.go
@@ -6,7 +6,7 @@ import (
 )
 
 // SafeOutput formats a string to match the requirements of granted output in the shell script
-// Currently in windows, the grantedoutput is handled differently, as linux and mac support the exec cli flag whereas windows does not yet have support
+// Currently in windows, the granted output is handled differently, as linux and mac support the exec cli flag whereas windows does not yet have support
 // this method may be changed in future if we implement support for "--exec" in windows
 func SafeOutput(s string) string {
 	// if the GRANTED_ALIAS_CONFIGURED env variable isn't set,

--- a/pkg/autosync/autosync.go
+++ b/pkg/autosync/autosync.go
@@ -9,7 +9,7 @@ import (
 
 // shouldFailForRequiredKeys when true will fail the profile registry sync
 // in case where user specific values that are defined in granted.yml's `templateValues` are not available.
-// this is done so that users are aware of required keys when granted credential-process is used thorugh AWS CLI.
+// this is done so that users are aware of required keys when granted's credential-process is used through the AWS CLI.
 func Run(shouldFailForRequiredKeys bool) {
 	if registry.IsOutdatedConfig() {
 		clio.Warn("Outdated Profile Registry Configuration. Use `granted registry migrate` to update your configuration.")

--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -39,7 +39,7 @@ var ChromiumPathLinux = []string{`/usr/bin/chromium`, `/../../mnt/c/Program File
 var ChromiumPathWindows = []string{`\Program Files\Chromium\chromium.exe`}
 
 func ChromePathDefaults() ([]string, error) {
-	//check linuxpath for binary install
+	// check linuxpath for binary install
 	path, err := exec.LookPath("google-chrome-stable")
 	if err != nil {
 		path, err = exec.LookPath("google-chrome")
@@ -63,7 +63,7 @@ func ChromePathDefaults() ([]string, error) {
 }
 
 func BravePathDefaults() ([]string, error) {
-	//check linuxpath for binary install
+	// check linuxpath for binary install
 	path, err := exec.LookPath("brave")
 	if err == nil {
 		return []string{path}, nil
@@ -81,7 +81,7 @@ func BravePathDefaults() ([]string, error) {
 }
 
 func EdgePathDefaults() ([]string, error) {
-	//check linuxpath for binary install
+	// check linuxpath for binary install
 	path, err := exec.LookPath("edge")
 	if err == nil {
 		return []string{path}, nil
@@ -99,7 +99,7 @@ func EdgePathDefaults() ([]string, error) {
 }
 
 func FirefoxPathDefaults() ([]string, error) {
-	//check linuxpath for binary install
+	// check linuxpath for binary install
 	path, err := exec.LookPath("firefox")
 	if err == nil {
 		return []string{path}, nil
@@ -117,7 +117,7 @@ func FirefoxPathDefaults() ([]string, error) {
 }
 
 func ChromiumPathDefaults() ([]string, error) {
-	//check linuxpath for binary install
+	// check linuxpath for binary install
 	path, err := exec.LookPath("chromium")
 	if err == nil {
 		return []string{path}, nil

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -21,7 +21,7 @@ import (
 
 // Checks the config to see if the user has already set up their default browser
 func UserHasDefaultBrowser(ctx *cli.Context) (bool, error) {
-	//just check the config file for the default browser efield
+	// just check the config file for the default browser field
 	conf, err := config.Load()
 	if err != nil {
 		return false, err
@@ -31,7 +31,7 @@ func UserHasDefaultBrowser(ctx *cli.Context) (bool, error) {
 	if conf.DefaultBrowser == StdoutKey || conf.DefaultBrowser == FirefoxStdoutKey {
 		return true, nil
 	}
-	// Due to a change in the behaviour of the browser detection , this is here to migrate existing users who have already configured granted
+	// Due to a change in the behaviour of the browser detection, this is here to migrate existing users who have already configured granted
 	// The change is that the browser path will be saved in the config along with the browser type for all installations, except the Stdout browser types
 	// This can be removed in a future version of granted, when everyone is expected to have migrated
 	if conf.DefaultBrowser != "" && conf.CustomBrowserPath == "" {
@@ -45,7 +45,7 @@ func UserHasDefaultBrowser(ctx *cli.Context) (bool, error) {
 }
 
 func HandleManualBrowserSelection() (string, error) {
-	//didn't find it request manual input
+	// didn't find it, request manual input
 
 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 	in := survey.Select{
@@ -165,6 +165,7 @@ func HandleBrowserWizard(ctx *cli.Context) (string, error) {
 	clio.Warn("Granted works best with Firefox but also supports Chrome, Brave, and Edge (https://docs.commonfate.io/granted/introduction#supported-browsers). You can change this setting later by running 'granted browser set'")
 	in := survey.Confirm{
 		Message: "Use Firefox as default Granted browser?",
+		Default: true,
 	}
 	var confirm bool
 	err = testable.AskOne(&in, &confirm, withStdio)
@@ -184,7 +185,7 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 	title := cases.Title(language.AmericanEnglish)
 	browserTitle := title.String(strings.ToLower(browserKey))
-	// We allow users to configure a custom install path is we cannot detect the installation
+	// We allow users to configure a custom install path if we cannot detect the installation
 	browserPath := path
 	// detect installation
 	if browserKey != FirefoxStdoutKey && browserKey != StdoutKey {
@@ -225,7 +226,7 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 			}
 		}
 	}
-	//save the detected browser as the default
+	// save the detected browser as the default
 	conf, err := config.Load()
 	if err != nil {
 		return err
@@ -264,7 +265,7 @@ func SSOBrowser(grantedDefaultBrowser string) error {
 	if err != nil {
 		return err
 	}
-	//save the detected browser as the default
+	// save the detected browser as the default
 	conf, err := config.Load()
 	if err != nil {
 		return err

--- a/pkg/browser/osx.go
+++ b/pkg/browser/osx.go
@@ -9,44 +9,44 @@ import (
 )
 
 type plist struct {
-	//XMLName xml.Name `xml:"plist"`
+	// XMLName xml.Name `xml:"plist"`
 	Pdict Pdict `xml:"dict"`
 }
 
 type Pdict struct {
-	//XMLName xml.Name `xml:"dict"`
+	// XMLName xml.Name `xml:"dict"`
 	Key   string `xml:"key"`
 	Array Array  `xml:"array"`
 }
 
 type Array struct {
-	//XMLName xml.Name `xml:"array"`
+	// XMLName xml.Name `xml:"array"`
 	Dict Dict `xml:"dict"`
 }
 
 type Dict struct {
-	//XMLName xml.Name `xml:"dict"`
+	// XMLName xml.Name `xml:"dict"`
 	Key     []string `xml:"key"`
 	Dict    IntDict  `xml:"dict"`
 	Strings []string `xml:"string"`
 }
 
 type IntDict struct {
-	//XMLName xml.Name `xml:"dict"`
+	// XMLName xml.Name `xml:"dict"`
 	Key     string `xml:"key"`
 	Strings string `xml:"string"`
 }
 
 func HandleOSXBrowserSearch() (string, error) {
-	//get home dir
+	// get home dir
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
 	path := home + "/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
 
-	//convert plist to xml using putil
-	//plutil -convert xml1
+	// convert plist to xml using putil
+	// plutil -convert xml1
 	args := []string{"-convert", "xml1", path}
 	cmd := exec.Command("plutil", args...)
 	err = cmd.Run()
@@ -54,7 +54,7 @@ func HandleOSXBrowserSearch() (string, error) {
 		clio.Debug(err.Error())
 	}
 
-	//read plist file
+	// read plist file
 	data, err := os.ReadFile(path)
 
 	if err != nil {
@@ -62,13 +62,13 @@ func HandleOSXBrowserSearch() (string, error) {
 	}
 	plist := &plist{}
 
-	//unmarshal the xml into the structs
+	// unmarshal the xml into the structs
 	err = xml.Unmarshal([]byte(data), &plist)
 	if err != nil {
 		clio.Debug(err.Error())
 	}
 
-	//get out the default browser
+	// get out the default browser
 
 	for i, s := range plist.Pdict.Array.Dict.Strings {
 		if s == "http" {

--- a/pkg/cfaws/access_request.go
+++ b/pkg/cfaws/access_request.go
@@ -39,7 +39,7 @@ func FormatAWSErrorWithGrantedApprovalsURL(awsError error, rawConfig *ini.Sectio
 	if url != "" {
 		// if we have a request URL, we can prompt the user to make a request by visiting the URL.
 		requestURL := buildRequestURL(url, SSORoleName, SSOAccountId)
-		// need to escape the % symbol in the request url which has been query escaped so that fmt does';t try to substitute it
+		// need to escape the % symbol in the request url which has been query escaped so that fmt doesn't try to substitute it
 		cliError.Messages = append(cliError.Messages, clierr.Warn("You need to request access to this role:"), clierr.Warn(requestURL))
 		return cliError
 	}

--- a/pkg/cfaws/assumer_aws_azure_login.go
+++ b/pkg/cfaws/assumer_aws_azure_login.go
@@ -16,18 +16,18 @@ import (
 type AwsAzureLoginAssumer struct {
 }
 
-//https://github.com/sportradar/aws-azure-login
+// https://github.com/sportradar/aws-azure-login
 
 // then fetch them from the environment for use
 func (aal *AwsAzureLoginAssumer) AssumeTerminal(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
-	//check to see if the creds are already exported
+	// check to see if the creds are already exported
 	creds, err := GetCredentialsCreds(ctx, c)
 
 	if err == nil {
 		return creds, nil
 	}
 
-	//request for the creds if they are invalid
+	// request for the creds if they are invalid
 	a := []string{fmt.Sprintf("--profile=%s", c.Name)}
 	a = append(a, configOpts.Args...)
 

--- a/pkg/cfaws/assumer_aws_credential_process.go
+++ b/pkg/cfaws/assumer_aws_credential_process.go
@@ -28,7 +28,7 @@ func loadCredProcessCreds(ctx context.Context, c *Profile) (aws.Credentials, err
 }
 
 func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
-	// if the profile has parents, then we need to first use credentail process to assume the root profile.
+	// if the profile has parents, then we need to first use credential process to assume the root profile.
 	// then assume each of the chained profiles
 	if len(c.Parents) != 0 {
 		p := c.Parents[0]

--- a/pkg/cfaws/assumer_aws_iam.go
+++ b/pkg/cfaws/assumer_aws_iam.go
@@ -59,7 +59,7 @@ func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *Profile, config
 		return aws.Credentials{}, err
 	}
 
-	//inform the user about using the secure storage to securely store IAM user credentials
+	// inform the user about using the secure storage to securely store IAM user credentials
 	// if it has no parents and it reached this point, it must have had plain text credentials
 	// if it has parents, and the root is not a secure storage iam profile, then it has plain text credentials
 	if len(c.Parents) == 0 || !c.Parents[0].HasSecureStorageIAMCredentials {
@@ -72,7 +72,7 @@ func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *Profile, config
 }
 
 // if required will get a FederationToken to be used to launch the console
-// This is required is the iam profile does not assume a role using sts.AssumeRole
+// This is required if the iam profile does not assume a role using sts.AssumeRole
 func (aia *AwsIamAssumer) AssumeConsole(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
 	if c.AWSConfig.Credentials.SessionToken != "" {
 		clio.Debug("found existing session token in credentials for IAM profile, using this to launch the console")
@@ -108,7 +108,7 @@ var allowAllPolicy = `{
     ]
 }`
 
-// GetFederationToken is used when launching a console session with longlived IAM credentials profiles
+// GetFederationToken is used when launching a console session with long-lived IAM credentials profiles
 // GetFederation token uses an allow all IAM policy so that the console session will be able to access everything
 // If this is not provided, the session cannot do anything in the console
 func getFederationToken(ctx context.Context, c *Profile) (aws.Credentials, error) {
@@ -117,7 +117,7 @@ func getFederationToken(ctx context.Context, c *Profile) (aws.Credentials, error
 		config.WithSharedConfigProfile(c.Name),
 	}
 
-	//load the creds from the credentials file
+	// load the creds from the credentials file
 	cfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
 		return aws.Credentials{}, err

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -145,7 +145,7 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 				return aws.Credentials{}, err
 			}
 			// only print for sub assumes because the final credentials are printed at the end of the assume command
-			// this is here for visibility in to role traversals when assuming a final profile with sso
+			// this is here for visibility into role traversals when assuming a final profile with sso
 			if i < len(toAssume)-1 {
 				durationDescription := durafmt.Parse(time.Until(stsCreds.Expires) * time.Second).LimitFirstN(1).String()
 				clio.Successf("Assumed parent profile: [%s](%s) session credentials will expire %s", p.Name, region, durationDescription)
@@ -185,7 +185,7 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 	url := aws.ToString(deviceAuth.VerificationUriComplete)
 	clio.Info("If the browser does not open automatically, please open this link: " + url)
 
-	//check if sso browser path is set
+	// check if sso browser path is set
 	config, err := grantedConfig.Load()
 	if err != nil {
 		return nil, err
@@ -198,7 +198,7 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 			// fail silently
 			clio.Debug(err.Error())
 		} else {
-			// detatch from this new process because it continues to run
+			// detach from this new process because it continues to run
 			err = cmd.Process.Release()
 			if err != nil {
 				// fail silently

--- a/pkg/cfaws/assumers.go
+++ b/pkg/cfaws/assumers.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Added support for optional pass through args on proxy sso provider
-// When using a sso provider adding pass through flags can be acheived by adding the -pass-through or -pt flag
+// When using a sso provider adding pass through flags can be achieved by adding the -pass-through or -pt flag
 // EG. assume role-a -pt --mode -pt gui (Run the proxy login with a gui rather than in cli. Example taken from aws-azure-login)
 type Assumer interface {
 	// AssumeTerminal should follow the required process for it implemetation and return aws credentials ready to be exported to the terminal environment
@@ -18,7 +18,7 @@ type Assumer interface {
 	AssumeConsole(context.Context, *Profile, ConfigOpts) (aws.Credentials, error)
 	// A unique key which identifies this assumer e.g AWS-SSO or GOOGLE-AWS-AUTH
 	Type() string
-	// ProfileMatchesType takes a list of strings which are the lines in an aw config profile and returns true if this profile is the assumers type
+	// ProfileMatchesType takes a list of strings which are the lines in an aws config profile and returns true if this profile is the assumers type
 	ProfileMatchesType(*ini.Section, config.SharedConfig) bool
 }
 

--- a/pkg/cfaws/cred-exporter.go
+++ b/pkg/cfaws/cred-exporter.go
@@ -15,7 +15,7 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 	// fetch the parsed cred file
 	credPath := config.DefaultSharedCredentialsFilename()
 
-	//create it if it doesn't exist
+	// create it if it doesn't exist
 	if _, err := os.Stat(credPath); os.IsNotExist(err) {
 
 		f, err := os.Create(credPath)
@@ -52,7 +52,7 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 	if err != nil {
 		return err
 	}
-	//put the creds into options
+	// put the creds into options
 	err = section.ReflectFrom(&struct {
 		AWSAccessKeyID     string `ini:"aws_access_key_id"`
 		AWSSecretAccessKey string `ini:"aws_secret_access_key"`

--- a/pkg/cfaws/creds.go
+++ b/pkg/cfaws/creds.go
@@ -34,10 +34,10 @@ func GetEnvCredentials(ctx context.Context) aws.Credentials {
 }
 
 func GetCredentialsCreds(ctx context.Context, c *Profile) (aws.Credentials, error) {
-	//check to see if the creds are already exported
+	// check to see if the creds are already exported
 	creds, _ := aws.NewCredentialsCache(&CredProv{Credentials: c.AWSConfig.Credentials}).Retrieve(ctx)
 
-	//check creds are valid - return them if they are
+	//c heck creds are valid - return them if they are
 	if creds.HasKeys() && !creds.Expired() {
 		cfg := aws.NewConfig()
 		cfg.Credentials = &CredProv{Credentials: c.AWSConfig.Credentials}

--- a/pkg/cfaws/creds.go
+++ b/pkg/cfaws/creds.go
@@ -37,7 +37,7 @@ func GetCredentialsCreds(ctx context.Context, c *Profile) (aws.Credentials, erro
 	// check to see if the creds are already exported
 	creds, _ := aws.NewCredentialsCache(&CredProv{Credentials: c.AWSConfig.Credentials}).Retrieve(ctx)
 
-	//c heck creds are valid - return them if they are
+	// check creds are valid - return them if they are
 	if creds.HasKeys() && !creds.Expired() {
 		cfg := aws.NewConfig()
 		cfg.Credentials = &CredProv{Credentials: c.AWSConfig.Credentials}

--- a/pkg/cfaws/granted_config.go
+++ b/pkg/cfaws/granted_config.go
@@ -94,7 +94,7 @@ func IsValidGrantedProfile(profile *Profile) error {
 	return nil
 }
 
-// check if the config section shas any keys prefixed with "granted_sso_"
+// check if the config section has any keys prefixed with "granted_sso_"
 func hasGrantedSSOPrefix(rawConfig *ini.Section) bool {
 	for _, v := range rawConfig.KeyStrings() {
 		if strings.HasPrefix(v, "granted_sso_") {
@@ -122,12 +122,12 @@ func validateCredentialProcess(arg string, awsProfileName string) error {
 			return fmt.Errorf("profile name not provided. Try adding profile name like 'granted credential-process --profile <profile-name>'")
 		}
 
-		// if matches then do nth.
+		// if matches then do nothing.
 		if profileName == awsProfileName {
 			return nil
 		}
 
-		return fmt.Errorf("unmatched profile names. The profile name '%s' provided to 'granted credential-process' doesnot match AWS profile name '%s'", profileName, awsProfileName)
+		return fmt.Errorf("unmatched profile names. The profile name '%s' provided to 'granted credential-process' does not match AWS profile name '%s'", profileName, awsProfileName)
 	}
 
 	return fmt.Errorf("unable to parse 'credential_process'. Looks like your credential_process isn't configured correctly. \n You need to add 'granted credential-process --profile <profile-name>'")

--- a/pkg/cfaws/granted_config_test.go
+++ b/pkg/cfaws/granted_config_test.go
@@ -23,7 +23,7 @@ func TestValidateCredentialProcess(t *testing.T) {
 			name:        "valid argument with incorrect profile name",
 			arg:         "granted credential-process --profile abc",
 			profileName: "develop",
-			wantErr:     "unmatched profile names. The profile name 'abc' provided to 'granted credential-process' doesnot match AWS profile name 'develop'",
+			wantErr:     "unmatched profile names. The profile name 'abc' provided to 'granted credential-process' does not match AWS profile name 'develop'",
 		},
 		{
 			name:        "invalid argument",

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -62,9 +62,9 @@ type Profiles struct {
 func LoadSSOSessions(configFile *ini.File) (map[string]SSOSession, error) {
 	sessions := make(map[string]SSOSession)
 
-	// Itterate through the config sections
+	// Iterate through the config sections
 	for _, section := range configFile.Sections() {
-		// the ini package adds an extra section called DEFAULT, but this is different to the AWS standard of 'default' so we ignore it an only look at 'default'
+		// the ini package adds an extra section called DEFAULT, but this is different to the AWS standard of 'default' so we ignore it and only look at 'default'
 		if strings.HasPrefix(section.Name(), "sso-session ") {
 			session := SSOSession{}
 			regionKey, err := section.GetKey("sso_region")
@@ -87,7 +87,7 @@ func (p *Profiles) HasProfile(profile string) bool {
 
 // if the profile has a "granted_${name}" key, the value is returned. else an empty string
 func (p *Profile) CustomGrantedProperty(name string) string {
-	// rawConfig can be nil when all the required paraments are pass as arguments
+	// rawConfig can be nil when all the required parameters are passed as arguments
 	// like assume --sso --sso_start-url ...
 	if p.RawConfig == nil {
 		return ""
@@ -171,7 +171,7 @@ func (p *Profiles) loadDefaultConfigFile(loader ConfigFileLoader) error {
 	if err != nil {
 		return err
 	}
-	// Itterate through the config sections
+	// Iterate through the config sections
 	for _, section := range configFile.Sections() {
 		// the ini package adds an extra section called DEFAULT, but this is different to the AWS standard of 'default' so we ignore it an only look at 'default'
 		if section.Name() != "DEFAULT" {
@@ -208,13 +208,13 @@ func (p *Profiles) loadDefaultConfigFile(loader ConfigFileLoader) error {
 // aws_secret_access_key = xxxxxx
 // ...
 func (p *Profiles) loadDefaultCredentialsFile(loader ConfigFileLoader) error {
-	//fetch parsed credentials file
+	// fetch parsed credentials file
 	credentialsFile, err := loader.Load()
 	if err != nil {
 		return err
 	}
 	for _, section := range credentialsFile.Sections() {
-		// the ini package adds an extra section called DEFAULT, but this is different to the AWS standard of 'default' so we ignore it an only look at 'default'
+		// the ini package adds an extra section called DEFAULT, but this is different to the AWS standard of 'default' so we ignore it and only look at 'default'
 		if section.Name() != "DEFAULT" {
 			// We only care about the non default sections for the credentials file (no profile prefix either)
 			if section.Name() != "default" && IsLegalProfileName(section.Name()) {
@@ -235,7 +235,7 @@ func (p *Profiles) loadDefaultCredentialsFile(loader ConfigFileLoader) error {
 // Helper function which returns true if provided profile name string does not contain illegal characters
 func IsLegalProfileName(name string) bool {
 	illegalProfileNameCharacters := regexp.MustCompile(`[\\[\];'" ]`)
-	illegalChars := `\][;'"` // These characters break the config file format and should not be usable for profile names
+	illegalChars := `\][;'"` // These characters break the config file format and are not allowed for profile names
 	if illegalProfileNameCharacters.MatchString(name) {
 		clio.Warnf("The profile %s cannot be loaded because the name contains one or more of these characters '%s'", name, illegalChars)
 		clio.Infof("Try renaming the profile to '%s'", illegalProfileNameCharacters.ReplaceAllString(name, "-"))
@@ -245,7 +245,7 @@ func IsLegalProfileName(name string) bool {
 }
 
 // InitialiseProfilesTree will initialise all profiles
-// this means that the profile prarent relations are walked and the profile type is determined
+// this means that the profile parent relations are walked and the profile type is determined
 // use this if you need to know the type of every profile in the config
 // for large configuations, this may be expensive
 func (p *Profiles) InitialiseProfilesTree(ctx context.Context) {
@@ -402,7 +402,7 @@ func (p *Profile) init(ctx context.Context, profiles *Profiles, depth int) error
 	return nil
 }
 
-// Region will attempt to load the reason on this profile, if it is not set,
+// Region will attempt to load the region on this profile, if it is not set,
 // attempt to load the parent if it exists
 // else attempts to use the sso-region
 // else attempts to load the default config

--- a/pkg/cfaws/session_name_test.go
+++ b/pkg/cfaws/session_name_test.go
@@ -9,7 +9,7 @@ import (
 // sessionName returns a unique session identifier for the aws console
 // this ensures that user activity can be easily audited per session
 func TestSessionName(t *testing.T) {
-	//getfederationtoken fails if name is longer than 32 characters long
+	// getfederationtoken fails if name is longer than 32 characters long
 	name := sessionName()
 	assert.LessOrEqual(t, len(name), 32)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	// denying access to assume a particular role.
 	AccessRequestURL string `toml:",omitempty"`
 
-	// depricated in favor of ProfileRegistry
+	// deprecated in favor of ProfileRegistry
 	ProfileRegistryURLS []string `toml:",omitempty"`
 	ProfileRegistry     struct {
 		// add any global configuration to profile registry here.

--- a/pkg/console/aws.go
+++ b/pkg/console/aws.go
@@ -102,8 +102,8 @@ func makeDestinationURL(service string, region string) (string, error) {
 	}
 	dest := prefix + service + "/home"
 
-	//excluding region here if the service is apart of the global service list
-	//incomplete list of global services
+	// excluding region here if the service is a part of the global service list
+	// incomplete list of global services
 	_, global := globalServiceMap[service]
 	hasRegion := region != ""
 	if !global && hasRegion {

--- a/pkg/forkprocess/forkprocess.go
+++ b/pkg/forkprocess/forkprocess.go
@@ -27,7 +27,7 @@ type Process struct {
 }
 
 // New creates a new Process with the current user's user and group ID.
-// Call Start() on the returned process to actually it.
+// Call Start() on the returned process to actually start it.
 func New(args ...string) (*Process, error) {
 	u, err := user.Current()
 	if err != nil {

--- a/pkg/forkprocess/forkprocess_windows.go
+++ b/pkg/forkprocess/forkprocess_windows.go
@@ -16,7 +16,7 @@ type Process struct {
 }
 
 // New creates a new Process with the current user's user and group ID.
-// Call Start() on the returned process to actually it.
+// Call Start() on the returned process to actually start it.
 func New(args ...string) (*Process, error) {
 	p := Process{
 		Args: args,

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -46,7 +46,7 @@ func max(a, b int) int {
 	return b
 }
 
-// Returns the cached entries stored in decending order by frecency, optionally limit the returned results
+// Returns the cached entries stored in descending order by frecency, optionally limit the returned results
 func (store *FrecencyStore) GetFrecentEntriess(optionalLimit *int) []interface{} {
 	entries := []interface{}{}
 	limit := len(store.Entries)

--- a/pkg/granted/browser.go
+++ b/pkg/granted/browser.go
@@ -12,7 +12,7 @@ var DefaultBrowserCommand = cli.Command{
 	Usage:       "View the web browser that Granted uses to open cloud consoles",
 	Subcommands: []*cli.Command{&SetBrowserCommand, &SetSSOBrowserCommand},
 	Action: func(c *cli.Context) error {
-		//return the default browser that is set
+		// return the default browser that is set
 		conf, err := config.Load()
 		if err != nil {
 			return err
@@ -54,7 +54,7 @@ var SetSSOBrowserCommand = cli.Command{
 	Action: func(c *cli.Context) (err error) {
 		outcome := c.String("browser")
 		path := c.String("path")
-		//save the detected browser as the default
+		// save the detected browser as the default
 		conf, err := config.Load()
 		if err != nil {
 			return err

--- a/pkg/granted/completion.go
+++ b/pkg/granted/completion.go
@@ -59,12 +59,12 @@ func installFishCompletions(c *cli.Context) error {
 	assumeAppOutput, _ := assumeApp.ToFishCompletion()
 	combinedOutput := fmt.Sprintf("%s\n%s", grantedAppOutput, assumeAppOutput)
 
-	// try fetch user home dir
+	// try to fetch user home dir
 	user, _ := user.Current()
 
 	executableDir := user.HomeDir + "/.config/fish/completions/granted_completer_fish.fish"
 
-	// Try create a file
+	// Try to create a file
 	err := os.WriteFile(executableDir, []byte(combinedOutput), 0600)
 	if err != nil {
 		return fmt.Errorf("Something went wrong when saving fish autocompletions: " + err.Error())

--- a/pkg/granted/credentials.go
+++ b/pkg/granted/credentials.go
@@ -70,7 +70,7 @@ var AddCredentialsCommand = cli.Command{
 	},
 }
 
-// addCredentialProcessToConfigfileProfile creates or updates a profile entry in the aws config file withs a granted credential_process entry
+// addCredentialProcessToConfigfileProfile creates or updates a profile entry in the aws config file with a granted credential_process entry
 // this allows the profile to still work as expected with the AWS cli or other tools using the --profile flag
 //
 //	[profile my-profile]
@@ -283,7 +283,7 @@ var UpdateCredentialsCommand = cli.Command{
 		if !has {
 			return fmt.Errorf("no credentials exist for %s in secure storage. If you wanted to add a new profile, run '%s credentials add'", profileName, build.GrantedBinaryName())
 		}
-		
+
 		credentials, err := promptCredentials()
 		if err != nil {
 			return err
@@ -292,7 +292,6 @@ var UpdateCredentialsCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-
 
 		fmt.Printf("Updated %s in secure storage\n", profileName)
 
@@ -443,7 +442,7 @@ var ExportCredentialsCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-			//fetch parsed credentials file
+			// fetch parsed credentials file
 			credentialsFilePath := config.DefaultSharedCredentialsFilename()
 			credentialsFile, err := ini.LoadSources(ini.LoadOptions{
 				AllowNonUniqueSections:  false,
@@ -484,9 +483,9 @@ var ExportCredentialsCommand = cli.Command{
 			sectionName := "profile " + profileName
 			if section, _ := configFile.GetSection(sectionName); section != nil {
 				if section.HasKey("credential_process") {
-					// if the result of removing the credential process is that the profile has not configuration, then just remove it completely.
+					// if the result of removing the credential process is that the profile has no configuration, then just remove it completely.
 					// the profile in the credential file will suffice
-					// else just remove teh credential process line.
+					// else just remove the credential process line.
 					// this avoids leaving the config file with an empty profile, which appears to be some kind of error when its not
 					if len(section.Keys()) > 1 {
 						section.DeleteKey("credential_process")
@@ -510,9 +509,9 @@ var ExportCredentialsCommand = cli.Command{
 }
 
 var RotateCredentialsCommand = cli.Command{
-	Name:      "rotate",
-	Usage:     "Generates new access key for the profile in AWS, and updates the profile",
-	Flags:     []cli.Flag{&cli.StringFlag{Name: "profile", Usage: "If provided, generates new access key for the specified profile"}},
+	Name:  "rotate",
+	Usage: "Generates new access key for the profile in AWS, and updates the profile",
+	Flags: []cli.Flag{&cli.StringFlag{Name: "profile", Usage: "If provided, generates new access key for the specified profile"}},
 	Action: func(c *cli.Context) error {
 		profileName := c.String("profile")
 
@@ -547,13 +546,13 @@ var RotateCredentialsCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		
+
 		opts := []func(*config.LoadOptions) error{
 			// load the config profile
 			config.WithSharedConfigProfile(profileName),
 		}
-	
-		//load the creds from the credentials file
+
+		// load the creds from the credentials file
 		cfg, err := config.LoadDefaultConfig(c.Context, opts...)
 		if err != nil {
 			return err
@@ -574,10 +573,10 @@ var RotateCredentialsCommand = cli.Command{
 		_, err = iamClient.UpdateAccessKey(c.Context, &iam.UpdateAccessKeyInput{AccessKeyId: &t.AccessKeyID, Status: "Inactive"})
 		if err != nil {
 			return err
-		}	
+		}
 
 		clio.Successf("Access Key of '%s' profile has been successfully rotated and updated in secure storage\n", profileName)
 
-		return nil		
+		return nil
 	},
 }

--- a/pkg/granted/registry/registry.go
+++ b/pkg/granted/registry/registry.go
@@ -190,8 +190,8 @@ func (r Registry) PromptRequiredKeys(passedKeys []string, shouldFailForRequiredK
 
 				// if the required key is missing and the command is called through credential process
 				// then instead of asking for prompt we need to fail the process because
-				// credential process might be used with native AWS CLI command which can't have any thing
-				// in it's STDIO expect the JSON output that AWS credential_process expects.
+				// credential process might be used with native the AWS CLI command which can't have any thing
+				// in its STDIO except the JSON output that AWS credential_process expects.
 				// so fail with warning that there are required keys you need to fill by running granted sync.
 				if shouldFailForRequiredKeys {
 					clio.Errorf("Error syncing registry '%s'. You need to enter value for required key: '%s' before you can preceed.", r.Config.Name, fieldName)

--- a/pkg/granted/registry/sections.go
+++ b/pkg/granted/registry/sections.go
@@ -170,15 +170,15 @@ func generateNewRegistrySection(r *Registry, configFile *ini.File, clonedFile *i
 	currentProfiles := configFile.SectionStrings()
 	namespace := sectionName
 
-	// iterate each profile section from clonned repo
+	// iterate each profile section from cloned repo
 	// add them to aws config file
-	// if there is collision in the profile names then prefix with namespace.
+	// if there is a collision in the profile names then prefix with namespace.
 	for _, sec := range clonedFile.Sections() {
 		if sec.Name() == ini.DefaultSection {
 			continue
 		}
 
-		// All section that starts with 'profile' prefix will be considered as AWS profile and will be verified
+		// All sections that start with 'profile' prefix will be considered as AWS profiles and will be verified
 		// 1. if they have a correct profile name
 		// 2. if they have duplicate profile names i.e if the new profile name already exists on the aws config file
 		// For any other section, copy the content as it is.

--- a/pkg/granted/registry/sync.go
+++ b/pkg/granted/registry/sync.go
@@ -90,7 +90,7 @@ func runSync(r *Registry, configFile *ini.File, configFilePath string, opts sync
 		return err
 	}
 
-	// If the local repo has been deleted, then attem	pt to clone it again
+	// If the local repo has been deleted, then attempt to clone it again
 	_, err = os.Stat(repoDirPath)
 	if os.IsNotExist(err) {
 		err = gitClone(r.Config.URL, repoDirPath)
@@ -136,10 +136,10 @@ func runSync(r *Registry, configFile *ini.File, configFilePath string, opts sync
 }
 
 // when there is new duplication when running sync command
-// and if user choses to duplicate then currenlty the config is not saved to gconfig.
+// and if user chooses to duplicate then currently the config is not saved to gconfig.
 
 // Sync function will load all the configs provided in the clonedFile.
-// and generated a new section in the ~/.aws/profile file.
+// and generate a new section in the ~/.aws/profile file.
 func Sync(r *Registry, awsConfigFile *ini.File, opts syncOpts) error {
 	clio.Debugf("syncing %s \n", r.Config.Name)
 
@@ -153,7 +153,7 @@ func Sync(r *Registry, awsConfigFile *ini.File, opts syncOpts) error {
 		return err
 	}
 
-	// return custom error that should be catched and skipped.
+	// return custom error that should be caught and skipped.
 	err = generateNewRegistrySection(r, awsConfigFile, clonedFile, gconf, opts)
 	if err != nil {
 		return &SyncError{

--- a/pkg/granted/settings/print.go
+++ b/pkg/granted/settings/print.go
@@ -22,7 +22,7 @@ var PrintCommand = cli.Command{
 			{"update-checker-api-url", c.String("update-checker-api-url")},
 		}
 		// display config, this uses reflection to convert the config struct to a map
-		// it will always show all teh values in teh config without us having to update it
+		// it will always show all the values in the config without us having to update it
 		for k, v := range structs.Map(cfg) {
 			data = append(data, []string{k, fmt.Sprint(v)})
 		}

--- a/pkg/granted/tokens.go
+++ b/pkg/granted/tokens.go
@@ -64,24 +64,24 @@ var ListSSOTokensCommand = cli.Command{
 }
 
 var TokenExpiryCommand = cli.Command{
-	Name:        "expiry",
-	Usage:       "Lists expiry status for all access tokens saved in the keyring",
-	Flags: 		 []cli.Flag{&cli.StringFlag{Name: "url", Usage: "If provided, prints the expiry of the token for the specific SSO URL"}},
+	Name:  "expiry",
+	Usage: "Lists expiry status for all access tokens saved in the keyring",
+	Flags: []cli.Flag{&cli.StringFlag{Name: "url", Usage: "If provided, prints the expiry of the token for the specific SSO URL"}},
 	Action: func(ctx *cli.Context) error {
 		url := ctx.String("url")
-		
-		secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()		
 
-		if url != ""{			
+		secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
+
+		if url != "" {
 			token := secureSSOTokenStorage.GetValidSSOToken(url)
 
 			var expiry string
-			if token == nil{
+			if token == nil {
 				return errors.New("SSO token is expired")
 			}
-			expiry = token.Expiry.Local().Format(time.RFC3339)			
+			expiry = token.Expiry.Local().Format(time.RFC3339)
 			fmt.Println(expiry)
-				
+
 			return nil
 		}
 
@@ -106,10 +106,10 @@ var TokenExpiryCommand = cli.Command{
 			token := secureSSOTokenStorage.GetValidSSOToken(key)
 
 			var expiry string
-			if token == nil{
+			if token == nil {
 				expiry = "EXPIRED"
-			}else {
-				expiry = token.Expiry.Local().Format(time.RFC3339)			
+			} else {
+				expiry = token.Expiry.Local().Format(time.RFC3339)
 			}
 
 			clio.Logf("%-*s (%s) expires at: %s", max, key, strings.Join(startUrlMap[key], ", "), expiry)
@@ -118,9 +118,9 @@ var TokenExpiryCommand = cli.Command{
 	},
 }
 
-// granted token -> lists all tick
-// granted token list -> lists all tick
-// granted token clear -> prompts for selection // promt confirm?
+// granted token -> lists all tokens
+// granted token list -> lists all tokens
+// granted token clear -> prompts for selection // prompt confirm?
 // granted token clear --all or -a -> clear all
 // granted token clear profilename -> clear profile
 // granted token clear profilename --confirm -> skip confirm prompt

--- a/pkg/testable/testable.go
+++ b/pkg/testable/testable.go
@@ -29,7 +29,7 @@ func EndTesting() {
 	isTesting = false
 }
 
-// Configure this with a function that retruns the next input required for a cli test
+// Configure this with a function that returns the next input required for a cli test
 func WithNextSurveyInputFunc(next func() StringOrBool) {
 	nextSurveyInput = next
 }


### PR DESCRIPTION
## Describe your changes

This change does the following:
1. Default prompt for `Use Firefox as default Granted browser?` to Y instead of N
1. Minor grammatical/typo cleanup in comments

> **Note** I need guidance on `pkg/assume/assume.go` the url is broken and I'm not sure what it should be.  Look for `TODO` in the changes to find the url.

## Type of change

- [x] Enhancement

## Issue and Documentation

No issue, just that currently this prompt defaults to No if you hit enter and I'd expect it to be Yes if it is the preferred browser:

`? Use Firefox as default Granted browser? (y/N)`

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.

1. Remove `DefaultBrowser` line from `.granted/config` and run `assume`

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [x] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
