### PR TITLE
Fix credential process for headless clients

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -63,6 +63,10 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
 	cachedToken := secureSSOTokenStorage.GetValidSSOToken(ssoTokenKey)
 	var accessToken *string
+	//Dont try device flow if using granted credential process
+	if cachedToken == nil && configOpts.UsingCredentialProcess {
+		return aws.Credentials{}, errors.New("no sso token found. run 'granted sso login'")
+	}
 	if cachedToken == nil {
 		newSSOToken, err := SSODeviceCodeFlowFromStartUrl(ctx, *cfg, rootProfile.AWSConfig.SSOStartURL)
 		if err != nil {

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -2,6 +2,7 @@ package cfaws
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os/exec"
 	"time"
@@ -65,7 +66,18 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 	var accessToken *string
 	//Dont try device flow if using granted credential process
 	if cachedToken == nil && configOpts.UsingCredentialProcess {
-		return aws.Credentials{}, errors.New("error when retrieving credentials from custom process. please login using 'granted sso login'")
+		cmd := "granted sso login"
+		startURL := c.AWSConfig.SSOStartURL
+		if startURL != "" {
+			cmd += " --sso-start-url " + startURL
+		}
+
+		region := c.AWSConfig.SSORegion
+		if region != "" {
+			cmd += " --sso-region " + region
+		}
+
+		return aws.Credentials{}, fmt.Errorf("error when retrieving credentials from custom process. please login using '%s'", cmd)
 	}
 	if cachedToken == nil {
 		newSSOToken, err := SSODeviceCodeFlowFromStartUrl(ctx, *cfg, rootProfile.AWSConfig.SSOStartURL)

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -65,7 +65,7 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 	var accessToken *string
 	//Dont try device flow if using granted credential process
 	if cachedToken == nil && configOpts.UsingCredentialProcess {
-		return aws.Credentials{}, errors.New("no sso token found. run 'granted sso login'")
+		return aws.Credentials{}, errors.New("error when retrieving credentials from custom process. please login using 'granted sso login'")
 	}
 	if cachedToken == nil {
 		newSSOToken, err := SSODeviceCodeFlowFromStartUrl(ctx, *cfg, rootProfile.AWSConfig.SSOStartURL)

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -20,8 +20,9 @@ import (
 )
 
 type ConfigOpts struct {
-	Duration time.Duration
-	Args     []string
+	UsingCredentialProcess bool
+	Duration               time.Duration
+	Args                   []string
 }
 
 type SSOSession struct {

--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -43,7 +43,7 @@ var CredentialProcess = cli.Command{
 			duration = *profile.AWSConfig.RoleDurationSeconds
 		}
 
-		creds, err := profile.AssumeTerminal(c.Context, cfaws.ConfigOpts{Duration: duration})
+		creds, err := profile.AssumeTerminal(c.Context, cfaws.ConfigOpts{Duration: duration, UsingCredentialProcess: true})
 		if err != nil {
 			return err
 		}

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -213,7 +213,7 @@ var LoginCommand = cli.Command{
 		ssoStartUrl := c.String("sso-start-url")
 
 		if ssoStartUrl == "" {
-			in1 := survey.Input{Message: "SSO Start Url"}
+			in1 := survey.Input{Message: "SSO Start URL"}
 			err := testable.AskOne(&in1, &ssoStartUrl)
 			if err != nil {
 				return err

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -233,20 +233,15 @@ var LoginCommand = cli.Command{
 		cfg.Region = ssoRegion
 
 		secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
-		cachedToken := secureSSOTokenStorage.GetValidSSOToken(ssoStartUrl)
 
-		if cachedToken == nil {
-			newSSOToken, err := cfaws.SSODeviceCodeFlowFromStartUrl(ctx, *cfg, ssoStartUrl)
-			if err != nil {
-				return err
-			}
-
-			secureSSOTokenStorage.StoreSSOToken(ssoStartUrl, *newSSOToken)
-		} else {
-			clio.Info("Cached token found. Aborting SSO authentication flow.")
-			return nil
+		newSSOToken, err := cfaws.SSODeviceCodeFlowFromStartUrl(ctx, *cfg, ssoStartUrl)
+		if err != nil {
+			return err
 		}
-		clio.Info("Successfully authenticated using sso")
+
+		secureSSOTokenStorage.StoreSSOToken(ssoStartUrl, *newSSOToken)
+
+		clio.Successf("Successfully logged into Start URL: %s", ssoStartUrl)
 
 		return nil
 	},

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -243,7 +243,7 @@ var LoginCommand = cli.Command{
 
 			secureSSOTokenStorage.StoreSSOToken(ssoStartUrl, *newSSOToken)
 		} else {
-			clio.Info("Using cached token")
+			clio.Info("Cached token found. Aborting SSO authentication flow.")
 			return nil
 		}
 		clio.Info("Successfully authenticated using sso")

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -199,6 +199,34 @@ var PopulateCommand = cli.Command{
 	},
 }
 
+// var LoginCommand = cli.Command{
+// 	Name:  "login",
+// 	Usage: "Log in via AWS SSO interactive credential process",
+// 	Flags: []cli.Flag{},
+// 	Action: func(c *cli.Context) error {
+// 		ssoTokenKey := rootProfile.AWSConfig.SSOStartURL
+// 		cfg := aws.NewConfig()
+// 		cfg.Region = rootProfile.AWSConfig.SSORegion
+
+// 		secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
+// 		cachedToken := secureSSOTokenStorage.GetValidSSOToken(ssoTokenKey)
+// 		var accessToken *string
+
+// 		if cachedToken == nil {
+// 			newSSOToken, err := SSODeviceCodeFlowFromStartUrl(ctx, *cfg, rootProfile.AWSConfig.SSOStartURL)
+// 			if err != nil {
+// 				return aws.Credentials{}, err
+// 			}
+
+// 			secureSSOTokenStorage.StoreSSOToken(ssoTokenKey, *newSSOToken)
+// 			accessToken = &newSSOToken.AccessToken
+// 		} else {
+// 			accessToken = &cachedToken.AccessToken
+// 		}
+// 		return nil
+// 	},
+// }
+
 func getCFProfileSource(c *cli.Context, region, startURL string) (profilesource.Source, error) {
 	kr, err := securestorage.NewCF().Storage.Keyring()
 	if err != nil {


### PR DESCRIPTION
Add bool config opt to specify if credential process is context. Returns error when no sso token is found in the cache when attempting to get creds


