### PR TITLE
add support for Safari on OSX

### DIFF
--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -9,12 +9,13 @@ import (
 // A browser supported by Granted.
 const (
 	ChromeKey        string = "CHROME"
-	FirefoxKey       string = "FIREFOX"
-	FirefoxStdoutKey string = "FIREFOX_STDOUT"
-	EdgeKey          string = "EDGE"
 	BraveKey         string = "BRAVE"
-	StdoutKey        string = "STDOUT"
+	EdgeKey          string = "EDGE"
+	FirefoxKey       string = "FIREFOX"
 	ChromiumKey      string = "CHROMIUM"
+	SafariKey        string = "SAFARI"
+	StdoutKey        string = "STDOUT"
+	FirefoxStdoutKey string = "FIREFOX_STDOUT"
 )
 
 // A few default paths to check for the browser
@@ -37,6 +38,8 @@ var FirefoxPathWindows = []string{`\Program Files\Mozilla Firefox\firefox.exe`}
 var ChromiumPathMac = []string{"/Applications/Chromium.app/Contents/MacOS/Chromium"}
 var ChromiumPathLinux = []string{`/usr/bin/chromium`, `/../../mnt/c/Program Files/Chromium/chromium.exe`}
 var ChromiumPathWindows = []string{`\Program Files\Chromium\chromium.exe`}
+
+var SafariPathMac = []string{"/Applications/Safari.app/Contents/MacOS/Safari"}
 
 func ChromePathDefaults() ([]string, error) {
 	//check linuxpath for binary install
@@ -129,6 +132,15 @@ func ChromiumPathDefaults() ([]string, error) {
 		return ChromiumPathMac, nil
 	case "linux":
 		return ChromiumPathLinux, nil
+	default:
+		return nil, errors.New("os not supported")
+	}
+}
+
+func SafariPathDefaults() ([]string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return SafariPathMac, nil
 	default:
 		return nil, errors.New("os not supported")
 	}

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -144,7 +144,6 @@ func DetectInstallation(browserKey string) (string, bool) {
 	default:
 		return "", false
 	}
-	clio.Infof("err: %s", browserKey)
 	if len(bPath) == 0 {
 		return "", false
 	}

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -50,7 +50,7 @@ func HandleManualBrowserSelection() (string, error) {
 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 	in := survey.Select{
 		Message: "Select one of the browsers from the list",
-		Options: []string{"Chrome", "Brave", "Edge", "Firefox", "Chromium", "Stdout", "FirefoxStdout"},
+		Options: []string{"Chrome", "Brave", "Edge", "Firefox", "Chromium", "Safari", "Stdout", "FirefoxStdout"},
 	}
 	var selection string
 	clio.NewLine()
@@ -103,21 +103,23 @@ func GetBrowserKey(b string) string {
 	if strings.Contains(strings.ToLower(b), "chrome") {
 		return ChromeKey
 	}
-
-	if strings.Contains(strings.ToLower(b), "chromium") {
-		return ChromiumKey
-	}
 	if strings.Contains(strings.ToLower(b), "brave") {
 		return BraveKey
 	}
 	if strings.Contains(strings.ToLower(b), "edge") {
 		return EdgeKey
 	}
-	if strings.Contains(strings.ToLower(b), "firefoxstdout") {
-		return FirefoxStdoutKey
-	}
 	if strings.Contains(strings.ToLower(b), "firefox") || strings.Contains(strings.ToLower(b), "mozilla") {
 		return FirefoxKey
+	}
+	if strings.Contains(strings.ToLower(b), "chromium") {
+		return ChromiumKey
+	}
+	if strings.Contains(strings.ToLower(b), "safari") {
+		return SafariKey
+	}
+	if strings.Contains(strings.ToLower(b), "firefoxstdout") {
+		return FirefoxStdoutKey
 	}
 	return StdoutKey
 }
@@ -137,9 +139,12 @@ func DetectInstallation(browserKey string) (string, bool) {
 		bPath, _ = FirefoxPathDefaults()
 	case ChromiumKey:
 		bPath, _ = ChromiumPathDefaults()
+	case SafariKey:
+		bPath, _ = SafariPathDefaults()
 	default:
 		return "", false
 	}
+	clio.Infof("err: %s", browserKey)
 	if len(bPath) == 0 {
 		return "", false
 	}

--- a/pkg/launcher/chrome_profile.go
+++ b/pkg/launcher/chrome_profile.go
@@ -33,3 +33,5 @@ func chromeProfileName(profile string) string {
 	hash := fmt.Sprint(h.Sum32())
 	return hash
 }
+
+func (l ChromeProfile) UseForkProcess() bool { return true }

--- a/pkg/launcher/firefox.go
+++ b/pkg/launcher/firefox.go
@@ -12,3 +12,5 @@ func (l Firefox) LaunchCommand(url string, profile string) []string {
 		url,
 	}
 }
+
+func (l Firefox) UseForkProcess() bool { return true }

--- a/pkg/launcher/open.go
+++ b/pkg/launcher/open.go
@@ -11,3 +11,5 @@ func (l Open) LaunchCommand(url string, profile string) []string {
 	cmd := browser.OpenCommand()
 	return []string{cmd, url}
 }
+
+func (l Open) UseForkProcess() bool { return false }

--- a/pkg/launcher/safari.go
+++ b/pkg/launcher/safari.go
@@ -1,0 +1,13 @@
+package launcher
+
+import "github.com/common-fate/granted/pkg/browser"
+
+// Open calls the 'open' command to open a URL.
+// This is the same command as when you run 'open https://commonfate.io'
+// in your own terminal.
+type Safari struct{}
+
+func (l Safari) LaunchCommand(url string, profile string) []string {
+	cmd := browser.OpenCommand()
+	return []string{cmd, "-a", "Safari", url}
+}

--- a/pkg/launcher/safari.go
+++ b/pkg/launcher/safari.go
@@ -11,3 +11,5 @@ func (l Safari) LaunchCommand(url string, profile string) []string {
 	cmd := browser.OpenCommand()
 	return []string{cmd, "-a", "Safari", url}
 }
+
+func (l Safari) UseForkProcess() bool { return false }

--- a/pkg/launcher/safari.go
+++ b/pkg/launcher/safari.go
@@ -3,7 +3,7 @@ package launcher
 import "github.com/common-fate/granted/pkg/browser"
 
 // Open calls the 'open' command to open a URL.
-// This is the same command as when you run 'open https://commonfate.io'
+// This is the same command as when you run 'open -a Safari https://commonfate.io'
 // in your own terminal.
 type Safari struct{}
 


### PR DESCRIPTION
## Describe your changes

I extended if cases and switch statements to support Safari browser on OSX. I have also added the browser path and explicitly removed support for other OSes if Safari is chosen.

Not strictly related to this feature: I have also made sure that the browser order in different if cases is the same. I think this helps with readability a bit.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Issue and Documentation

<!-- Please link the appropriate Linear/GitHub issues as well as any supporting documentation or video explainers. Also include a link to the documentation PR if relevant. -->

https://github.com/common-fate/granted/issues/247

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.

1. make cli
2. run dassume
3. configure it to use Safari
4. run dassume again and assume some role of yours
5. dassume should open Safari browser window with the AWS console login page.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
