### PR TITLE
CF-716: support for ~/.aws/sso/cache

### DIFF
--- a/pkg/cfaws/ssotoken.go
+++ b/pkg/cfaws/ssotoken.go
@@ -119,7 +119,7 @@ func SsoCredsAreInConfigCache() bool {
 	return true
 }
 
-func ReadCreds() (SSOPlainTextOut, error) {
+func ReadPlaintextSsoCreds(startUrl string) (SSOPlainTextOut, error) {
 
 	/**
 
@@ -173,7 +173,10 @@ func ReadCreds() (SSOPlainTextOut, error) {
 				if err != nil {
 					return SSOPlainTextOut{}, err
 				}
-				return sso, nil
+				// check if the startUrl matches
+				if sso.StartUrl == startUrl {
+					return sso, nil
+				}
 			}
 		}
 	}

--- a/pkg/cfaws/ssotoken.go
+++ b/pkg/cfaws/ssotoken.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -156,7 +156,7 @@ func ReadCreds() (SSOPlainTextOut, error) {
 				return SSOPlainTextOut{}, err
 			}
 			// read the file
-			data, err := ioutil.ReadAll(f)
+			data, err := io.ReadAll(f)
 			if err != nil {
 				return SSOPlainTextOut{}, err
 			}

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -253,7 +253,7 @@ func (s AWSSSOSource) GetProfiles(ctx context.Context) ([]awsconfigfile.SSOProfi
 	if ssoToken == nil {
 		// if there is no valid token in the cache, check in ~/.aws/sso/cahe
 		if cfaws.SsoCredsAreInConfigCache() {
-			creds, err := cfaws.ReadCreds()
+			creds, err := cfaws.ReadPlaintextSsoCreds(s.StartURL)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -277,7 +277,7 @@ func (s AWSSSOSource) GetProfiles(ctx context.Context) ([]awsconfigfile.SSOProfi
 
 	ssoClient := sso.NewFromConfig(*cfg)
 
-	// if the token is nill fetch it from config instead
+	// if the token is nil fetch it from config instead
 	var ssoProfiles []awsconfigfile.SSOProfile
 	listAccountsNextToken := ""
 	for {


### PR DESCRIPTION
## Describe your changes

**Problem**

Granted doesn’t yet have coverage of `sso/cache` 

```diff
~/.aws/sso/cache
+└── a092ca4eExample27b5add8ec31d9b.json
```

When running `aws sso login` credentials are stored in plain text here

This means that when running subsequent queries to `assume` the default behaviour will require you to re-authenticate (poor UX), rather than read from here

****Important distinction:**** `~/.aws/sso/cache` is different from `~/.aws/config` and `~/.aws/credentials`

Therefore we must add suport reading creds from `~/.aws/sso/cache`

****************Implementation Problem**************** 

This is fine for just one aws profile, but this may complicate things if a (power) user is logged in to more than one SSO session at once. IMO, this can be added in a subsequent PR. We’ll have to do a multi-lookup and specify an id

```diff
~/.aws/sso/cache
└── a092ca4eExample27b5add8ec31d9b.json
+└── anotherRandomStringSetOfCreds.json
+└── anotherRandomStringSetOfCreds.json
+└── anotherRandomStringSetOfCreds.json
```


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Issue and Documentation

<!-- Please link the appropriate Linear/GitHub issues as well as any supporting documentation or video explainers. Also include a link to the documentation PR if relevant. -->

https://linear.app/common-fate/issue/CF-716/granted-sso-generatepopulate-commands-should-fall-back-to-plaintext

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.

### remove tokens
granted sso-tokens clear

### now log in 
aws sso login --profile AWSAdministratorAccess-902101723122

### this adds an additional entry to ~/.aws/sso/cache
```diff
~/.aws/sso/cache
+└── a092ca4eExample27b5add8ec31d9b.json
```

### now try gen with the roles
```
go run ./cmd/granted/main.go sso generate --sso-region ap-southeast-2 [url]
```

### you should not be prompted for login again

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
