### PR TITLE
fix panic due to error printing

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -397,7 +397,7 @@ func AssumeCommand(c *cli.Context) error {
 		}
 
 		if startErr != nil {
-			return clierr.New(fmt.Sprintf("Granted was unable to open a browser session automatically due to the following error: %s", err.Error()),
+			return clierr.New(fmt.Sprintf("Granted was unable to open a browser session automatically due to the following error: %s", startErr.Error()),
 				// allow them to try open the url manually
 				clierr.Info("You can open the browser session manually using the following url:"),
 				clierr.Info(consoleURL),


### PR DESCRIPTION
Fixes a panic due to `err.Error()` being called on the wrong error type