### PR TITLE
use destination profile name when interpolating profile variable

### DIFF
--- a/pkg/granted/registry/sections.go
+++ b/pkg/granted/registry/sections.go
@@ -302,13 +302,14 @@ func generateNewRegistrySection(r *Registry, configFile *ini.File, clonedFile *i
 	return nil
 }
 
+// copy section content from source profile to destination profile.
 func copySectionContent(r *Registry, s *ini.Section, d *ini.Section) error {
 	for _, key := range s.KeyStrings() {
 		value := s.Key(key).Value()
 
 		// check if the value contains go-template
 		if containsTemplate(value) {
-			output, err := interpolateVariables(r, value, strings.TrimPrefix(s.Name(), "profile "))
+			output, err := interpolateVariables(r, value, strings.TrimPrefix(d.Name(), "profile "))
 			if err != nil {
 				return err
 			}

--- a/pkg/granted/registry/sections.go
+++ b/pkg/granted/registry/sections.go
@@ -303,24 +303,24 @@ func generateNewRegistrySection(r *Registry, configFile *ini.File, clonedFile *i
 }
 
 // copy section content from source profile to destination profile.
-func copySectionContent(r *Registry, s *ini.Section, d *ini.Section) error {
-	for _, key := range s.KeyStrings() {
-		value := s.Key(key).Value()
+func copySectionContent(r *Registry, src *ini.Section, dest *ini.Section) error {
+	for _, key := range src.KeyStrings() {
+		value := src.Key(key).Value()
 
 		// check if the value contains go-template
 		if containsTemplate(value) {
-			output, err := interpolateVariables(r, value, strings.TrimPrefix(d.Name(), "profile "))
+			output, err := interpolateVariables(r, value, strings.TrimPrefix(dest.Name(), "profile "))
 			if err != nil {
 				return err
 			}
 
-			_, err = d.NewKey(key, output)
+			_, err = dest.NewKey(key, output)
 			if err != nil {
 				return err
 			}
 
 		} else {
-			_, err := d.NewKey(key, s.Key(key).Value())
+			_, err := dest.NewKey(key, src.Key(key).Value())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Describe your changes
As mentioned in this issue #382, when interpolating we need to use destination profile name so that it contains prefixed profile name. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
