### PR TITLE
remove command echo from shell scripts

### DIFF
--- a/scripts/assume
+++ b/scripts/assume
@@ -98,46 +98,6 @@ if [ "$GRANTED_FLAG" = "GrantedAssume" ]; then
   if [ ! "${GRANTED_11}" = "None" ]; then
     export GRANTED_SSO_ACCOUNT_ID="${GRANTED_11}"
   fi
-
-  for GRANTED_var in "$@"
-  do
-    if [[ "$GRANTED_var" == "-s"* ]]; then
-      if [ ! "${GRANTED_1}" = "None" ]; then
-        echo export AWS_ACCESS_KEY_ID="${GRANTED_1}"
-      fi
-      if [ ! "${GRANTED_2}" = "None" ]; then
-        echo export AWS_SECRET_ACCESS_KEY="${GRANTED_2}"
-      fi
-      if [ ! "${GRANTED_3}" = "None" ]; then
-        echo export AWS_SESSION_TOKEN="${GRANTED_3}"
-      fi
-      if [ ! "${GRANTED_4}" = "None" ]; then
-        echo export AWS_PROFILE="${GRANTED_4}"
-      fi
-      if [ ! "${GRANTED_5}" = "None" ]; then
-        echo export AWS_REGION="${GRANTED_5}"
-      fi
-       if [ ! "${GRANTED_6}" = "None" ]; then
-        echo export AWS_SESSION_EXPIRATION="${GRANTED_6}"
-        echo export AWS_CREDENTIAL_EXPIRATION="${GRANTED_6}"
-      fi
-      if [ ! "${GRANTED_7}" = "None" ]; then
-        echo export GRANTED_SSO="${GRANTED_7}"
-      fi
-      if [ ! "${GRANTED_8}" = "None" ]; then
-        echo export GRANTED_SSO_START_URL="${GRANTED_8}"
-      fi
-      if [ ! "${GRANTED_9}" = "None" ]; then
-        echo export GRANTED_SSO_ROLE_NAME="${GRANTED_9}"
-      fi      
-      if [ ! "${GRANTED_10}" = "None" ]; then
-        echo export GRANTED_SSO_REGION="${GRANTED_10}"
-      fi      
-      if [ ! "${GRANTED_11}" = "None" ]; then
-        echo export GRANTED_SSO_ACCOUNT_ID="${GRANTED_11}"
-      fi      
-    fi
-  done
 fi
 
 # Mark: Automatically re-assume when credentials expire.

--- a/scripts/assume.fish
+++ b/scripts/assume.fish
@@ -80,28 +80,6 @@ else if test "$GRANTED_FLAG" = "GrantedAssume"
     set -gx GRANTED_SSO_ACCOUNT_ID $GRANTED_11
   end
 
-  if contains -- -s $argv
-    if test "$GRANTED_1" != "None"
-      echo set -gx AWS_ACCESS_KEY_ID $GRANTED_1
-    end
-    if test "$GRANTED_2" != "None"
-      echo set -gx AWS_SECRET_ACCESS_KEY $GRANTED_2
-    end
-    if test "$GRANTED_3" != "None"
-      echo set -gx AWS_SESSION_TOKEN $GRANTED_3
-    end
-    if test "$GRANTED_4" != "None"
-      echo set -gx AWS_PROFILE $GRANTED_4
-    end
-    if test "$GRANTED_5" != "None"
-      echo set -gx AWS_REGION $GRANTED_5
-    end
-    if test "$GRANTED_6" != "None"
-      echo set -gx AWS_SESSION_EXPIRATION $GRANTED_6
-      echo set -gx AWS_CREDENTIAL_EXPIRATION $GRANTED_6
-    end
-  end
-
 else if test "$GRANTED_FLAG" = "GrantedOutput"
   for line in $GRANTED_OUTPUT
       if test "$line" != "GrantedOutput"


### PR DESCRIPTION
## Describe your changes
- fixes an issue where `assume -s rds -t` would cause the shell script to echo the credentials to the terminal.
- This was because the shell script had a mechanism in bash and fish to echo when the -s flag was used.
- This feature is not required for our cli and so I have removed it for simplicity

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Issue and Documentation

-

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.

1. run `assume -s rds -t` and assert that your session credentials are available in teh terminal, that the browser opens and that the credentials are not printed to the terminal

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [x] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
