### PR TITLE
Add disableusagetips setting and update mechanism

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -301,7 +301,7 @@ func AssumeCommand(c *cli.Context) error {
 	getConsoleURL := !assumeFlags.Bool("env") && (assumeFlags.Bool("console") || assumeFlags.Bool("active-role") || assumeFlags.String("service") != "" || assumeFlags.Bool("url"))
 
 	// this makes it easy for users to copy the actual command and avoid needing to lookup profiles
-	if showRerunCommand {
+	if !cfg.DisableUsageTips && showRerunCommand {
 		clio.Infof("To assume this profile again later without needing to select it, run this command:\n> assume %s %s", profile.Name, strings.Join(os.Args[1:], " "))
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,9 @@ type Config struct {
 	// denying access to assume a particular role.
 	AccessRequestURL string `toml:",omitempty"`
 
+	// Set this to true to disable usage tips like `To assume this profile again later without needing to select it, run this command:`
+	DisableUsageTips bool `toml:",omitempty"`
+
 	// deprecated in favor of ProfileRegistry
 	ProfileRegistryURLS []string `toml:",omitempty"`
 	ProfileRegistry     struct {

--- a/pkg/granted/settings/set.go
+++ b/pkg/granted/settings/set.go
@@ -1,0 +1,134 @@
+package settings
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/common-fate/clio"
+	"github.com/common-fate/granted/pkg/config"
+	"github.com/urfave/cli/v2"
+)
+
+var SetConfigCommand = cli.Command{
+	Name:  "set",
+	Usage: "Set a value in settings",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "setting", Aliases: []string{"s"}, Usage: "The name of a configuration setting, currently only string, int and bool types are supported. e.g 'DisableUsageTips'. For other configuration, set the value using builtin commands or by directly modifying the config file for advanced use cases."},
+		&cli.StringFlag{Name: "string-value"},
+		&cli.BoolFlag{Name: "bool-value"},
+		&cli.IntFlag{Name: "int-value"},
+	},
+	Action: func(c *cli.Context) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		// Get the type and value of the Config struct
+		configType := reflect.TypeOf(*cfg)
+		configValue := reflect.ValueOf(cfg).Elem()
+		type field struct {
+			ftype  reflect.StructField
+			fvalue reflect.Value
+		}
+		var fields []string
+		var fieldMap = make(map[string]field)
+		// Iterate over the fields of the Config struct
+		for i := 0; i < configType.NumField(); i++ {
+			fieldType := configType.Field(i)
+			kind := fieldType.Type.Kind()
+			if kind == reflect.Bool || kind == reflect.String || kind == reflect.Int {
+				fieldValue := configValue.Field(i)
+				fields = append(fields, fieldType.Name)
+				fieldMap[fieldType.Name] = field{
+					fvalue: fieldValue,
+					ftype:  fieldType,
+				}
+			}
+		}
+
+		var selectedFieldName = c.String("setting")
+		if selectedFieldName == "" {
+			p := &survey.Select{
+				Message: "Select the configuration to change",
+				Options: fields,
+			}
+			err = survey.AskOne(p, &selectedFieldName)
+			if err != nil {
+				return err
+			}
+		}
+
+		var selectedField field
+		var ok bool
+		selectedField, ok = fieldMap[selectedFieldName]
+		if !ok {
+			return fmt.Errorf("the selected field %s is not a valid config parameter", selectedFieldName)
+		}
+		// Prompt the user to update the field
+		var value interface{}
+		var prompt survey.Prompt
+		switch selectedField.ftype.Type.Kind() {
+		case reflect.Bool:
+			if c.Count("bool-value") == 0 {
+				prompt = &survey.Confirm{
+					Message: fmt.Sprintf("Enter new value for %s:", selectedFieldName),
+					Default: selectedField.fvalue.Bool(),
+				}
+				err = survey.AskOne(prompt, &value)
+				if err != nil {
+					return err
+				}
+			} else {
+				value = c.Bool("bool-value")
+			}
+
+		case reflect.String:
+			if c.Count("string-value") == 0 {
+				var str string
+				prompt = &survey.Input{
+					Message: fmt.Sprintf("Enter new value for %s:", selectedFieldName),
+					Default: fmt.Sprintf("%v", selectedField.fvalue.Interface()),
+				}
+				err = survey.AskOne(prompt, &str)
+				if err != nil {
+					return err
+				}
+				value = str
+			} else {
+				value = c.String("string-value")
+			}
+		case reflect.Int:
+			if c.Count("int-value") == 0 {
+				prompt = &survey.Input{
+					Message: fmt.Sprintf("Enter new value for %s:", selectedFieldName),
+					Default: fmt.Sprintf("%v", selectedField.fvalue.Interface()),
+				}
+				err = survey.AskOne(prompt, &value)
+				if err != nil {
+					return err
+				}
+			} else {
+				value = c.Int("int-value")
+			}
+		}
+
+		// Set the new value for the field
+		newValue := reflect.ValueOf(value)
+		if newValue.Type().ConvertibleTo(selectedField.ftype.Type) {
+			selectedField.fvalue.Set(newValue.Convert(selectedField.ftype.Type))
+		} else {
+			return fmt.Errorf("invalid type for %s", selectedField.ftype.Name)
+		}
+
+		clio.Infof("Updating the value of %s to %v", selectedFieldName, value)
+		err = cfg.Save()
+		if err != nil {
+			return err
+		}
+		clio.Success("Config updated successfully")
+		// Call the Save method to save the updated struct
+		return nil
+	},
+}

--- a/pkg/granted/settings/set.go
+++ b/pkg/granted/settings/set.go
@@ -15,9 +15,9 @@ var SetConfigCommand = cli.Command{
 	Usage: "Set a value in settings",
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "setting", Aliases: []string{"s"}, Usage: "The name of a configuration setting, currently only string, int and bool types are supported. e.g 'DisableUsageTips'. For other configuration, set the value using builtin commands or by directly modifying the config file for advanced use cases."},
-		&cli.StringFlag{Name: "string-value"},
-		&cli.BoolFlag{Name: "bool-value"},
-		&cli.IntFlag{Name: "int-value"},
+		&cli.StringFlag{Name: "value-string", Aliases: []string{"vs"}},
+		&cli.BoolFlag{Name: "value-bool", Aliases: []string{"vb"}},
+		&cli.IntFlag{Name: "valie-int", Aliases: []string{"vi"}},
 	},
 	Action: func(c *cli.Context) error {
 		cfg, err := config.Load()
@@ -71,7 +71,7 @@ var SetConfigCommand = cli.Command{
 		var prompt survey.Prompt
 		switch selectedField.ftype.Type.Kind() {
 		case reflect.Bool:
-			if c.Count("bool-value") == 0 {
+			if c.Count("value-bool") == 0 {
 				prompt = &survey.Confirm{
 					Message: fmt.Sprintf("Enter new value for %s:", selectedFieldName),
 					Default: selectedField.fvalue.Bool(),
@@ -81,11 +81,11 @@ var SetConfigCommand = cli.Command{
 					return err
 				}
 			} else {
-				value = c.Bool("bool-value")
+				value = c.Bool("value-bool")
 			}
 
 		case reflect.String:
-			if c.Count("string-value") == 0 {
+			if c.Count("value-string") == 0 {
 				var str string
 				prompt = &survey.Input{
 					Message: fmt.Sprintf("Enter new value for %s:", selectedFieldName),
@@ -97,10 +97,10 @@ var SetConfigCommand = cli.Command{
 				}
 				value = str
 			} else {
-				value = c.String("string-value")
+				value = c.String("value-string")
 			}
 		case reflect.Int:
-			if c.Count("int-value") == 0 {
+			if c.Count("valie-int") == 0 {
 				prompt = &survey.Input{
 					Message: fmt.Sprintf("Enter new value for %s:", selectedFieldName),
 					Default: fmt.Sprintf("%v", selectedField.fvalue.Interface()),
@@ -110,7 +110,7 @@ var SetConfigCommand = cli.Command{
 					return err
 				}
 			} else {
-				value = c.Int("int-value")
+				value = c.Int("valie-int")
 			}
 		}
 

--- a/pkg/granted/settings/settings.go
+++ b/pkg/granted/settings/settings.go
@@ -9,6 +9,6 @@ import (
 var SettingsCommand = cli.Command{
 	Name:        "settings",
 	Usage:       "Manage Granted settings",
-	Subcommands: []*cli.Command{&PrintCommand, &ProfileOrderingCommand, &ExportSettingsCommand, &requesturl.Commands},
+	Subcommands: []*cli.Command{&PrintCommand, &ProfileOrderingCommand, &ExportSettingsCommand, &requesturl.Commands, &SetConfigCommand},
 	Action:      PrintCommand.Action,
 }


### PR DESCRIPTION
## Describe your changes

- In response to user feedback, experienced users would like to be able to disable the usage tips presented when using assume.
- As a catch all, I have implemented a config flag which can be set to disable these tips from showing
- I have only disabled the tip that shows when you don't supply a profile name during assume, more can be added as requested.
- In order to make this and other simple config easy to update, I have added a generic `granted settings set` command which can set the value for string, int and bool config fields
- This way we can share with users a one liner to disable the tips `granted settings set -s DisableUsageTips -vb` will configure their installation to not show the tip.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Issue and Documentation

-

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.
1. `make cli`
1. try running `dgranted settings set -s DisableUsageTips -vb` followed by `assume` do not supply a profile name, expect not to see a usage tip.
2. try running `dgranted settings set -s DisableUsageTips -vb false`  followed by `assume` do not supply a profile name, expect to see the prompt with the tip on usage.

3. run  `dgranted settings set` and see that you can update other settings
## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
