### PR TITLE
Implement credential cache in keychain for credential_process

### DIFF
--- a/pkg/securestorage/session_credential_storage.go
+++ b/pkg/securestorage/session_credential_storage.go
@@ -1,0 +1,33 @@
+package securestorage
+
+import (
+	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+type SessionCredentialSecureStorage struct {
+	SecureStorage SecureStorage
+}
+
+func NewSecureSessionCredentialStorage() SessionCredentialSecureStorage {
+	return SessionCredentialSecureStorage{
+		SecureStorage: SecureStorage{
+			StorageSuffix: "aws-session-credentials",
+		},
+	}
+}
+
+func (i *SessionCredentialSecureStorage) GetCredentials(profile string) (credentials aws.Credentials, ok bool, err error) {
+	err = i.SecureStorage.Retrieve(profile, &credentials)
+	if err == keyring.ErrKeyNotFound {
+		err = nil
+	} else if err == nil {
+		ok = true
+	}
+	return
+}
+
+func (i *SessionCredentialSecureStorage) StoreCredentials(profile string, credentials aws.Credentials) (err error) {
+	err = i.SecureStorage.Store(profile, &credentials)
+	return
+}


### PR DESCRIPTION
## Describe your changes
Implements a keychain backed cache for session credentials when using `credential_process` to invoke granted so `GetRoleCredentials` is not invoked every time. More details in issue #395.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issue and Documentation
#395 

## Testing

Please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment.

1. Configure granted as a [credential_process](https://docs.commonfate.io/granted/recipes/credential-process) in your `~/.aws/config`
2. Invoke `granted credential-process --profile demo | jq -r .Expiration`
3. Invoke the command again, observe the same token/expiration is returned
4. Invoke the command again adding `--window 24h` which demonstrates that the cache will be replaced when expiration - window is reached.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Do analytics need to be implemented?
- [ ] I have made corresponding changes to the documentation, docs PR has been linked.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
