### PR TITLE
Reintroduce fallback support for any POSIX-compatible shell

### DIFF
--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -30,9 +30,9 @@ func init() {
 }
 
 const fishAlias = `alias assume="source /usr/local/bin/assume.fish"`
-const defaultAlias = `alias assume="source assume"`
+const defaultAlias = `alias assume=". assume"`
 const devFishAlias = `alias dassume="source /usr/local/bin/dassume.fish"`
-const devDefaultAlias = `alias dassume="source dassume"`
+const devDefaultAlias = `alias dassume=". dassume"`
 
 func GetDefaultAlias() string {
 	if build.IsDev() {
@@ -77,7 +77,9 @@ func GetShellFromShellEnv(shellEnv string) (string, error) {
 
 	} else if strings.Contains(shellEnv, "zsh") {
 		return "zsh", nil
-
+	} else if strings.Contains(shellEnv, "sh") {
+		// Fallback to POSIX
+		return "posix", nil
 	} else {
 		return "", fmt.Errorf("we couldn't detect your shell type (%s). Please follow the steps at https://docs.commonfate.io/granted/internals/shell-alias to assume roles with Granted", shellEnv)
 	}
@@ -96,6 +98,8 @@ func GetShellAlias(shell string) (Config, error) {
 		file, err = shells.GetBashConfigFile()
 	case "zsh":
 		file, err = shells.GetZshConfigFile()
+	case "posix":
+		file, err = shells.GetPosixConfigFile()
 	default:
 		err = &ErrShellNotSupported{Shell: shell}
 	}

--- a/pkg/shells/find_config.go
+++ b/pkg/shells/find_config.go
@@ -1,9 +1,35 @@
 package shells
 
 import (
+	"fmt"
 	"os"
 	"path"
+	"path/filepath"
+	"strings"
 )
+
+func GetPosixConfigFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	file := os.Getenv("ENV")
+	if file == "" {
+		return "", fmt.Errorf("cannot determine a shell config file. Please specify one using the ENV variable")
+	}
+	if strings.HasPrefix(file, "~") {
+		file = filepath.Join(home, file[1:])
+	}
+	// check that the file exists; create it if not
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		f, err := os.Create(file)
+		if err != nil {
+			return "", err
+		}
+		defer f.Close()
+	}
+	return file, nil
+}
 
 func GetFishConfigFile() (string, error) {
 	home, err := os.UserHomeDir()

--- a/scripts/assume
+++ b/scripts/assume
@@ -1,10 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
 #GRANTED_FLAG - what assumego told the shell to do
 #GRANTED_n - the data from assumego
 
 # pass an environment variable to the Go binary if the Granted alias hasn't been configured
-if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+_this_type=$(type -- "$0")
+if [ "${_this_type#*alias}" = "$_this_type" ]; then
+  # The word 'alias' was not found in the type definition
   GRANTED_RETURN_STATUS="true"
   export GRANTED_ALIAS_CONFIGURED="true"
 fi
@@ -15,13 +17,15 @@ GRANTED_OUTPUT=$(assumego "$@")
 
 GRANTED_STATUS=$?
 # shellcheck disable=SC2162
-IFS=' ' read GRANTED_FLAG GRANTED_1 GRANTED_2 GRANTED_3 GRANTED_4 GRANTED_5 GRANTED_6 GRANTED_7 GRANTED_8 GRANTED_9 GRANTED_10 GRANTED_11<<< "${GRANTED_OUTPUT}"
+IFS=' ' read GRANTED_FLAG GRANTED_1 GRANTED_2 GRANTED_3 GRANTED_4 GRANTED_5 GRANTED_6 GRANTED_7 GRANTED_8 GRANTED_9 GRANTED_10 GRANTED_11 << EOF
+${GRANTED_OUTPUT}
+EOF
 
 # # unset the exported GRANTED_ALIAS_CONFIGURED flag
 unset GRANTED_ALIAS_CONFIGURED
 
 # remove carraige return
-GRANTED_FLAG=$(echo "$GRANTED_FLAG" | tr -d '\r')
+GRANTED_FLAG=$(printf '%s\n' "$GRANTED_FLAG" | tr -d '\r')
 
 if [ "$GRANTED_FLAG" = "GrantedDesume" ]; then
   unset AWS_ACCESS_KEY_ID
@@ -59,8 +63,8 @@ if [ "$GRANTED_FLAG" = "GrantedAssume" ]; then
   # shellcheck disable=SC2124
   export GRANTED_COMMAND="$@"
 
-  export GRANTED_SSO=${GRANTED_7}
-  
+  export GRANTED_SSO="${GRANTED_7}"
+
   if [ ! "${GRANTED_1}" = "None" ]; then
     export AWS_ACCESS_KEY_ID="${GRANTED_1}"
   fi
@@ -102,35 +106,36 @@ fi
 
 # Mark: Automatically re-assume when credentials expire.
 _is_assume_expired() {
-  if [[ -z "${AWS_PROFILE}" ]]; then return 1; fi
+  [ -z "${AWS_PROFILE}" ] && return 1
 
   # Note: this must remain compatible with both BSD and GNU date.
   # TODO: This should probably run a few minutes (configurable) before it expires.
-  local current_time expiry
+  # shellcheck disable=SC2034,SC3043 # Only used by zsh
+  local curent_time expiry
   current_time="$(date -Iseconds)"
   expiry="$AWS_SESSION_EXPIRATION"
+  # shellcheck disable=SC3010,SC3054 # Only used by zsh
   [[ "${current_time}" > "${expiry}" ]]
 }
 
 granted_auto_reassume() {
   # Nothing to do, we can't reassume a profile that we don't know.
-  if [[ -z "${AWS_PROFILE}" ]]; then return 0; fi
+  [ -z "${AWS_PROFILE}" ] && return 0
 
-  if ! _is_assume_expired; then return 0; fi
+  _is_assume_expired || return 0
 
-  if [[ "${GRANTED_QUIET}" != "true" ]]
-  then
-    echo "granted session expired; reassuming ${AWS_PROFILE}." >&2
-  fi
+  [ "${GRANTED_QUIET}" = "true" ] ||
+    printf 'granted session expired; reassuming %s\n.' "${AWS_PROFILE}" >&2
   assume "${AWS_PROFILE}"
 }
 
-if [[ -n "${ZSH_NAME}" ]]
+if [ -n "${ZSH_NAME}" ]
 then
-  if [[ "${GRANTED_ENABLE_AUTO_REASSUME}" = "true" ]]
+  if [ "${GRANTED_ENABLE_AUTO_REASSUME}" = "true" ]
   then
-    # shellcheck disable=SC2154
-    if ! [[ " ${preexec_functions[*]} " =~ " granted_auto_reassume " ]]
+    # shellcheck disable=SC2154,SC3054
+    pfuncs=$(print -l -- "${preexec_functions[*]}")
+    if [ "${pfuncs#*granted_auto_reassume}" = "$pfuncs" ]
     then
       autoload -Uz add-zsh-hook
       add-zsh-hook preexec granted_auto_reassume
@@ -142,10 +147,10 @@ fi
 # The GrantedOutput flag should be followed by a newline, then the output.
 # This way, the shell script can omit the first line containing the flag and return the unaltered output to the stdout
 # This is great as it works well with the -exec flag
-if [ "$GRANTED_FLAG" = "GrantedOutput" ];then
-  echo "${GRANTED_OUTPUT}" | sed -n '1!p'
+if [ "$GRANTED_FLAG" = "GrantedOutput" ]; then
+  printf '%s\n' "${GRANTED_OUTPUT}" | sed -n '1!p'
 fi
 
 if [ "$GRANTED_RETURN_STATUS" = "true" ]; then
-  return $GRANTED_STATUS
+  exit $GRANTED_STATUS
 fi


### PR DESCRIPTION
This was originally merged to `main` in @jhuntwork's PR #389, however for some reason it caused some of our GitHub Actions tests to fail. I've reverted the PR temporarily and am introducing it again on this branch to evaluate why the tests were failing.

------------

* Add fallback support for any POSIX-compatible shell

As a last resort before erroring, try to determine a 'config' or 'profile' file to use via a POSIX-specific test.

[POSIX states regarding the ENV variable](https://pubs.opengroup.org/onlinepubs/9699919799/):

> This variable, when and only when an interactive shell is invoked, shall be
> subjected to parameter expansion (see Parameter Expansion) by the shell, and
> the resulting value shall be used as a pathname of a file containing shell
> commands to execute in the current environment. The file need not be
> executable.

## Motivation

My main shell is typically [mksh](http://www.mirbsd.org/mksh.htm). Even though it lacks many of the bells and whistles of bash and zsh, it is an adequate and comfortable interactive shell. By making all the common pieces POSIX-compliant, all the currently supported shells should continue to work and any additional shell that is POSIX-compliant should work as well.

This also requires some changes in the assume shim script. Even though some parts are zsh-specific and warnings can be ignored, the whole thing is sourced and so needs to be syntactically correct:

- Replace '<<<' with a simple heredoc.
- Replace the 'source' command with '.'
- Use parameter substitution for testing the existence of substrings
- Remove some other unnecessary bashisms
- Minor tweak, but replace uses of `echo` with `printf` since that tends to be safer and more explicit in formatting. A good summary of the difference is [here](https://www.etalabs.net/sh_tricks.html)

* change 'return' to 'exit'
