### PR TITLE
fix build errors

### DIFF
--- a/pkg/granted/tokens.go
+++ b/pkg/granted/tokens.go
@@ -210,7 +210,9 @@ var ClearSSOTokensCommand = cli.Command{
 			selection = selectionsMap[out]
 		}
 
-		err = clearToken(selection)
+		secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
+
+		err = secureSSOTokenStorage.SecureStorage.Clear(selection)
 		if err != nil {
 			return err
 		}
@@ -227,7 +229,7 @@ func clearAllTokens() error {
 		return err
 	}
 	for _, k := range keys {
-		if err := secureSSOTokenStorage.SecureStorage.Clear(key); err != nil {
+		if err := secureSSOTokenStorage.SecureStorage.Clear(k); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
### What changed?
Fixed Go build errors by replacing references to `clearTokens()` (a function that was removed in #404) with `secureSSOTokenStorage.SecureStorage.Clear()`

### Why?
To fix `main` build errors

### How did you test it?
All build errors shown as resolved in VSCode


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs