### PR TITLE
Remove trailing slashes from `granted_sso_start_url`

### DIFF
--- a/pkg/cfaws/granted_config.go
+++ b/pkg/cfaws/granted_config.go
@@ -58,11 +58,8 @@ func ParseGrantedSSOProfile(ctx context.Context, profile *Profile) (*config.Shar
 	_, err = url.ParseRequestURI(cfg.SSOStartURL)
 	
 	// normalize the url to remove trailing slashes if they exist
-    if cfg.SSOStartURL != nil {
-		cfg.SSOStartURL = strings.TrimSuffix(cfg.SSOStartURL, "/")
-	}
+	cfg.SSOStartURL = strings.TrimSuffix(cfg.SSOStartURL, "/")
 
-	if cfg.SSOStartURL != nil &&
 	if err != nil {
 		clio.Debug(err)
 		return nil, fmt.Errorf("invalid value '%s' provided for 'granted_sso_start_url'", cfg.SSOStartURL)

--- a/pkg/cfaws/granted_config.go
+++ b/pkg/cfaws/granted_config.go
@@ -56,6 +56,13 @@ func ParseGrantedSSOProfile(ctx context.Context, profile *Profile) (*config.Shar
 
 	// sanity check to verify if the provided value is a valid url
 	_, err = url.ParseRequestURI(cfg.SSOStartURL)
+	
+	// normalize the url to remove trailing slashes if they exist
+    if cfg.SSOStartURL != nil {
+		cfg.SSOStartURL = strings.TrimSuffix(cfg.SSOStartURL, "/")
+	}
+
+	if cfg.SSOStartURL != nil &&
 	if err != nil {
 		clio.Debug(err)
 		return nil, fmt.Errorf("invalid value '%s' provided for 'granted_sso_start_url'", cfg.SSOStartURL)


### PR DESCRIPTION
### What changed?
This removes trailing slashes from `granted_sso_start_url`
_Disclaimer_: I don't know `go`, I don't know whether I need nil checks, and I don't know whether this is the central placed used by `assume`

### Why?
The [keyring isn't used correctly when you have a trailing slash in your start_url](https://commonfatecommunity.slack.com/archives/C0356DGLXME/p1683305567119909)

### How did you test it?
I couldn't find instructions on how to run the tests, all I did was `make cli`  If you can point me at how and a suitable starting place, I can update `CONTRIBUTING.md` and write a test.

### Potential risks

It doesn't work and breaks everything

### Is patch release candidate?

No

### Link to relevant docs PRs

This shouldn't need a doc change.