### PR TITLE
Auto SSO region configuration

### DIFF
--- a/pkg/cfaws/granted_config.go
+++ b/pkg/cfaws/granted_config.go
@@ -56,6 +56,13 @@ func ParseGrantedSSOProfile(ctx context.Context, profile *Profile) (*config.Shar
 
 	// sanity check to verify if the provided value is a valid url
 	_, err = url.ParseRequestURI(cfg.SSOStartURL)
+	
+	// normalize the url to remove trailing slashes if they exist
+    if cfg.SSOStartURL != nil {
+		cfg.SSOStartURL = strings.TrimSuffix(cfg.SSOStartURL, "/")
+	}
+
+	if cfg.SSOStartURL != nil &&
 	if err != nil {
 		clio.Debug(err)
 		return nil, fmt.Errorf("invalid value '%s' provided for 'granted_sso_start_url'", cfg.SSOStartURL)


### PR DESCRIPTION
### What changed?
It extracts the sso region using the region meta tag in the html from the sso-start-url so the user doesn't need to enter it

### Why?
Saves a step

### How did you test it?
```
❯ dgranted sso login
? SSO Start URL https://d-92677b5a84.awsapps.com/start
[i] If the browser does not open automatically, please open this link: https://device.sso.us-west-2.amazonaws.com/?user_code=XXXX-XXXX
[i] Awaiting AWS authentication in the browser
[i] You will be prompted to authenticate with AWS in the browser, then you will be prompted to 'Allow'
[✔] Successfully logged into Start URL: https://d-92677b5a84.awsapps.com/start
```

### Potential risks

This could be only part of the places that need to be updated to auto configure the sso region.
Tests break because I don't know how to run them.


### Is patch release candidate?

No


### Link to relevant docs PRs

I could feasibly update this: https://docs.commonfate.io/granted/troubleshooting/#regions but I'm not seeing any documentation for `granted sso login`