### PR TITLE
Update completion docs link

### DIFF
--- a/pkg/granted/completion.go
+++ b/pkg/granted/completion.go
@@ -43,12 +43,12 @@ var CompletionCommand = cli.Command{
 		case "bash":
 			err = installBashCompletions(c)
 		default:
-			clio.Info("To install completions for other shells, please see our docs: https://granted.dev/autocompletion")
+			clio.Info("To install completions for other shells, please see our docs: https://docs.commonfate.io/granted/configuration#autocompletion")
 		}
 		return err
 	},
 
-	Description: "Install completions for fish, zsh, or bash. To install completions for other shells, please see our docs:\nhttps://granted.dev/autocompletion\n",
+	Description: "Install completions for fish, zsh, or bash. To install completions for other shells, please see our docs:\nhttps://docs.commonfate.io/granted/configuration#autocompletion\n",
 }
 
 func installFishCompletions(c *cli.Context) error {


### PR DESCRIPTION
Looks like the docs have moved but the link wasn't updated

### What changed?
Completion docs link

### Why?
Old link is dead

### How did you test it?
Went to the old link > 404
Went to new link > docs 🥳 

### Potential risks
🤷 

### Is patch release candidate?
I have no idea

### Link to relevant docs PRs
https://github.com/common-fate/docs/pull/1