### PR TITLE
add config option to disable cache

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,8 @@ type Config struct {
 
 	// Set this to true to disable usage tips like `To assume this profile again later without needing to select it, run this command:`
 	DisableUsageTips bool `toml:",omitempty"`
-
+	// Set this to true to disable credential caching feature when using credential process
+	DisableCredentialProcessCache bool `toml:",omitempty"`
 	// deprecated in favor of ProfileRegistry
 	ProfileRegistryURLS []string `toml:",omitempty"`
 	ProfileRegistry     struct {


### PR DESCRIPTION
additional logging outputs

### What changed?
Added `DisableCredentialProcessCache` config option to disable using the cache for credentials when using credential process

`granted settings set --s DisableCredentialProcessCache --v true` to disable the cache

### Why?
Some users reported issues with the cached credentials when Granted is used in combination with Common Fate

### How did you test it?
Manually, using all the option to test existing behaviour still works and that the disable option works as expected

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs