### PR TITLE
Add AWS "sm" service shortcut for Secrets Manager

### DIFF
--- a/pkg/browsers/console.go
+++ b/pkg/browsers/console.go
@@ -56,6 +56,7 @@ var ServiceMap = map[string]string{
 	"param":          "systems-manager/parameters",
 	"redshift":       "redshiftv2",
 	"sagemaker":      "sagemaker",
+	"sm":             "secrets-manager",
 	"ssm":            "systems-manager",
 }
 


### PR DESCRIPTION
Not to be confused with AWS Systems Manager, aka "SSM". 🙄
