### PR TITLE
fix text disappearing in some instances due to spinner

### DIFF
--- a/cmd/granted/main.go
+++ b/cmd/granted/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"runtime"
+	"syscall"
 
 	"github.com/common-fate/clio"
 	"github.com/common-fate/clio/clierr"
@@ -16,6 +20,19 @@ import (
 func main() {
 	updatecheck.Check(updatecheck.GrantedCLI, build.Version, !build.IsDev())
 	defer updatecheck.Print()
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-c
+		// restore cursor in case spinner gets stuck
+		// https://github.com/apppackio/apppack/commit/a711e55238af2402b4b027a73fccc663ec7ba0f4
+		// https://github.com/briandowns/spinner/issues/122
+		if runtime.GOOS != "windows" {
+			fmt.Fprint(os.Stdin, "\033[?25h")
+		}
+		os.Exit(130)
+	}()
 
 	// Use a single binary to keep keychain ACLs simple, swapping behavior via argv[0]
 	var app *cli.App


### PR DESCRIPTION
### What changed?
Prints the cursor unhide sequence to ensure the cursor is shown again if the user presses Control+C or the CLI closes while a spinner is active.

### Why?
Cursor was being hidden in some instances.

### How did you test it?
Manual testing - verified working without impacting other CLI functionality

### Potential risks
Control+C could stop working (I've verified this isn't the case)

### Is patch release candidate?
Yes

### Link to relevant docs PRs