### PR TITLE
remove grant overlaps error in exp request aws workflow

### DIFF
--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -97,6 +98,7 @@ func requestAccess(ctx context.Context, opts requestAccessOpts) error {
 		return errors.Wrap(err, "loading keyring")
 	}
 
+	// creates the Common Fate API client
 	cf, err := client.FromConfig(ctx, cfcfg, client.WithKeyring(k), client.WithLoginHint("granted login"))
 	if err != nil {
 		return err
@@ -355,8 +357,13 @@ func requestAccess(ctx context.Context, opts requestAccessOpts) error {
 		},
 		With: withPtr,
 	})
+
 	if err != nil {
-		return err
+		if strings.Contains(err.Error(), "this request overlaps an existing grant") {
+			clio.Warn("This request has already been approved, continuing anyway...")
+		} else {
+			return err
+		}
 	}
 
 	si.Stop()


### PR DESCRIPTION
### What changed?
Removed grant overlaps error in `granted exp request aws` workflow and show warning instead

### Why?

### How did you test it?
Ran `dgranted exp request aws` twice requesting the same account

<img width="982" alt="Screen Shot 2023-06-13 at 2 56 16 PM" src="https://github.com/common-fate/granted/assets/32020525/6d47f656-cd0a-4842-9645-f9142a4803cb">


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs
([Linear](https://linear.app/common-fate/issue/CF-1350/remove-this-request-overlaps-an-existing-grant-error-message-and-add-a))