### PR TITLE
use brew --prefix instead of hardcoded path for fish alias

### DIFF
--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -29,9 +29,9 @@ func init() {
 	_, color.NoColor = os.LookupEnv("NO_COLOR")
 }
 
-const fishAlias = `alias assume="source /usr/local/bin/assume.fish"`
+const fishAlias = `alias assume="source (brew --prefix)/assume.fish"`
 const defaultAlias = `alias assume="source assume"`
-const devFishAlias = `alias dassume="source /usr/local/bin/dassume.fish"`
+const devFishAlias = `alias dassume="source (brew --prefix)/dassume.fish"`
 const devDefaultAlias = `alias dassume="source dassume"`
 
 func GetDefaultAlias() string {


### PR DESCRIPTION
the hardcoded path doesn't work on brew installs on apple silicon (or if someone specifies an alternate location for brew)

### What changed?

Used `brew --prefix` to get root homebrew location

### Why?

as reported in #246 the alias installation doesn't work for `fish` on Apple Silicon (M1/M2) since the homebrew binaries are installed in `/opt/homebrew` rather than `/usr/local`

### How did you test it?

Manually inserted the same change in my local `config.fish` (on Apple silicon). 

### Potential risks

not e2e-tested on intel macs (but I have verified that `brew --prefix` command works identically on intel-based Brew, which I also have installed)

### Is patch release candidate?

yes, it's a small bugfix that should make things work for all people who use Fish on Apple Silicon, and be unnoticed by everyone else.


