### PR TITLE
Cleaned up error message for exp request aws

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -197,7 +197,6 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 		}
 	}
 	return credProvider.Credentials, nil
-
 }
 
 func (c *Profile) getRoleCredentialsWithRetry(ctx context.Context, ssoClient *sso.Client, accessToken *string, rootProfile *Profile) (*ssotypes.RoleCredentials, error) {
@@ -225,7 +224,7 @@ func (c *Profile) getRoleCredentialsWithRetry(ctx context.Context, ssoClient *ss
 		}
 	}
 
-	return nil, errors.Wrap(er, "max retried exceeded")
+	return nil, errors.Wrap(er, "max retries exceeded")
 }
 
 // SSODeviceCodeFlowFromStartUrl contains all the steps to complete a device code flow to retrieve an SSO token

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -491,7 +491,10 @@ func requestAccess(ctx context.Context, opts requestAccessOpts) error {
 		durationDescription := durafmt.Parse(time.Duration(requestDuration) * time.Second).LimitFirstN(1).String()
 		profile, err := cfaws.LoadProfileByAccountIdAndRole(selectedAccountID, selectedRole)
 		if err != nil {
-			clio.Errorw("error while trying to automatically detect if profile is active", "error", err)
+			// make sure to print err.Error(), rather than just err.
+			// If the argument to Errorw is an error rather than a string, zap will print the stack trace from where the error originated.
+			// This makes the log output look quite messy.
+			clio.Errorw("error while trying to automatically detect if profile is active", "error", err.Error())
 			clio.Infof("To use the profile with the AWS CLI, sync your ~/.aws/config by running 'granted sso populate'. Then, run:\nexport AWS_PROFILE=%s", fullName)
 			return nil
 		}
@@ -515,7 +518,10 @@ func requestAccess(ctx context.Context, opts requestAccessOpts) error {
 			ShouldRetryAssuming: aws.Bool(true),
 		})
 		if err != nil {
-			clio.Errorw("error while trying to automatically detect if profile is active", "error", err)
+			// make sure to print err.Error(), rather than just err.
+			// If the argument to Errorw is an error rather than a string, zap will print the stack trace from where the error originated.
+			// This makes the log output look quite messy.
+			clio.Errorw("error while trying to automatically detect if profile is active by assuming the role", "error", err.Error())
 			clio.Infof("To use the profile with the AWS CLI, sync your ~/.aws/config by running 'granted sso populate'. Then, run:\nexport AWS_PROFILE=%s", fullName)
 			return nil
 		}


### PR DESCRIPTION
### What changed?
Removed stack trace for errors when automatically detecting profile

### Why?
The message was clutter

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs