### PR TITLE
In export AWS_PROFILE output replacing spaces with - 

### DIFF
--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -486,6 +486,7 @@ func requestAccess(ctx context.Context, opts requestAccessOpts) error {
 	clio.Infof("Access Request: %s (%s)", cases.Title(language.English).String(strings.ToLower(string(latestRequest.Status))), reqURL)
 
 	fullName := fmt.Sprintf("%s/%s", selectedAccountInfo.Label, selectedRole)
+	fullName = strings.ReplaceAll(fullName, " ", "-") // Replacing spaces with "-" to make export AWS_PROFILE work properly
 
 	if latestRequest.Status == types.RequestStatusAPPROVED {
 		durationDescription := durafmt.Parse(time.Duration(requestDuration) * time.Second).LimitFirstN(1).String()


### PR DESCRIPTION
### What changed?
In export AWS_PROFILE output replacing spaces with - 

### Why?
Accounts that have a space in their name populate like `export AWS_PROFILE=Log Archive/AWSAdministratorAccess`. Adding a - to the export command to make it functional.

### How did you test it?
Dgranted

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs
[Linear](https://linear.app/common-fate/issue/CF-1753/incorrect-profile-name-used-for-aws-cli-export-command)