### PR TITLE
improve brew alias check

### DIFF
--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -29,9 +30,10 @@ func init() {
 	_, color.NoColor = os.LookupEnv("NO_COLOR")
 }
 
-const fishAlias = `alias assume="source (brew --prefix)/assume.fish"`
+const fishAlias = `alias assume="source /usr/local/bin/assume.fish"`
+const fishAliasBrew = `alias assume="source (brew --prefix)/assume.fish"`
 const defaultAlias = `alias assume="source assume"`
-const devFishAlias = `alias dassume="source (brew --prefix)/dassume.fish"`
+const devFishAlias = `alias dassume="source /usr/local/bin/dassume.fish"`
 const devDefaultAlias = `alias dassume="source dassume"`
 
 func GetDefaultAlias() string {
@@ -44,6 +46,13 @@ func GetFishAlias() string {
 	if build.IsDev() {
 		return devFishAlias
 	}
+
+	// if 'brew' exists on the path, use the brew prefix rather than /usr/local/bin when installing the alias.
+	// chrnorm: there's not really a better way to determine if we've been installed with brew or not.
+	if _, err := exec.LookPath("brew"); err == nil {
+		return fishAliasBrew
+	}
+
 	return fishAlias
 }
 


### PR DESCRIPTION
only use the brew prefix if brew is installed

### What changed?
added an extra check to see if brew is installed before installing the alias as `alias assume="source (brew --prefix)/assume.fish"`

### Why?
Smoke test fails in main branch after https://github.com/common-fate/granted/pull/437 was merged

### How did you test it?
Will verify if smoke test passes in CI

### Potential risks


### Is patch release candidate?
Yes, to be included in next release

### Link to relevant docs PRs