### PR TITLE
Add ability to overwrite default aws config paths with $AWS_CONFIG_FILE & $AWS_SHARED_CREDENTIALS_FILE env

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/common-fate/awsconfigfile"
 	"github.com/common-fate/clio"
 	"github.com/common-fate/clio/ansi"
@@ -77,7 +76,7 @@ func AssumeCommand(c *cli.Context) error {
 		// save the profile to the AWS config file if the user requested it.
 		saveProfileName := assumeFlags.String("save-to")
 		if saveProfileName != "" {
-			configFilename := awsconfig.DefaultSharedConfigFilename()
+			configFilename := cfaws.GetAWSConfigPath()
 			config, err := ini.LoadSources(ini.LoadOptions{
 				AllowNonUniqueSections:  false,
 				SkipUnrecognizableLines: false,
@@ -122,7 +121,7 @@ func AssumeCommand(c *cli.Context) error {
 		var wg sync.WaitGroup
 
 		withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
-		profiles, err := cfaws.LoadProfilesFromDefaultFiles()
+		profiles, err := cfaws.LoadProfiles()
 		if err != nil {
 			return err
 		}

--- a/pkg/assume/completion.go
+++ b/pkg/assume/completion.go
@@ -26,7 +26,7 @@ func Completion(ctx *cli.Context) {
 		cli.DefaultAppComplete(ctx)
 	} else {
 		// Ignore errors from this function. Tab completion handles graceful degradation back to listing files.
-		awsProfiles, _ := cfaws.LoadProfilesFromDefaultFiles()
+		awsProfiles, _ := cfaws.LoadProfiles()
 		// Tab completion script requires each option to be separated by a newline
 		fmt.Println(strings.Join(awsProfiles.ProfileNames, "\n"))
 	}

--- a/pkg/cfaws/cred-exporter.go
+++ b/pkg/cfaws/cred-exporter.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/common-fate/clio"
 	gconfig "github.com/common-fate/granted/pkg/config"
 	"gopkg.in/ini.v1"
@@ -13,7 +12,7 @@ import (
 // ExportCredsToProfile will write assumed credentials to ~/.aws/credentials with a specified profile name header
 func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 	// fetch the parsed cred file
-	credPath := config.DefaultSharedCredentialsFilename()
+	credPath := GetAWSCredentialsPath()
 
 	// create it if it doesn't exist
 	if _, err := os.Stat(credPath); os.IsNotExist(err) {

--- a/pkg/cfaws/granted_config_test.go
+++ b/pkg/cfaws/granted_config_test.go
@@ -77,7 +77,7 @@ sso_region     = ap-southeast-2
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := loader{fileString: tt.file}
-			profiles, err := LoadProfiles(l, nooploader{})
+			profiles, err := loadProfiles(l, nooploader{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -134,21 +134,50 @@ func (f FileLoader) Load() (*ini.File, error) {
 	}
 	return configFile, nil
 }
-func LoadProfilesFromDefaultFiles() (*Profiles, error) {
-	return LoadProfiles(FileLoader{
-		FilePath: config.DefaultSharedConfigFilename(),
+
+// GetAWSConfigPath will return default AWS config file path unless $AWS_CONFIG_FILE
+// environment variable is set
+func GetAWSConfigPath() string {
+	file := os.Getenv("AWS_CONFIG_FILE")
+	if file != "" {
+		clio.Debugf("using aws config filepath: %s", file)
+		return file
+	}
+
+	return config.DefaultSharedConfigFilename()
+}
+
+// GetAWSCredentialsPath will return default AWS shared credential file path unless $AWS_SHARED_CREDENTIALS_FILE
+// environment variable is set
+func GetAWSCredentialsPath() string {
+	file := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if file != "" {
+		clio.Debugf("using aws credential filepath: %s", file)
+		return file
+	}
+
+	return config.DefaultSharedCredentialsFilename()
+}
+
+// LoadProfiles will load aws config files from $AWS_CONFIG_FILE, $AWS_SHARED_CREDENTIALS_FILE environment variables
+// or defaults to ~/.aws/config and ~/.aws/credentials
+func LoadProfiles() (*Profiles, error) {
+	return loadProfiles(FileLoader{
+		FilePath: GetAWSConfigPath(),
 	}, FileLoader{
-		FilePath: config.DefaultSharedCredentialsFilename(),
+		FilePath: GetAWSCredentialsPath(),
 	})
 }
-func LoadProfiles(configFileLoader, credentialsFileLoader ConfigFileLoader) (*Profiles, error) {
 
+func loadProfiles(configFileLoader, credentialsFileLoader ConfigFileLoader) (*Profiles, error) {
 	p := Profiles{profiles: make(map[string]*Profile)}
-	err := p.loadDefaultConfigFile(configFileLoader)
+
+	err := p.loadConfigFile(configFileLoader)
 	if err != nil {
 		return nil, err
 	}
-	err = p.loadDefaultCredentialsFile(credentialsFileLoader)
+
+	err = p.loadCredentialsFile(credentialsFileLoader)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +188,7 @@ func LoadProfiles(configFileLoader, credentialsFileLoader ConfigFileLoader) (*Pr
 // Note, this function doesn't handle the condition when there are same accountId & role in different regions.
 func LoadProfileByAccountIdAndRole(accountId string, role string) (*Profile, error) {
 
-	profiles, err := LoadProfilesFromDefaultFiles()
+	profiles, err := LoadProfiles()
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +233,7 @@ func LoadProfileByAccountIdAndRole(accountId string, role string) (*Profile, err
 // [profile cf-prod]
 // sso_region=ap-southeast-2
 // ...
-func (p *Profiles) loadDefaultConfigFile(loader ConfigFileLoader) error {
+func (p *Profiles) loadConfigFile(loader ConfigFileLoader) error {
 
 	configFile, err := loader.Load()
 	if err != nil {
@@ -250,7 +279,7 @@ func (p *Profiles) loadDefaultConfigFile(loader ConfigFileLoader) error {
 // aws_access_key_id = xxxxxx
 // aws_secret_access_key = xxxxxx
 // ...
-func (p *Profiles) loadDefaultCredentialsFile(loader ConfigFileLoader) error {
+func (p *Profiles) loadCredentialsFile(loader ConfigFileLoader) error {
 	// fetch parsed credentials file
 	credentialsFile, err := loader.Load()
 	if err != nil {

--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -69,7 +69,7 @@ var CredentialProcess = cli.Command{
 		}
 
 		if needsRefresh {
-			profiles, err := cfaws.LoadProfilesFromDefaultFiles()
+			profiles, err := cfaws.LoadProfiles()
 			if err != nil {
 				return err
 			}

--- a/pkg/granted/credentials.go
+++ b/pkg/granted/credentials.go
@@ -41,7 +41,7 @@ var AddCredentialsCommand = cli.Command{
 		}
 
 		// validate the the profile does not already exist
-		profiles, err := cfaws.LoadProfilesFromDefaultFiles()
+		profiles, err := cfaws.LoadProfiles()
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ var AddCredentialsCommand = cli.Command{
 //	[profile my-profile]
 //	credential_process = granted credential-process --profile=my-profile
 func updateOrCreateProfileWithCredentialProcess(profileName string) error {
-	configPath := config.DefaultSharedConfigFilename()
+	configPath := cfaws.GetAWSConfigPath()
 	configFile, err := ini.LoadSources(ini.LoadOptions{
 		AllowNonUniqueSections:  false,
 		SkipUnrecognizableLines: false,
@@ -141,7 +141,7 @@ var ImportCredentialsCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		profileName := c.Args().First()
-		profiles, err := cfaws.LoadProfilesFromDefaultFiles()
+		profiles, err := cfaws.LoadProfiles()
 		if err != nil {
 			return err
 		}
@@ -179,7 +179,7 @@ var ImportCredentialsCommand = cli.Command{
 		}
 
 		// remove the profile from the credentials file
-		credentialsFilePath := config.DefaultSharedCredentialsFilename()
+		credentialsFilePath := cfaws.GetAWSCredentialsPath()
 		credentialsFile, err := ini.LoadSources(ini.LoadOptions{
 			AllowNonUniqueSections:  false,
 			SkipUnrecognizableLines: false,
@@ -193,7 +193,7 @@ var ImportCredentialsCommand = cli.Command{
 			return err
 		}
 
-		configPath := config.DefaultSharedConfigFilename()
+		configPath := cfaws.GetAWSConfigPath()
 		configFile, err := ini.LoadSources(ini.LoadOptions{
 			AllowNonUniqueSections:  false,
 			SkipUnrecognizableLines: false,
@@ -329,7 +329,7 @@ var RemoveCredentialsCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		secureIAMCredentialStorage := securestorage.NewSecureIAMCredentialStorage()
-		configPath := config.DefaultSharedConfigFilename()
+		configPath := cfaws.GetAWSConfigPath()
 		configFile, err := ini.LoadSources(ini.LoadOptions{
 			AllowNonUniqueSections:  false,
 			SkipUnrecognizableLines: false,
@@ -443,7 +443,7 @@ var ExportCredentialsCommand = cli.Command{
 				return err
 			}
 			// fetch parsed credentials file
-			credentialsFilePath := config.DefaultSharedCredentialsFilename()
+			credentialsFilePath := cfaws.GetAWSCredentialsPath()
 			credentialsFile, err := ini.LoadSources(ini.LoadOptions{
 				AllowNonUniqueSections:  false,
 				SkipUnrecognizableLines: false,
@@ -472,7 +472,7 @@ var ExportCredentialsCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-			configPath := config.DefaultSharedConfigFilename()
+			configPath := cfaws.GetAWSConfigPath()
 			configFile, err := ini.LoadSources(ini.LoadOptions{
 				AllowNonUniqueSections:  false,
 				SkipUnrecognizableLines: false,

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/briandowns/spinner"
 	"github.com/common-fate/awsconfigfile"
 	"github.com/common-fate/cli/pkg/client"
@@ -431,7 +430,7 @@ func requestAccess(ctx context.Context, opts requestAccessOpts) error {
 
 	region := gConf.CommonFateDefaultSSORegion
 
-	configFilename := awsconfig.DefaultSharedConfigFilename()
+	configFilename := cfaws.GetAWSConfigPath()
 
 	config, err := ini.LoadSources(ini.LoadOptions{
 		AllowNonUniqueSections:  false,

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -158,7 +158,7 @@ var PopulateCommand = cli.Command{
 		}
 
 		// end of --region flag behaviour warnings. These can be removed once https://github.com/common-fate/granted/issues/360 is closed.
-		configFilename := config.DefaultSharedConfigFilename()
+		configFilename := cfaws.GetAWSConfigPath()
 
 		config, err := ini.LoadSources(ini.LoadOptions{
 			AllowNonUniqueSections:  false,

--- a/pkg/granted/tokens.go
+++ b/pkg/granted/tokens.go
@@ -131,7 +131,7 @@ func MapTokens(ctx context.Context) (map[string][]string, error) {
 		return nil, err
 	}
 
-	profiles, err := cfaws.LoadProfilesFromDefaultFiles()
+	profiles, err := cfaws.LoadProfiles()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What changed?
Solves: https://github.com/common-fate/granted/issues/229

### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs