### PR TITLE
Add `granted credentials import-from-env` subcmd to load new profile with credentials from env

### DIFF
--- a/pkg/granted/credentials.go
+++ b/pkg/granted/credentials.go
@@ -3,12 +3,14 @@ package granted
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"gopkg.in/ini.v1"
 
@@ -23,7 +25,7 @@ import (
 var CredentialsCommand = cli.Command{
 	Name:        "credentials",
 	Usage:       "Manage secure IAM credentials",
-	Subcommands: []*cli.Command{&AddCredentialsCommand, &ImportCredentialsCommand, &UpdateCredentialsCommand, &ListCredentialsCommand, &RemoveCredentialsCommand, &ExportCredentialsCommand, &RotateCredentialsCommand},
+	Subcommands: []*cli.Command{&AddCredentialsCommand, &ImportCredentialsCommand, &UpdateCredentialsCommand, &ListCredentialsCommand, &RemoveCredentialsCommand, &ExportCredentialsCommand, &RotateCredentialsCommand, &ImportCredFromEnvCommand},
 }
 
 var AddCredentialsCommand = cli.Command{
@@ -578,5 +580,88 @@ var RotateCredentialsCommand = cli.Command{
 		clio.Successf("Access Key of '%s' profile has been successfully rotated and updated in secure storage\n", profileName)
 
 		return nil
+	},
+}
+
+var ImportCredFromEnvCommand = cli.Command{
+	Name:  "import-from-env",
+	Usage: "Create a new AWS config profile with IAM credentials imported from environment. You must have $AWS_ACCESS_KEY_ID and $AWS_SECRET_ACCESS_KEY set in  your environment",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "profile", Required: true},
+	},
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+
+		accessKeyFromEnv, accessKeyFromEnvExists := os.LookupEnv("AWS_ACCESS_KEY_ID")
+		secretAccessKeyFromEnv, secretAccessKeyFromEnvExists := os.LookupEnv("AWS_ACCESS_KEY_ID")
+
+		if accessKeyFromEnvExists && secretAccessKeyFromEnvExists {
+			profileName := c.String("profile")
+			profiles, err := cfaws.LoadProfiles()
+			if err != nil {
+				return err
+			}
+
+			if profiles.HasProfile(profileName) {
+				return fmt.Errorf("profile with name '%s' already exist", profileName)
+			}
+
+			// create new static credential
+			credentials, err := credentials.NewStaticCredentialsProvider(accessKeyFromEnv, secretAccessKeyFromEnv, "").Retrieve(ctx)
+			if err != nil {
+				return err
+			}
+
+			secureIAMCredentialStorage := securestorage.NewSecureIAMCredentialStorage()
+			err = secureIAMCredentialStorage.StoreCredentials(profileName, credentials)
+			if err != nil {
+				return err
+			}
+
+			// fetch parsed credentials file
+			credentialsFilePath := cfaws.GetAWSCredentialsPath()
+			credentialsFile, err := ini.LoadSources(ini.LoadOptions{
+				AllowNonUniqueSections:  false,
+				SkipUnrecognizableLines: false,
+			}, credentialsFilePath)
+			if err != nil {
+				return err
+			}
+
+			section, err := credentialsFile.NewSection(profileName)
+			if err != nil {
+				return err
+			}
+			err = section.ReflectFrom(&struct {
+				AWSAccessKeyID     string `ini:"aws_access_key_id"`
+				AWSSecretAccessKey string `ini:"aws_secret_access_key"`
+			}{
+				AWSAccessKeyID:     accessKeyFromEnv,
+				AWSSecretAccessKey: secretAccessKeyFromEnv,
+			})
+			if err != nil {
+				return err
+			}
+			err = credentialsFile.SaveTo(credentialsFilePath)
+			if err != nil {
+				return err
+			}
+
+			err = updateOrCreateProfileWithCredentialProcess(profileName)
+			if err != nil {
+				return err
+			}
+
+			clio.Successf("successfully created new profile %s", profileName)
+
+			return nil
+
+		}
+
+		clio.Error("you don't have variables $AWS_ACCESS_KEY_ID and $AWS_SECRET_ACCESS_KEY set in your environment.")
+		clio.Info("If you instead want to import plain-text credentials from ~/.aws/credentials to secure storage then run 'granted credentials import'")
+
+		return nil
+
 	},
 }


### PR DESCRIPTION
### What changed?
Supercedes by making this implementation into it's own subcommand. https://github.com/common-fate/granted/pull/410

### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs