### PR TITLE
Update service_map.go

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -17,6 +17,7 @@ var ServiceMap = map[string]string{
 	"ct":             "cloudtrail",
 	"cw":             "cloudwatch",
 	"ddb":            "dynamodbv2",
+	"dynamodb":       "dynamodbv2",
 	"dms":            "dms/v2",
 	"dx":             "directconnect/v2",
 	"eb":             "elasticbeanstalk",


### PR DESCRIPTION
Adds dynamodb as a recognized option

### What changed?
Added `dynamodb` as a recognized service option

### Why?
I often use that as my endpoint and get the following message
```[!] We don't recognize service dynamodb but we'll try and open it anyway (you may receive a 404 page)```
This is indeed valid.

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs