### PR TITLE
Display Authentication code before prompting authentication in the browser. 

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -251,6 +251,7 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 	if err != nil {
 		return nil, err
 	}
+
 	// trigger OIDC login. open browser to login. close tab once login is done. press enter to continue
 	url := aws.ToString(deviceAuth.VerificationUriComplete)
 	clio.Info("If the browser does not open automatically, please open this link: " + url)
@@ -285,6 +286,7 @@ func SSODeviceCodeFlowFromStartUrl(ctx context.Context, cfg aws.Config, startUrl
 
 	clio.Info("Awaiting AWS authentication in the browser")
 	clio.Info("You will be prompted to authenticate with AWS in the browser, then you will be prompted to 'Allow'")
+	clio.Infof("Code: %s", *deviceAuth.UserCode)
 	token, err := PollToken(ctx, ssooidcClient, *register.ClientSecret, *register.ClientId, *deviceAuth.DeviceCode, PollingConfig{CheckInterval: time.Second * 2, TimeoutAfter: time.Minute * 2})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What changed?
AWS has made some changes to device authentication Popover where they request you to confirm if the code matches with the one that initiated this request. 

This change will show the user the initial code in their terminal. 


### Why?
![Screen Shot 2023-09-14 at 11 14 27 AM](https://github.com/common-fate/granted/assets/12543236/41f2d803-c04a-4d60-ab24-fe55d35ba184)



### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs