### PR TITLE
Fix for bash alias not detected issue

### DIFF
--- a/scripts/assume
+++ b/scripts/assume
@@ -10,8 +10,8 @@ _this_type=$(type -- "${0##*/}" 2>&1)
 # In that case the output will typically contain 'not found'.
 # In the case of zsh, the output will contain the word 'alias'.
 if [ "${_this_type#*not found}" != "$_this_type" ] ||
-    [ "${_this_type#*alias}" != "$_this_type" ] || 
-    [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    [ "${_this_type#*alias}" != "$_this_type" ] ||
+    [ -n "$BASH_VERSION" ] && [ "$BASH_SOURCE" != "$0" ]; then
   GRANTED_RETURN_STATUS="true"
   export GRANTED_ALIAS_CONFIGURED="true"
 fi

--- a/scripts/assume
+++ b/scripts/assume
@@ -11,7 +11,7 @@ _this_type=$(type -- "${0##*/}" 2>&1)
 # In the case of zsh, the output will contain the word 'alias'.
 if [ "${_this_type#*not found}" != "$_this_type" ] ||
     [ "${_this_type#*alias}" != "$_this_type" ] || 
-    [ "${BASH_SOURCE[0]:-$0}}" != "${0}" ]; then
+    [ "${BASH_SOURCE:-$0}" != "${0}" ]; then
   GRANTED_RETURN_STATUS="true"
   export GRANTED_ALIAS_CONFIGURED="true"
 fi

--- a/scripts/assume
+++ b/scripts/assume
@@ -10,8 +10,8 @@ _this_type=$(type -- "${0##*/}" 2>&1)
 # In that case the output will typically contain 'not found'.
 # In the case of zsh, the output will contain the word 'alias'.
 if [ "${_this_type#*not found}" != "$_this_type" ] ||
-    [ "${_this_type#*alias}" != "$_this_type" ] ||
-    [ -n "$BASH_VERSION" ] && [ "$BASH_SOURCE" != "$0" ]; then
+    [ "${_this_type#*alias}" != "$_this_type" ] || 
+    [ "${BASH_SOURCE[0]}" != "${0}" ]; then
   GRANTED_RETURN_STATUS="true"
   export GRANTED_ALIAS_CONFIGURED="true"
 fi

--- a/scripts/assume
+++ b/scripts/assume
@@ -11,7 +11,7 @@ _this_type=$(type -- "${0##*/}" 2>&1)
 # In the case of zsh, the output will contain the word 'alias'.
 if [ "${_this_type#*not found}" != "$_this_type" ] ||
     [ "${_this_type#*alias}" != "$_this_type" ] || 
-    [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    [ "${BASH_SOURCE[0]:-$0}}" != "${0}" ]; then
   GRANTED_RETURN_STATUS="true"
   export GRANTED_ALIAS_CONFIGURED="true"
 fi

--- a/scripts/assume
+++ b/scripts/assume
@@ -9,6 +9,7 @@ _this_type=$(type -- "${0##*/}" 2>&1)
 # file because $0 will be the login shell, e.g., -bash.
 # In that case the output will typically contain 'not found'.
 # In the case of zsh, the output will contain the word 'alias'.
+# shellcheck disable=SC3028
 if [ "${_this_type#*not found}" != "$_this_type" ] ||
     [ "${_this_type#*alias}" != "$_this_type" ] || 
     [ "${BASH_SOURCE:-$0}" != "${0}" ]; then

--- a/scripts/assume
+++ b/scripts/assume
@@ -10,7 +10,8 @@ _this_type=$(type -- "${0##*/}" 2>&1)
 # In that case the output will typically contain 'not found'.
 # In the case of zsh, the output will contain the word 'alias'.
 if [ "${_this_type#*not found}" != "$_this_type" ] ||
-    [ "${_this_type#*alias}" != "$_this_type" ]; then
+    [ "${_this_type#*alias}" != "$_this_type" ] || 
+    [ "${BASH_SOURCE[0]}" != "${0}" ]; then
   GRANTED_RETURN_STATUS="true"
   export GRANTED_ALIAS_CONFIGURED="true"
 fi


### PR DESCRIPTION
### What changed?
Edited the assume script to correctly detect bash alias

### Why?


### How did you test it?
Tested it locally with bash shell

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs