### PR TITLE
Add kms to ServiceMap

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -29,6 +29,7 @@ var ServiceMap = map[string]string{
 	"gd":             "guardduty",
 	"grafana":        "grafana",
 	"iam":            "iamv2",
+	"kms":            "kms",
 	"l":              "lambda",
 	"lambda":         "lambda",
 	"mwaa":           "mwaa",


### PR DESCRIPTION
### What changed?

Added `kms` as a recognized service option.

### Why?

It's currently not supported but it's working:

```
 [!] We don't recognize service kms but we'll try and open it anyway (you may receive a 404 page)
```

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs