### PR TITLE
Retains-indentation-in-.aws/config

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -130,6 +130,7 @@ func AssumeCommand(c *cli.Context) error {
 			config, err := ini.LoadSources(ini.LoadOptions{
 				AllowNonUniqueSections:  false,
 				SkipUnrecognizableLines: false,
+				AllowNestedValues:       true,
 			}, configFilename)
 			if err != nil {
 				if !os.IsNotExist(err) {

--- a/pkg/cfaws/cred-exporter.go
+++ b/pkg/cfaws/cred-exporter.go
@@ -32,6 +32,7 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 	credentialsFile, err := ini.LoadSources(ini.LoadOptions{
 		AllowNonUniqueSections:  false,
 		SkipUnrecognizableLines: false,
+		AllowNestedValues:       true,
 	}, credPath)
 	if err != nil {
 		return err

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -126,6 +126,7 @@ func (f FileLoader) Load() (*ini.File, error) {
 	configFile, err := ini.LoadSources(ini.LoadOptions{
 		AllowNonUniqueSections:  false,
 		SkipUnrecognizableLines: false,
+		AllowNestedValues:       true,
 	}, f.FilePath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/granted/credentials.go
+++ b/pkg/granted/credentials.go
@@ -82,6 +82,7 @@ func updateOrCreateProfileWithCredentialProcess(profileName string) error {
 	configFile, err := ini.LoadSources(ini.LoadOptions{
 		AllowNonUniqueSections:  false,
 		SkipUnrecognizableLines: false,
+		AllowNestedValues:       true,
 	}, configPath)
 	if err != nil {
 		return err
@@ -185,6 +186,7 @@ var ImportCredentialsCommand = cli.Command{
 		credentialsFile, err := ini.LoadSources(ini.LoadOptions{
 			AllowNonUniqueSections:  false,
 			SkipUnrecognizableLines: false,
+			AllowNestedValues:       true,
 		}, credentialsFilePath)
 		if err != nil {
 			return err
@@ -199,6 +201,7 @@ var ImportCredentialsCommand = cli.Command{
 		configFile, err := ini.LoadSources(ini.LoadOptions{
 			AllowNonUniqueSections:  false,
 			SkipUnrecognizableLines: false,
+			AllowNestedValues:       true,
 		}, configPath)
 		if err != nil {
 			return err
@@ -335,6 +338,7 @@ var RemoveCredentialsCommand = cli.Command{
 		configFile, err := ini.LoadSources(ini.LoadOptions{
 			AllowNonUniqueSections:  false,
 			SkipUnrecognizableLines: false,
+			AllowNestedValues:       true,
 		}, configPath)
 		if err != nil {
 			return err
@@ -449,6 +453,7 @@ var ExportCredentialsCommand = cli.Command{
 			credentialsFile, err := ini.LoadSources(ini.LoadOptions{
 				AllowNonUniqueSections:  false,
 				SkipUnrecognizableLines: false,
+				AllowNestedValues:       true,
 			}, credentialsFilePath)
 			if err != nil {
 				return err
@@ -478,6 +483,7 @@ var ExportCredentialsCommand = cli.Command{
 			configFile, err := ini.LoadSources(ini.LoadOptions{
 				AllowNonUniqueSections:  false,
 				SkipUnrecognizableLines: false,
+				AllowNestedValues:       true,
 			}, configPath)
 			if err != nil {
 				return err
@@ -623,6 +629,7 @@ var ImportCredFromEnvCommand = cli.Command{
 			credentialsFile, err := ini.LoadSources(ini.LoadOptions{
 				AllowNonUniqueSections:  false,
 				SkipUnrecognizableLines: false,
+				AllowNestedValues:       true,
 			}, credentialsFilePath)
 			if err != nil {
 				return err

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -435,6 +435,7 @@ func requestAccess(ctx context.Context, opts requestAccessOpts) error {
 	config, err := ini.LoadSources(ini.LoadOptions{
 		AllowNonUniqueSections:  false,
 		SkipUnrecognizableLines: false,
+		AllowNestedValues:       true,
 	}, configFilename)
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/pkg/granted/registry/ini.go
+++ b/pkg/granted/registry/ini.go
@@ -29,6 +29,7 @@ func loadAWSConfigFile() (*ini.File, string, error) {
 	awsConfig, err := ini.LoadSources(ini.LoadOptions{
 		SkipUnrecognizableLines: true,
 		AllowNonUniqueSections:  true,
+		AllowNestedValues:       true,
 	}, filepath)
 	if err != nil {
 		return nil, "", err

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -134,6 +134,7 @@ var PopulateCommand = cli.Command{
 		config, err := ini.LoadSources(ini.LoadOptions{
 			AllowNonUniqueSections:  false,
 			SkipUnrecognizableLines: false,
+			AllowNestedValues:       true,
 		}, configFilename)
 		if err != nil {
 			if !os.IsNotExist(err) {


### PR DESCRIPTION
### What changed?
Adding `AllowNestedValues: true` allows for nested values like:
```
[profile testing]
aws_access_key_id = foo
aws_secret_access_key = bar
region = us-west-2
s3 =
  max_concurrent_requests=10
  max_queue_size=1000
```

### Why?
Fix for: https://github.com/common-fate/granted/issues/502

### How did you test it?
Manually using dgranted

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs