### PR TITLE
Add acn as a valid service

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -4,6 +4,7 @@ package console
 // e.g. passing in `-s ec2` will open the console at the ec2/v2 URL.
 var ServiceMap = map[string]string{
 	"":               "console",
+	"acm":		  "acm",
 	"athena":         "athena",
 	"appsync":        "appsync",
 	"c9":             "cloud9",


### PR DESCRIPTION
### What changed?
Added `acm` as a recognized service option

### Why?
I often use that as my endpoint and get the following message
[!] We don't recognize service dynamodb but we'll try and open it anyway (you may receive a 404 page)
This is indeed valid.

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs