### PR TITLE
add no-credential-process flag back into command

### DIFF
--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -113,7 +113,9 @@ var PopulateCommand = cli.Command{
 		&cli.StringFlag{Name: "sso-region", Usage: "Specify the SSO region"},
 		&cli.StringSliceFlag{Name: "source", Usage: "The sources to load AWS profiles from", Value: cli.NewStringSlice("aws-sso")},
 		&cli.BoolFlag{Name: "prune", Usage: "Remove any generated profiles with the 'common_fate_generated_from' key which no longer exist"},
-		&cli.StringFlag{Name: "profile-template", Usage: "Specify profile name template", Value: awsconfigfile.DefaultProfileNameTemplate}},
+		&cli.StringFlag{Name: "profile-template", Usage: "Specify profile name template", Value: awsconfigfile.DefaultProfileNameTemplate},
+		&cli.BoolFlag{Name: "no-credential-process", Usage: "Generate profiles without the Granted credential-process integration"},
+	},
 	Action: func(c *cli.Context) error {
 		ctx := c.Context
 		fullCommand := fmt.Sprintf("%s %s", c.App.Name, c.Command.FullName()) // e.g. 'granted sso populate'


### PR DESCRIPTION
### What changed?
reverts accidental removal of no-credential-process flag from command in #489 

### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs