### PR TITLE
Add `codepipeline` and `codedeploy` services

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -14,6 +14,8 @@ var ServiceMap = map[string]string{
 	"cloudformation": "cloudformation",
 	"cloudmap":       "cloudmap",
 	"cloudwatch":     "cloudwatch",
+	"codepipeline":   "codepipeline",
+	"codedeploy":     "codedeploy",
 	"config":         "config",
 	"ct":             "cloudtrail",
 	"cw":             "cloudwatch",


### PR DESCRIPTION
### What changed?

Added `codepipeline` and `codedeploy`  as recognized service options.

### Why?

They are long words and currently dont tab complete. Both are opened fine with a warning..

```
[!] We don't recognize service codepipeline but we'll try and open it anyway (you may receive a 404 page)
```

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs