### PR TITLE
Add Waterfox as a browser option

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -382,7 +382,7 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 
-		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey {
+		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.WaterfoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey {
 			// tranform the URL into the Firefox Tab Container format.
 			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", containerProfile, url.QueryEscape(consoleURL), profile.CustomGrantedProperty("color"), profile.CustomGrantedProperty("icon"))
 		}
@@ -433,7 +433,7 @@ func AssumeCommand(c *cli.Context) error {
 				ExecutablePath: browserPath,
 				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "4"), // held over for backwards compatibility, "4" indicates Chromium profiles
 			}
-		case browser.FirefoxKey:
+		case browser.FirefoxKey, browser.WaterfoxKey:
 			l = launcher.Firefox{
 				ExecutablePath: browserPath,
 			}

--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -12,6 +12,7 @@ const (
 	BraveKey             string = "BRAVE"
 	EdgeKey              string = "EDGE"
 	FirefoxKey           string = "FIREFOX"
+	WaterfoxKey          string = "WATERFOX"
 	ChromiumKey          string = "CHROMIUM"
 	SafariKey            string = "SAFARI"
 	StdoutKey            string = "STDOUT"
@@ -40,6 +41,10 @@ var FirefoxPathWindows = []string{`\Program Files\Mozilla Firefox\firefox.exe`}
 var FirefoxDevPathMac = []string{"/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox"}
 var FirefoxDevPathLinux = []string{`/usr/bin/firefox-developer`, `/../../mnt/c/Program Files/Firefox Developer Edition/firefox.exe`}
 var FirefoxDevPathWindows = []string{`\Program Files\Firefox Developer Edition\firefox.exe`}
+
+var WaterfoxPathMac = []string{"/Applications/Waterfox.app/Contents/MacOS/waterfox"}
+var WaterfoxPathLinux = []string{`/usr/bin/waterfox`, `/../../mnt/c/Program Files/Waterfox/waterfox.exe`}
+var WaterfoxPathWindows = []string{`\Program Files\Waterfox\waterfox.exe`}
 
 var ChromiumPathMac = []string{"/Applications/Chromium.app/Contents/MacOS/Chromium"}
 var ChromiumPathLinux = []string{`/usr/bin/chromium`, `/../../mnt/c/Program Files/Chromium/chromium.exe`}
@@ -140,6 +145,24 @@ func FirefoxDevPathDefaults() ([]string, error) {
 		return FirefoxDevPathMac, nil
 	case "linux":
 		return FirefoxDevPathLinux, nil
+	default:
+		return nil, errors.New("os not supported")
+	}
+}
+
+func WaterfoxPathDefaults() ([]string, error) {
+	// check linuxpath for binary install
+	path, err := exec.LookPath("waterfox")
+	if err == nil {
+		return []string{path}, nil
+	}
+	switch runtime.GOOS {
+	case "windows":
+		return WaterfoxPathWindows, nil
+	case "darwin":
+		return WaterfoxPathMac, nil
+	case "linux":
+		return WaterfoxPathLinux, nil
 	default:
 		return nil, errors.New("os not supported")
 	}

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -50,7 +50,7 @@ func HandleManualBrowserSelection() (string, error) {
 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 	in := survey.Select{
 		Message: "Select one of the browsers from the list",
-		Options: []string{"Chrome", "Brave", "Edge", "Firefox", "Chromium", "Safari", "Stdout", "FirefoxStdout", "Firefox Developer Edition", "Arc"},
+		Options: []string{"Chrome", "Brave", "Edge", "Firefox", "Waterfox", "Chromium", "Safari", "Stdout", "FirefoxStdout", "Firefox Developer Edition", "Arc"},
 	}
 	var selection string
 	clio.NewLine()
@@ -117,6 +117,9 @@ func GetBrowserKey(b string) string {
 	if strings.Contains(strings.ToLower(b), "firefox") || strings.Contains(strings.ToLower(b), "mozilla") {
 		return FirefoxKey
 	}
+	if strings.Contains(strings.ToLower(b), "waterfox") {
+		return WaterfoxKey
+	}
 	if strings.Contains(strings.ToLower(b), "chromium") {
 		return ChromiumKey
 	}
@@ -146,6 +149,8 @@ func DetectInstallation(browserKey string) (string, bool) {
 		bPath, _ = EdgePathDefaults()
 	case FirefoxKey:
 		bPath, _ = FirefoxPathDefaults()
+	case WaterfoxKey:
+		bPath, _ = WaterfoxPathDefaults()
 	case ChromiumKey:
 		bPath, _ = ChromiumPathDefaults()
 	case SafariKey:
@@ -236,8 +241,8 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 			browserPath = customBrowserPath
 		}
 
-		if browserKey == FirefoxKey {
-			err := RunFirefoxExtensionPrompts(browserPath)
+		if browserKey == FirefoxKey || browserKey == WaterfoxKey {
+			err := RunFirefoxExtensionPrompts(browserPath, browserName)
 			if err != nil {
 				return err
 			}
@@ -303,11 +308,11 @@ func SSOBrowser(grantedDefaultBrowser string) error {
 
 }
 
-func RunFirefoxExtensionPrompts(firefoxPath string) error {
+func RunFirefoxExtensionPrompts(browserPath string, browserName string) error {
 	clio.Info("In order to use Granted with Firefox you need to download the Granted Firefox addon: https://addons.mozilla.org/en-GB/firefox/addon/granted")
 	clio.Info("This addon has minimal permissions and does not access any web page content")
 
-	label := "Open Firefox to download the extension?"
+	label := fmt.Sprintf("Open %s to download the extension?", browserName)
 
 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 	in := &survey.Select{
@@ -329,7 +334,7 @@ func RunFirefoxExtensionPrompts(firefoxPath string) error {
 		return nil
 	}
 
-	cmd := exec.Command(firefoxPath,
+	cmd := exec.Command(browserPath,
 		"--new-tab",
 		"https://addons.mozilla.org/en-GB/firefox/addon/granted/")
 	err = cmd.Start()


### PR DESCRIPTION
### What changed?

Added options to configure Waterfox as a browser and prompt for install of the Firefox extension into Waterfox. 

### Why?

I had set up Waterfox originally by just providing the path to Waterfox instead of Firefox, but if a user had Firefox already installed to its default path, this might not have worked. 

### How did you test it?

Tested on MacOS
1. built the CLI locally with `PREFIX=~/.local make cli`
2. ran `dgranted browser set`
3. selected `Waterfox`
4. ran `dassume -c <profile_name>` 
   - Waterfox opens to AWS console with correct login, container name, and container icon from `~/.aws/config`

> _I have not tested this on linux or windows so I took my best guess on the path for windows based on [this reddit post](https://www.reddit.com/r/waterfox/comments/do1az7/waterfox_classic_201910_full_installer_the). If the path is incorrect the user can correct it as usual and/or file an issue to have the default updated._

### Potential risks
Leveraging some shared code with Firefox to launch / control Waterfox. If Waterfox diverges there could be issues here, however that seems unlikely since diverging may cause a lot of issues for Waterfox users in general. 

### Is patch release candidate?


### Link to relevant docs PRs