### PR TITLE
add skip cred process string validation option

### DIFF
--- a/pkg/cfaws/granted_config.go
+++ b/pkg/cfaws/granted_config.go
@@ -65,15 +65,19 @@ func ParseGrantedSSOProfile(ctx context.Context, profile *Profile) (*config.Shar
 		return nil, fmt.Errorf("invalid value '%s' provided for 'granted_sso_start_url'", cfg.SSOStartURL)
 	}
 
-	// This is useful when we need to force some custom behaviour of the credential process, such as running a different version of granted at a specific path
-	item, err = profile.RawConfig.GetKey("granted_skip_credential_process_validation")
-	if err != nil {
-		return nil, err
+	shouldSkipValidation := false
+	if profile.RawConfig.HasKey("granted_skip_credential_process_validation") {
+		// This is useful when we need to force some custom behaviour of the credential process, such as running a different version of granted at a specific path
+		item, err = profile.RawConfig.GetKey("granted_skip_credential_process_validation")
+		if err != nil {
+			return nil, err
+		}
+		shouldSkipValidation, err = item.Bool()
+		if err != nil {
+			return nil, err
+		}
 	}
-	shouldSkipValidation, err := item.Bool()
-	if err != nil {
-		return nil, err
-	}
+
 	if !shouldSkipValidation {
 		item, err = profile.RawConfig.GetKey("credential_process")
 		if err != nil {


### PR DESCRIPTION
### What changed?
Adds a config item type to skip validation of the credential-process key

### Why?
To allow usage with a specific file path for the granted binary

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs