### PR TITLE
Allow access token to be exported to plain text on ~/.aws/sso/cache

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -524,6 +524,14 @@ func AssumeCommand(c *cli.Context) error {
 			}
 
 			clio.Successf("Exported credentials to ~/.aws/credentials file as %s successfully", profileName)
+
+			err := cfaws.ExportAccessTokenToCache(profile)
+
+			if err != nil {
+				return err
+			}
+
+			clio.Success("Exported access token to ~/.aws/sso/cache")
 		}
 
 		if execCfg != nil {

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -525,13 +525,16 @@ func AssumeCommand(c *cli.Context) error {
 
 			clio.Successf("Exported credentials to ~/.aws/credentials file as %s successfully", profileName)
 
+		}
+
+		if assumeFlags.Bool("export-sso-token") {
 			err := cfaws.ExportAccessTokenToCache(profile)
 
 			if err != nil {
 				return err
 			}
 
-			clio.Success("Exported access token to ~/.aws/sso/cache")
+			clio.Success("Exported sso token to ~/.aws/sso/cache")
 		}
 
 		if execCfg != nil {

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -26,6 +26,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "terminal", Aliases: []string{"t"}, Usage: "Use this with '-c' to open a console session and export credentials into the terminal at the same time."},
 		&cli.BoolFlag{Name: "env", Aliases: []string{"e"}, Usage: "Export credentials to a .env file"},
 		&cli.BoolFlag{Name: "export", Aliases: []string{"ex"}, Usage: "Export credentials to a ~/.aws/credentials file"},
+		&cli.BoolFlag{Name: "export-sso-token", Aliases: []string{"es"}, Usage: "Export sso token to ~/.aws/sso/cache"},
 		&cli.BoolFlag{Name: "unset", Aliases: []string{"un"}, Usage: "Unset all environment variables configured by Assume"},
 		&cli.BoolFlag{Name: "url", Aliases: []string{"u"}, Usage: "Get an active console session url"},
 		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Like --c, but opens to a specified service"},

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -170,6 +170,14 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 
 	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
 	cachedToken := secureSSOTokenStorage.GetValidSSOToken(ssoTokenKey)
+	// check if profile has a valid plaintext sso access token
+	plainTextToken := GetValidSSOTokenFromPlaintextCache(ssoTokenKey)
+
+	// store token to storage to avoid multiple logins
+	if plainTextToken != nil {
+		secureSSOTokenStorage.StoreSSOToken(ssoTokenKey, *plainTextToken)
+	}
+
 	var accessToken *string
 
 	skipAutoLogin := configOpts.UsingCredentialProcess && !configOpts.CredentialProcessAutoLogin
@@ -188,7 +196,7 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 		return aws.Credentials{}, fmt.Errorf("error when retrieving credentials from custom process. please login using '%s'", cmd)
 	}
 
-	if cachedToken == nil {
+	if cachedToken == nil && plainTextToken == nil {
 		newCfg := aws.NewConfig()
 		newCfg.Region = c.AWSConfig.SSORegion
 		newSSOToken, err := SSODeviceCodeFlowFromStartUrl(ctx, *newCfg, c.AWSConfig.SSOStartURL)
@@ -197,9 +205,13 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 		}
 
 		secureSSOTokenStorage.StoreSSOToken(ssoTokenKey, *newSSOToken)
-		accessToken = &newSSOToken.AccessToken
-	} else {
+		cachedToken = newSSOToken
+	}
+
+	if cachedToken != nil {
 		accessToken = &cachedToken.AccessToken
+	} else {
+		accessToken = &plainTextToken.AccessToken
 	}
 
 	cfg := aws.NewConfig()

--- a/pkg/cfaws/cred-exporter.go
+++ b/pkg/cfaws/cred-exporter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/common-fate/clio"
 	gconfig "github.com/common-fate/granted/pkg/config"
+	"github.com/common-fate/granted/pkg/securestorage"
 	"gopkg.in/ini.v1"
 )
 
@@ -66,4 +67,15 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 		return err
 	}
 	return credentialsFile.SaveTo(credPath)
+}
+
+// ExportAccessTokenToCache will export access tokens to ~/.aws/sso/cache
+func ExportAccessTokenToCache(profile *Profile) error {
+	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
+	// Find the access token for the SSOStartURL
+	cachedToken := secureSSOTokenStorage.GetValidSSOToken(profile.AWSConfig.SSOStartURL)
+	ssoPlainTextOut := CreatePlainTextSSO(profile.AWSConfig, cachedToken)
+	err := ssoPlainTextOut.DumpToCacheDirectory()
+
+	return err
 }


### PR DESCRIPTION
### What changed?
This change would allow the access tokens to be exported to ~/.aws/sso/cache when the user run `assume --export`. Allowing `awscli` to use said token without the need to login again. Adjusted the keys for the file name as the default used is `sso_session_name`, `sso_start_url` is used if the session name is not present. Fix for issue #155.

### Why?
Allows `awscli` to use the access token without the need to login, and allows assume to use access token from `~/.aws/sso/cache` to avoid multiple logins

### How did you test it?
Ran `dassume --export` and tested via `aws s3 ls --profile test-profile` and checked `~/.aws/sso/cache` file location

Ran `dassume --export` with no `granted-aws-sso-tokens` on my keychain and valid access tokens on `~/.aws/sso/cache`,
checked the key-chain if `granted-aws-sso-tokens` is set, also tested in reverse(no plain-text token and has key-chain access-token)

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs