### PR TITLE
`-z` alias for `--export-all-env-vars`

### DIFF
--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -47,7 +47,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "browser-profile", Aliases: []string{"bp"}, Usage: "Use a pre-existing profile in your browser"},
 		&cli.StringFlag{Name: "mfa-token", Usage: "Provide your current MFA token for the role you are assuming to skip being prompted"},
 		&cli.StringFlag{Name: "save-to", Usage: "Use this in conjunction with --sso, the profile name to save the role to in your AWS config file"},
-		&cli.BoolFlag{Name: "export-all-env-vars", Usage: "Exports all available credentials to the terminal when used with a profile configured for credential-process. Without this flag, only the AWS_PROFILE will be configured"},
+		&cli.BoolFlag{Name: "export-all-env-vars", Aliases: []string{"x"}, Usage: "Exports all available credentials to the terminal when used with a profile configured for credential-process. Without this flag, only the AWS_PROFILE will be configured"},
 		&cli.StringFlag{Name: "aws-config-file"},
 	}
 }


### PR DESCRIPTION
### What changed?
`-z` alias for new `--export-all-env-vars` used to invoke previous ([sometimes unwanted](https://github.com/common-fate/granted/issues/263)) default behaviour.


### Why?
For less typing for my main use of `assume`


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs
https://github.com/common-fate/granted/pull/467#issuecomment-1767993740