### PR TITLE
fix chrome profiles not launching if they contain slashes + automatically rename Chrome profiles

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
-	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -399,39 +398,12 @@ func AssumeCommand(c *cli.Context) error {
 			return errors.New("default browser not configured. run `granted browser set` to configure")
 		}
 
-		grantedFolder, err := config.GrantedConfigFolder()
-		if err != nil {
-			return err
-		}
-
 		var l Launcher
 		switch cfg.DefaultBrowser {
-		case browser.ChromeKey:
+		case browser.ChromeKey, browser.BraveKey, browser.EdgeKey, browser.ChromiumKey:
 			l = launcher.ChromeProfile{
-				BrowserType:    browser.ChromeKey,
+				BrowserType:    cfg.DefaultBrowser,
 				ExecutablePath: browserPath,
-				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "1"), // held over for backwards compatibility, "1" indicates Chrome profiles
-			}
-		case browser.BraveKey:
-			l = launcher.ChromeProfile{
-				BrowserType: browser.BraveKey,
-
-				ExecutablePath: browserPath,
-				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "2"), // held over for backwards compatibility, "2" indicates Brave profiles
-			}
-		case browser.EdgeKey:
-			l = launcher.ChromeProfile{
-				BrowserType: browser.EdgeKey,
-
-				ExecutablePath: browserPath,
-				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "3"), // held over for backwards compatibility, "3" indicates Edge profiles
-			}
-		case browser.ChromiumKey:
-			l = launcher.ChromeProfile{
-				BrowserType: browser.ChromiumKey,
-
-				ExecutablePath: browserPath,
-				UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "4"), // held over for backwards compatibility, "4" indicates Chromium profiles
 			}
 		case browser.FirefoxKey, browser.WaterfoxKey:
 			l = launcher.Firefox{

--- a/pkg/granted/console.go
+++ b/pkg/granted/console.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
-	"path"
 
 	"github.com/common-fate/clio"
 	"github.com/common-fate/clio/clierr"
@@ -63,11 +62,6 @@ var ConsoleCommand = cli.Command{
 			return nil
 		}
 
-		grantedFolder, err := config.GrantedConfigFolder()
-		if err != nil {
-			return err
-		}
-
 		var l assume.Launcher
 		if cfg.CustomBrowserPath == "" && cfg.DefaultBrowser != "" {
 			l = launcher.Open{}
@@ -78,22 +72,18 @@ var ConsoleCommand = cli.Command{
 			case browser.ChromeKey:
 				l = launcher.ChromeProfile{
 					ExecutablePath: cfg.CustomBrowserPath,
-					UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "1"), // held over for backwards compatibility, "1" indicates Chrome profiles
 				}
 			case browser.BraveKey:
 				l = launcher.ChromeProfile{
 					ExecutablePath: cfg.CustomBrowserPath,
-					UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "2"), // held over for backwards compatibility, "2" indicates Brave profiles
 				}
 			case browser.EdgeKey:
 				l = launcher.ChromeProfile{
 					ExecutablePath: cfg.CustomBrowserPath,
-					UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "3"), // held over for backwards compatibility, "3" indicates Edge profiles
 				}
 			case browser.ChromiumKey:
 				l = launcher.ChromeProfile{
 					ExecutablePath: cfg.CustomBrowserPath,
-					UserDataPath:   path.Join(grantedFolder, "chromium-profiles", "4"), // held over for backwards compatibility, "4" indicates Chromium profiles
 				}
 			case browser.FirefoxKey:
 				l = launcher.Firefox{

--- a/pkg/launcher/chrome_profile.go
+++ b/pkg/launcher/chrome_profile.go
@@ -2,32 +2,31 @@ package launcher
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path"
 	"runtime"
+	"strings"
 
 	"github.com/common-fate/clio"
 	"github.com/common-fate/granted/pkg/browser"
-	"github.com/pkg/errors"
 )
 
 type ChromeProfile struct {
 	// ExecutablePath is the path to the Chrome binary on the system.
 	ExecutablePath string
-	// UserDataPath is the path to the Chrome user data directory,
-	// which we override to put Granted profiles in a specific folder
-	// for easy management.
-	UserDataPath string
 
 	BrowserType string
 }
 
 func (l ChromeProfile) LaunchCommand(url string, profile string) []string {
-	profileName := FindBrowserProfile(profile, l.BrowserType)
+	// Chrome profiles can't contain slashes
+	profileName := strings.ReplaceAll(profile, "/", "-")
+
+	setProfileName(profileName, l.BrowserType)
 
 	return []string{
 		l.ExecutablePath,
-		// "--user-data-dir=" + l.UserDataPath,
 		"--profile-directory=" + profileName,
 		"--no-first-run",
 		"--no-default-browser-check",
@@ -51,43 +50,77 @@ var ChromiumPathMac = "Library/Application Support/Chromium/Local State"
 var ChromiumPathLinux = ".config/chromium/Local State"
 var ChromiumPathWindows = `AppData\Local\Chromium\User Data/Local State`
 
-// FindBrowserProfile will try to read profile data from local state path.
-// will fallback to provided profile value.
-func FindBrowserProfile(profile string, browserType string) string {
-	// work out which chromium browser we are using
+// setProfileName attempts to rename an existing Chrome profile from 'Person 2', 'Person 3', etc
+// into the name of the AWS profile that we're launching.
+//
+// The first time a particular profile is launched, this function will do nothing as the Chrome profile
+// does not yet exist in the Local State file.
+// However, subsequent launches will cause the profile to be correctly renamed.
+func setProfileName(profile string, browserType string) {
 	stateFile, err := getLocalStatePath(browserType)
 	if err != nil {
 		clio.Debugf("unable to find localstate path with err %s", err)
-		return profile
+		return
 	}
 
 	//read the state file
 	data, err := os.ReadFile(stateFile)
 	if err != nil {
 		clio.Debugf("unable to read local state file with err %s", err)
-		return profile
+		return
 	}
 
 	//the Local State json blob is a bunch of map[string]interfaces which makes it difficult to unmarshal
-	var f map[string]interface{}
+	var f map[string]any
 	err = json.Unmarshal(data, &f)
 	if err != nil {
 		clio.Debugf("unable to unmarshal local state file with err %s", err)
-		return profile
+		return
 	}
 
 	//grab the profiles out from the json blob
-	profiles := f["profile"].(map[string]interface{})
-	//can this be done cleaner with a conversion into a struct?
-	for profileName, profileObj := range profiles["info_cache"].(map[string]interface{}) {
-		//if the profile name is the same as the profile name we are assuming then we want to use the same profile
-		if profileObj.(map[string]interface{})["name"] == profile {
-			return profileName
-		}
-
+	profiles, ok := f["profile"].(map[string]any)
+	if !ok {
+		clio.Debugf("could not cast profiles to map[string]any")
+		return
 	}
 
-	return profile
+	infoCache, ok := profiles["info_cache"].(map[string]any)
+	if !ok {
+		clio.Debugf("could not cast info_cache to map[string]any")
+		return
+	}
+
+	profileObj, ok := infoCache[profile]
+	if !ok {
+		clio.Debugf("could not find profile %s in info_cache", profile)
+		return
+	}
+
+	profileContents, ok := profileObj.(map[string]any)
+	if !ok {
+		clio.Debugf("could not cast profile object to map[string]any")
+		return
+	}
+
+	if profileContents["name"] != profile {
+		clio.Debugf("updating profile name from %s to %s", profileContents["name"], profile)
+		profileContents["name"] = profile
+	}
+
+	file, err := os.OpenFile(stateFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		clio.Debugf("could not open Local State file: %s", err)
+		return
+	}
+
+	defer file.Close()
+	encoder := json.NewEncoder(file)
+	err = encoder.Encode(f)
+	if err != nil {
+		clio.Debugf("encode error to Local State file: %s", err)
+		return
+	}
 }
 
 func getLocalStatePath(browserType string) (stateFile string, err error) {


### PR DESCRIPTION
### What changed?
- AWS profiles containing slashes like `my/profile` now correctly open in Chrome and Chromium-based browsers
- Automatically renames Chrome profiles from 'Person 2', 'Person 3', etc to the name of the AWS profile

(note: the automatic renaming happens the second time that Chrome is launched - on the initial launch you'll still see 'Person 2')

Also removes UserDataPath from the ChromeLauncher struct as it is unused.

### Why?
- Fixes #524 


### How did you test it?
- Tested locally with Chrome on MacOS to verify that profiles with slashes now open, and profiles are automatically renamed

### Potential risks
- People with existing Chrome profiles held over from an earlier version of Chrome may have profiles recreated. I think this is unlikely to occur, and if it does, you can edit the Chrome `Local State` file to adjust the IDs of your profiles.

### Is patch release candidate?
No - automatic renaming of Chrome profiles should be a minor change

### Link to relevant docs PRs