### PR TITLE
add --chain flag to assume another role inline

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -303,7 +303,7 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 	}
-	if assumeFlags.String("chain-assume-role") != "" {
+	if assumeFlags.String("chain") != "" {
 		if assumeFlags.Bool("sso") {
 			return errors.New("chain-assume-role flag is not currently compatible with the sso flag, let us know on github if you would like this feature")
 		}
@@ -311,8 +311,8 @@ func AssumeCommand(c *cli.Context) error {
 		chainProfile := awsconfig.SharedConfig{
 			Source:                           &profile.AWSConfig,
 			SourceProfileName:                profile.Name,
-			RoleARN:                          assumeFlags.String("chain-assume-role"),
-			Profile:                          assumeFlags.String("chain-assume-role"),
+			RoleARN:                          assumeFlags.String("chain"),
+			Profile:                          assumeFlags.String("chain"),
 			EnableEndpointDiscovery:          profile.AWSConfig.EnableEndpointDiscovery,
 			S3UseARNRegion:                   profile.AWSConfig.S3UseARNRegion,
 			EC2IMDSEndpointMode:              profile.AWSConfig.EC2IMDSEndpointMode,

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -303,6 +303,9 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 	}
+
+	// inline role Chaining works by creating a mock config section/profile configured with the parent as it's source
+	// this means that existing assumers can be used to handle the base profile credential sourcing and assuming
 	if assumeFlags.String("chain") != "" {
 		// create a new aws shared config profile by copying most of the default config from the source profile
 		chainProfile := awsconfig.SharedConfig{
@@ -330,7 +333,7 @@ func AssumeCommand(c *cli.Context) error {
 		profile = &cfaws.Profile{
 			// empty section as a placeholder
 			RawConfig:   emptySection,
-			Name:        "Chain",
+			Name:        assumeFlags.String("chain"),
 			File:        profile.File,
 			ProfileType: profile.ProfileType,
 			Parents:     append(profile.Parents, profile),

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -304,9 +304,6 @@ func AssumeCommand(c *cli.Context) error {
 		}
 	}
 	if assumeFlags.String("chain") != "" {
-		if assumeFlags.Bool("sso") {
-			return errors.New("chain-assume-role flag is not currently compatible with the sso flag, let us know on github if you would like this feature")
-		}
 		// create a new aws shared config profile by copying most of the default config from the source profile
 		chainProfile := awsconfig.SharedConfig{
 			Source:                           &profile.AWSConfig,

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -49,6 +49,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "save-to", Usage: "Use this in conjunction with --sso, the profile name to save the role to in your AWS config file"},
 		&cli.BoolFlag{Name: "export-all-env-vars", Aliases: []string{"x"}, Usage: "Exports all available credentials to the terminal when used with a profile configured for credential-process. Without this flag, only the AWS_PROFILE will be configured"},
 		&cli.StringFlag{Name: "aws-config-file"},
+		&cli.StringFlag{Name: "chain", Usage: "Assume a given role ARN using the profile selected"},
 	}
 }
 


### PR DESCRIPTION
### What changed?
Fixes #506 

Also fixes a bug with --exec where existing AWS_ env vars are passed through from the callers environment, this can mean that AWS_PROFILE may be set and not overwritten

I now strip the AWS_PROFILE env var from the pass through env 

### Why?


### How did you test it?

Usage can be either with --exec or just a regular profile
`assume base-profile --chain arn:aws:iam::12345678912:role/aws-josh --exec -- aws sts get-caller-identity`
`assume base-profile --chain arn:aws:iam::12345678912:role/aws-josh`

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs