### PR TITLE
Use AWS SDK to load sso-session sections enable multiple sso users

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -170,10 +170,9 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 	if len(c.Parents) > 0 {
 		rootProfile = c.Parents[0]
 	}
-
-	ssoTokenKey := rootProfile.AWSConfig.SSOStartURL
+	ssoTokenKey := rootProfile.AWSConfig.SSOStartURL + c.AWSConfig.SSOSessionName
 	// if the profile has an sso user configured then suffix the sso token storage key to ensure unique logins
-	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage(c.SSOUser)
+	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
 	cachedToken := secureSSOTokenStorage.GetValidSSOToken(ssoTokenKey)
 	var accessToken *string
 

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -172,8 +172,8 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 	}
 
 	ssoTokenKey := rootProfile.AWSConfig.SSOStartURL
-
-	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
+	// if the profile has an sso user configured then suffix the sso token storage key to ensure unique logins
+	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage(c.SSOUser)
 	cachedToken := secureSSOTokenStorage.GetValidSSOToken(ssoTokenKey)
 	var accessToken *string
 

--- a/pkg/cfaws/granted_config.go
+++ b/pkg/cfaws/granted_config.go
@@ -28,10 +28,11 @@ func ParseGrantedSSOProfile(ctx context.Context, profile *Profile) (*config.Shar
 	cfg.SSOAccountID = item.Value()
 	item, err = profile.RawConfig.GetKey("granted_sso_region")
 	if err != nil {
-		if profile.SSOSession != nil && profile.SSOSession.SSORegion != "" {
-			cfg.SSORegion = profile.SSOSession.SSORegion
-		} else {
+		// the region may have been populated by an sso session section by the aws SDK
+		if cfg.SSOSession.SSORegion == "" {
 			return nil, err
+		} else {
+			cfg.SSORegion = cfg.SSOSession.SSORegion
 		}
 	} else {
 		cfg.SSORegion = item.Value()
@@ -45,10 +46,10 @@ func ParseGrantedSSOProfile(ctx context.Context, profile *Profile) (*config.Shar
 
 	item, err = profile.RawConfig.GetKey("granted_sso_start_url")
 	if err != nil {
-		if profile.SSOSession != nil && profile.SSOSession.SSORegion != "" {
-			cfg.SSOStartURL = profile.SSOSession.SSOStartURL
-		} else {
+		if cfg.SSOSession.SSOStartURL == "" {
 			return nil, err
+		} else {
+			cfg.SSOStartURL = cfg.SSOSession.SSOStartURL
 		}
 	} else {
 		cfg.SSOStartURL = item.Value()
@@ -87,11 +88,11 @@ func IsValidGrantedProfile(profile *Profile) error {
 			return fmt.Errorf("invalid aws config for granted login. '%s' field must be provided", value)
 		}
 	}
-	if profile.SSOSession != nil {
-		if profile.SSOSession.SSORegion == "" && !profile.RawConfig.HasKey("granted_sso_region") {
+	if profile.AWSConfig.SSOSession != nil {
+		if profile.AWSConfig.SSOSession.SSORegion == "" && !profile.RawConfig.HasKey("granted_sso_region") {
 			return fmt.Errorf("invalid aws config for granted login. '%s' field must be provided", "granted_sso_region")
 		}
-		if profile.SSOSession.SSOStartURL == "" && !profile.RawConfig.HasKey("granted_sso_start_url") {
+		if profile.AWSConfig.SSOSession.SSOStartURL == "" && !profile.RawConfig.HasKey("granted_sso_start_url") {
 			return fmt.Errorf("invalid aws config for granted login. '%s' field must be provided", "granted_sso_start_url")
 		}
 	}

--- a/pkg/cfaws/granted_config_test.go
+++ b/pkg/cfaws/granted_config_test.go
@@ -3,7 +3,6 @@ package cfaws
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"gopkg.in/ini.v1"
 )
 
@@ -42,50 +41,6 @@ func TestValidateCredentialProcess(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-		})
-	}
-}
-
-// tests support for aws sso-session configuration
-func TestSSOSessionSupport(t *testing.T) {
-	tests := []struct {
-		name           string
-		file           string
-		profileName    string
-		wantSSOSession *SSOSession
-	}{
-		{
-			name: "valid argument with correct profile name",
-			file: `[profile testing]
-sso_session = testing-sso
-sso_account_id     = 12345678912
-sso_role_name      = Test
-region             = ap-southeast-2
-
-[sso-session testing-sso]
-sso_start_url  = https://d-12345678910.awsapps.com/start
-sso_region     = ap-southeast-2
-`,
-			profileName: "testing",
-			wantSSOSession: &SSOSession{
-				SSORegion:   "ap-southeast-2",
-				SSOStartURL: "https://d-12345678910.awsapps.com/start",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			l := loader{fileString: tt.file}
-			profiles, err := loadProfiles(l, nooploader{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			profile, err := profiles.Profile(tt.profileName)
-			if err != nil {
-				t.Fatal(err)
-			}
-			assert.Equal(t, tt.wantSSOSession, profile.SSOSession)
 		})
 	}
 }

--- a/pkg/cfaws/granted_config_test.go
+++ b/pkg/cfaws/granted_config_test.go
@@ -2,8 +2,6 @@ package cfaws
 
 import (
 	"testing"
-
-	"gopkg.in/ini.v1"
 )
 
 func TestValidateCredentialProcess(t *testing.T) {
@@ -43,25 +41,4 @@ func TestValidateCredentialProcess(t *testing.T) {
 			}
 		})
 	}
-}
-
-type loader struct {
-	fileString string
-}
-
-func (l loader) Path() string { return "" }
-func (l loader) Load() (*ini.File, error) {
-	testConfigFile, err := ini.LoadSources(ini.LoadOptions{}, []byte(l.fileString))
-	if err != nil {
-		return nil, err
-	}
-	return testConfigFile, nil
-}
-
-type nooploader struct {
-}
-
-func (l nooploader) Path() string { return "" }
-func (l nooploader) Load() (*ini.File, error) {
-	return ini.Empty(), nil
 }

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -51,6 +51,8 @@ type Profile struct {
 
 	// AWS SDK doesn't support sso_session yet so we check for it manually
 	SSOSession *SSOSession
+	// Optional username to distinguish SSO logins when multiple AWS users are used on the same machine
+	SSOUser string
 }
 
 var ErrProfileNotInitialised error = errors.New("profile not initialised")
@@ -254,6 +256,7 @@ func (p *Profiles) loadConfigFile(loader ConfigFileLoader) error {
 				name := strings.TrimPrefix(section.Name(), "profile ")
 				sectionPtr := section
 				profile := &Profile{RawConfig: sectionPtr, Name: name, File: loader.Path()}
+				profile.SSOUser = profile.CustomGrantedProperty("sso_user")
 				if section.HasKey("sso_session") {
 					key, _ := section.GetKey("sso_session")
 					ssoSession, ok := ssoSessions[key.Value()]

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -28,11 +28,6 @@ type ConfigOpts struct {
 	MFATokenCode               string
 }
 
-type SSOSession struct {
-	SSORegion   string
-	SSOStartURL string
-}
-
 type Profile struct {
 	// allows access to the raw values from the file
 	RawConfig *ini.Section
@@ -48,11 +43,6 @@ type Profile struct {
 	Initialised                    bool
 	LoadingError                   error
 	HasSecureStorageIAMCredentials bool
-
-	// AWS SDK doesn't support sso_session yet so we check for it manually
-	SSOSession *SSOSession
-	// Optional username to distinguish SSO logins when multiple AWS users are used on the same machine
-	SSOUser string
 }
 
 var ErrProfileNotInitialised error = errors.New("profile not initialised")
@@ -65,27 +55,6 @@ type Profiles struct {
 	profiles     map[string]*Profile
 }
 
-func LoadSSOSessions(configFile *ini.File) (map[string]SSOSession, error) {
-	sessions := make(map[string]SSOSession)
-
-	// Iterate through the config sections
-	for _, section := range configFile.Sections() {
-		// the ini package adds an extra section called DEFAULT, but this is different to the AWS standard of 'default' so we ignore it and only look at 'default'
-		if strings.HasPrefix(section.Name(), "sso-session ") {
-			session := SSOSession{}
-			regionKey, err := section.GetKey("sso_region")
-			if err == nil {
-				session.SSORegion = regionKey.Value()
-			}
-			startURLKey, err := section.GetKey("sso_start_url")
-			if err == nil {
-				session.SSOStartURL = startURLKey.Value()
-			}
-			sessions[strings.TrimPrefix(section.Name(), "sso-session ")] = session
-		}
-	}
-	return sessions, nil
-}
 func (p *Profiles) HasProfile(profile string) bool {
 	_, ok := p.profiles[profile]
 	return ok
@@ -243,10 +212,7 @@ func (p *Profiles) loadConfigFile(loader ConfigFileLoader) error {
 	if err != nil {
 		return err
 	}
-	ssoSessions, err := LoadSSOSessions(configFile)
-	if err != nil {
-		return err
-	}
+
 	// Iterate through the config sections
 	for _, section := range configFile.Sections() {
 		// the ini package adds an extra section called DEFAULT, but this is different to the AWS standard of 'default' so we ignore it an only look at 'default'
@@ -256,16 +222,6 @@ func (p *Profiles) loadConfigFile(loader ConfigFileLoader) error {
 				name := strings.TrimPrefix(section.Name(), "profile ")
 				sectionPtr := section
 				profile := &Profile{RawConfig: sectionPtr, Name: name, File: loader.Path()}
-				profile.SSOUser = profile.CustomGrantedProperty("sso_user")
-				if section.HasKey("sso_session") {
-					key, _ := section.GetKey("sso_session")
-					ssoSession, ok := ssoSessions[key.Value()]
-					if !ok {
-						clio.Errorf("failed to load config profile %s because it has an 'sso_session = %s' section but the [sso-session %s] section was not found", name, key.Value(), key.Value())
-						continue
-					}
-					profile.SSOSession = &ssoSession
-				}
 				p.ProfileNames = append(p.ProfileNames, name)
 				p.profiles[name] = profile
 			}
@@ -447,15 +403,6 @@ func (p *Profile) init(ctx context.Context, profiles *Profiles, depth int) error
 			return err
 		}
 
-		// set the sso session if it exists and not overridden on the profile
-		if p.SSOSession != nil {
-			if cfg.SSOStartURL == "" {
-				cfg.SSOStartURL = p.SSOSession.SSOStartURL
-			}
-			if cfg.SSORegion == "" {
-				cfg.SSORegion = p.SSOSession.SSORegion
-			}
-		}
 		p.AWSConfig = cfg
 
 		if depth < 10 {

--- a/pkg/securestorage/sso_token_storage.go
+++ b/pkg/securestorage/sso_token_storage.go
@@ -1,7 +1,6 @@
 package securestorage
 
 import (
-	"strings"
 	"time"
 
 	"github.com/common-fate/clio"
@@ -12,10 +11,10 @@ type SSOTokensSecureStorage struct {
 	SecureStorage SecureStorage
 }
 
-func NewSecureSSOTokenStorage(suffixes ...string) SSOTokensSecureStorage {
+func NewSecureSSOTokenStorage() SSOTokensSecureStorage {
 	return SSOTokensSecureStorage{
 		SecureStorage: SecureStorage{
-			StorageSuffix: "aws-sso-tokens" + strings.Join(suffixes, "-"),
+			StorageSuffix: "aws-sso-tokens",
 		},
 	}
 }

--- a/pkg/securestorage/sso_token_storage.go
+++ b/pkg/securestorage/sso_token_storage.go
@@ -1,6 +1,7 @@
 package securestorage
 
 import (
+	"strings"
 	"time"
 
 	"github.com/common-fate/clio"
@@ -11,10 +12,10 @@ type SSOTokensSecureStorage struct {
 	SecureStorage SecureStorage
 }
 
-func NewSecureSSOTokenStorage() SSOTokensSecureStorage {
+func NewSecureSSOTokenStorage(suffixes ...string) SSOTokensSecureStorage {
 	return SSOTokensSecureStorage{
 		SecureStorage: SecureStorage{
-			StorageSuffix: "aws-sso-tokens",
+			StorageSuffix: "aws-sso-tokens" + strings.Join(suffixes, "-"),
 		},
 	}
 }


### PR DESCRIPTION
### What changed?
In order to support uses who login with multiple SSO users we needed to update our implementation of sso-session section support.

When it was first added, the AWS sdk did not yet have support for it, this has since been added so code related to loading those sections has been updated/removed in favour of the sdk.


### Why?


### How did you test it?

The following config is an example of how you can have 2 profiles that login to the same account with a different aws user by using an sso-session section for one of them.

You can also use an sso section for both your users and their config can be the same, they just need different names
```
make cli
dassume profile-1
dassume profile-2
```

```
[sso-session user-1]
sso_start_url  = https://example.awsapps.com/start
sso_region     = ap-southeast-2

[profile profile-1]
sso_session = user-1
sso_account_id = 12345678912
sso_role_name  = AWSAdministratorAccess
region                 = ap-southeast-2

[profile profile-2]
sso_start_url  = https://example.awsapps.com/start
sso_region     = ap-southeast-2
sso_account_id = 12345678912
sso_role_name  = AWSAdministratorAccess
region                 = ap-southeast-2
```
### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs