### PR TITLE
fix AWS SSO polling config

### DIFF
--- a/pkg/cfaws/assume_aws_sso_test.go
+++ b/pkg/cfaws/assume_aws_sso_test.go
@@ -1,0 +1,25 @@
+package cfaws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPollingConfig(t *testing.T) {
+	in := ssooidc.StartDeviceAuthorizationOutput{
+		ExpiresIn: 120, // seconds
+		Interval:  5,   // seconds
+	}
+
+	got := getPollingConfig(&in)
+
+	want := PollingConfig{
+		TimeoutAfter:  2 * time.Minute,
+		CheckInterval: 5 * time.Second,
+	}
+
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
### What changed?
Polling config for OIDC Device Code flow is now sourced from the AWS SSO rather than being hardcoded

### Why?
Fixes #491 

### How did you test it?
Unit test verifies the parsing of the device auth response
