### PR TITLE
fix panic: runtime error

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -502,7 +502,7 @@ func AssumeCommand(c *cli.Context) error {
 			return RunExecCommandWithCreds(creds, region, execCfg.Cmd, execCfg.Args...)
 		}
 
-		if profile.RawConfig.HasKey("credential_process") && assumeFlags.Bool("export-all-env-vars") {
+		if profile.RawConfig != nil && profile.RawConfig.HasKey("credential_process") && assumeFlags.Bool("export-all-env-vars") {
 			canExpire := "false"
 			if creds.CanExpire {
 				canExpire = "true"
@@ -519,7 +519,7 @@ func AssumeCommand(c *cli.Context) error {
 
 		// If the profile uses "credential_process" to source credential externally then do not set accessKeyId, secretAccessKey, sessionToken
 		// so that aws cli automatically refreshes credential when they expire.
-		if profile.RawConfig.HasKey("credential_process") {
+		if profile.RawConfig != nil && profile.RawConfig.HasKey("credential_process") {
 			output := PrepareStringsForShellScript([]string{"", "", "", profile.Name, region, "", "true", "", "", "", ""})
 			fmt.Printf("GrantedAssume %s %s %s %s %s %s %s %s %s %s %s", output...)
 


### PR DESCRIPTION
### What changed?
Added nil check for profile.RawConfig in assume.go

### Why?
it was causing a panic: runtime error when you run 
`assume --sso --sso-start-url ... --sso-region ... --account-id ... --role-name ...`


### How did you test it?
locally, the error got fixed. I was able to replicate it by using the format above

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs