### PR TITLE
Added DefaultExportAllEnvVar config

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -502,7 +502,7 @@ func AssumeCommand(c *cli.Context) error {
 			return RunExecCommandWithCreds(creds, region, execCfg.Cmd, execCfg.Args...)
 		}
 
-		if profile.RawConfig.HasKey("credential_process") && (assumeFlags.Bool("export-all-env-vars") || cfg.DefaultExportAllEnvVar == true) {
+		if profile.RawConfig.HasKey("credential_process") && (assumeFlags.Bool("export-all-env-vars") || cfg.DefaultExportAllEnvVar) {
 			canExpire := "false"
 			if creds.CanExpire {
 				canExpire = "true"

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -502,7 +502,7 @@ func AssumeCommand(c *cli.Context) error {
 			return RunExecCommandWithCreds(creds, region, execCfg.Cmd, execCfg.Args...)
 		}
 
-		if profile.RawConfig.HasKey("credential_process") && assumeFlags.Bool("export-all-env-vars") {
+		if profile.RawConfig.HasKey("credential_process") && (assumeFlags.Bool("export-all-env-vars") || cfg.DefaultExportAllEnvVar == true) {
 			canExpire := "false"
 			if creds.CanExpire {
 				canExpire = "true"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,10 @@ type Config struct {
 	DisableUsageTips bool `toml:",omitempty"`
 	// Set this to true to disable credential caching feature when using credential process
 	DisableCredentialProcessCache bool `toml:",omitempty"`
+
+	// Set this to true to set `--export-all-env-vars` as default
+	DefaultExportAllEnvVar bool `toml:",omitempty"`
+
 	// deprecated in favor of ProfileRegistry
 	ProfileRegistryURLS []string `toml:",omitempty"`
 	ProfileRegistry     struct {


### PR DESCRIPTION
### What changed?
Added DefaultExportAllEnvVar config to set `--export-all-env-vars` as default

### Why?
Instead of using the flag all the time 

### How did you test it?
Locally

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs