### PR TITLE
Added ExportCredsToAWS config

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -481,7 +481,7 @@ func AssumeCommand(c *cli.Context) error {
 			clio.Success("Exported credentials to .env file successfully")
 		}
 
-		if assumeFlags.Bool("export") {
+		if assumeFlags.Bool("export") || cfg.ExportCredsToAWS {
 			err = cfaws.ExportCredsToProfile(profile.Name, creds)
 			if err != nil {
 				return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,9 @@ type Config struct {
 	// AccessRequestURL is a Granted Approvals URL that users can visit
 	// to request access, in the event that we receive a ForbiddenException
 	// denying access to assume a particular role.
+	//Set this to true to set `--export` to ~/.aws/credentials as default
+	ExportCredsToAWS bool `toml:",omitempty"`
+
 	AccessRequestURL string `toml:",omitempty"`
 
 	CommonFateDefaultSSOStartURL string `toml:",omitempty"`


### PR DESCRIPTION
### What changed?
Added ExportCredsToAWS to set `--export` to ~/.aws/credentials as default

### Why?
Make it easier for users 

### How did you test it?
Locally

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs