### PR TITLE
Output-sso-expiry-in-JSON

### DIFF
--- a/pkg/granted/tokens.go
+++ b/pkg/granted/tokens.go
@@ -133,7 +133,7 @@ var TokenExpiryCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		clio.Logf(string(jsonData))
+		fmt.Println(string(jsonData))
 
 		return nil
 	},


### PR DESCRIPTION
### What changed?
`granted sso-tokens expiry` returns a JSON output 

### Why?
It is easier to programmatically check if the token is expired 

### How did you test it?
Output of `dgranted sso-tokens expiry`. Also checked that you can run commands like `dgranted sso-tokens expiry | jq -r '[.[] | select(.is_expired == true)]'`

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs