### PR TITLE
add aos (Amazon OpenSearch) to ServiceMap

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -5,6 +5,7 @@ package console
 var ServiceMap = map[string]string{
 	"":               "console",
 	"acm":		  "acm",
+	"aos":            "aos",
 	"athena":         "athena",
 	"appsync":        "appsync",
 	"c9":             "cloud9",


### PR DESCRIPTION
### What changed?
ServiceMap addition

### Why?
Because I am getting a warning when using -s aos, but it works.


### How did you test it?
Code was not tested, but using -s aos works.

### Potential risks
None known.

### Is patch release candidate?
Not known.

### Link to relevant docs PRs