### PR TITLE
fix(firefox_dev): fix granted containers for Firefox Dev Edition

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -416,7 +416,7 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 
-		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.WaterfoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey {
+		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.WaterfoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey || cfg.DefaultBrowser == browser.FirefoxDevEditionKey {
 			// tranform the URL into the Firefox Tab Container format.
 			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", containerProfile, url.QueryEscape(consoleURL), profile.CustomGrantedProperty("color"), profile.CustomGrantedProperty("icon"))
 		}

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -241,7 +241,7 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 			browserPath = customBrowserPath
 		}
 
-		if browserKey == FirefoxKey || browserKey == WaterfoxKey {
+		if browserKey == FirefoxKey || browserKey == WaterfoxKey || browserKey == FirefoxDevEditionKey {
 			err := RunFirefoxExtensionPrompts(browserPath, browserName)
 			if err != nil {
 				return err

--- a/pkg/launcher/firefox_dev_edition.go
+++ b/pkg/launcher/firefox_dev_edition.go
@@ -12,4 +12,4 @@ func (l FirefoxDevEdition) LaunchCommand(url string, profile string) []string {
 	}
 }
 
-func (l FirefoxDevEdition) UseForkProcess() bool { return false }
+func (l FirefoxDevEdition) UseForkProcess() bool { return true }


### PR DESCRIPTION
### What changed?

Allow assume to use the granted containers extension on Firefox Dev Edition

### Why?

Looks like no-one added support for this yet

### How did you test it?

1. Build granted
2. Set browser to Firefox Dev Edition (`dgranted browser set` and select Firefox Dev Edition)
3. Assume a profile + console (`dassume -c <some-profile>`)
4. Granted opens Firefox Dev Edition with containers enabled

### Potential risks

I don't see any

### Is patch release candidate?

This is a patch candidate, just added support for a feature that was already there for Firefox

### Link to relevant docs PRs