### PR TITLE
Ensure proper initialization of profiles with source_profile

### DIFF
--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -311,8 +311,19 @@ func (p *Profiles) LoadInitialisedProfile(ctx context.Context, profile string) (
 		return nil, err
 	}
 
-	// For config that has 'granted' prefix we need to convert this to AWS config fields
-	// aws configuration
+	// Initialize the profile, which will also handle source_profile chains
+	err = pr.init(ctx, p, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Debug output to log the profile's name and its source_profile after initialization
+	clio.Debugw("Loading profile",
+		"profileName", pr.Name,
+		"sourceProfile", pr.AWSConfig.SourceProfileName,
+	)
+
+	// Check for 'granted' prefix in the profile configuration
 	if hasGrantedSSOPrefix(pr.RawConfig) {
 		awsConfig, err := ParseGrantedSSOProfile(ctx, pr)
 		if err != nil {
@@ -320,43 +331,46 @@ func (p *Profiles) LoadInitialisedProfile(ctx context.Context, profile string) (
 		}
 		pr.AWSConfig = *awsConfig
 		pr.Initialised = true
-
-		as := assumers
-		for _, a := range as {
-			if a.ProfileMatchesType(pr.RawConfig, pr.AWSConfig) {
-				pr.ProfileType = a.Type()
-				break
-			} else {
-				pr.ProfileType = "AWS_SSO"
-			}
-		}
-
+		pr.ProfileType = "AWS_SSO"
 		return pr, nil
-	} else {
-		for _, v := range pr.RawConfig.Keys() {
-			if v.Name() == "credential_process" && strings.HasPrefix(v.Value(), build.GrantedBinaryName()) {
-				awsConfig, err := config.LoadSharedConfigProfile(ctx, pr.Name, func(lsco *config.LoadSharedConfigOptions) { lsco.ConfigFiles = []string{pr.File} })
-				if err != nil {
-					return nil, err
-				}
+	}
 
-				pr.AWSConfig = awsConfig
-				pr.AWSConfig.CredentialProcess = ""
-				pr.Initialised = true
-				pr.ProfileType = "AWS_IAM"
-				pr.HasSecureStorageIAMCredentials = true
-				return pr, nil
+	// Check for 'credential_process' key in the profile configuration
+	for _, v := range pr.RawConfig.Keys() {
+		if v.Name() == "credential_process" && strings.HasPrefix(v.Value(), build.GrantedBinaryName()) {
+			awsConfig, err := config.LoadSharedConfigProfile(ctx, pr.Name, func(lsco *config.LoadSharedConfigOptions) { lsco.ConfigFiles = []string{pr.File} })
+			if err != nil {
+				return nil, err
 			}
+
+			pr.AWSConfig = awsConfig
+			pr.AWSConfig.CredentialProcess = ""
+			pr.Initialised = true
+			pr.ProfileType = "AWS_IAM"
+			pr.HasSecureStorageIAMCredentials = true
+			return pr, nil
 		}
 	}
 
-	// default initializaton flow
-	err = pr.init(ctx, p, 0)
-	if err != nil {
-		return nil, err
+	// Determine the profile type based on the initialized profile's keys
+	// This should be done after the profile is fully initialized to ensure we are checking the correct keys
+	foundAssumer := false
+	for _, a := range assumers {
+		if a.ProfileMatchesType(pr.RawConfig, pr.AWSConfig) {
+			pr.ProfileType = a.Type()
+			foundAssumer = true
+			break
+		}
 	}
+
+	// If no specific assumer matched, default to AWS_SSO
+	if !foundAssumer {
+		pr.ProfileType = "AWS_SSO"
+	}
+
 	return pr, nil
 }
+
 
 // Initialize profile's AWS config by fetching credentials from plain-text-SSO-token
 // located at default cache directory.


### PR DESCRIPTION


### What changed?
Adjusts the LoadInitialisedProfile function to consistently initialise profiles, including those with a 'granted' prefix or a 'credential_process' key. 

### Why?
The initialisation now handles source_profile chains before any profile-specific logic is applied. 

### How did you test it?
Tested on both source_profile and non source_profile configurations. aws-azure-login was used for the source_profile, and the profile that uses the azure sso profile as the source was also tested. 

### Potential risks
This is my first PR for Go, feedback would be appreciated but also please check through properly! 


### Link to relevant docs PRs
fixes #558