### PR TITLE
fix(fish_alias): fix assume script path for fish alias for brew

### DIFF
--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -33,7 +33,7 @@ func init() {
 const fishAlias = `alias assume="source /usr/local/bin/assume.fish"`
 
 const defaultAlias = `alias assume=". assume"`
-const fishAliasBrew = `alias assume="source (brew --prefix)/assume.fish"`
+const fishAliasBrew = `alias assume="source (brew --prefix)/bin/assume.fish"`
 
 const devFishAlias = `alias dassume="source /usr/local/bin/dassume.fish"`
 const devDefaultAlias = `alias dassume=". dassume"`


### PR DESCRIPTION
### What changed?

`fishAliasBrew` value updated to match `assume.fish` file path.

### Why?

The path of the file `assume.fish` was prefixed by `brew --profile` which resolve to `/opt/homebrew` but the script is stored in `/opt/homebrew/bin/assume.fish`

### How did you test it?

Updated the path on my fish config locally when I get this error:
```
$ assume
source: Error encountered while sourcing file '/opt/homebrew/assume.fish':
source: No such file or directory
```
And checking
```
$ ls /opt/homebrew/bin/ | grep assume.fish
assume.fish -> ../Cellar/granted/0.20.3/bin/assume.fish
```
