### PR TITLE
🐛 Fix SSO token lookup keys

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -175,7 +175,7 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
 	cachedToken := secureSSOTokenStorage.GetValidSSOToken(ssoTokenKey)
 	// check if profile has a valid plaintext sso access token
-	plainTextToken := GetValidSSOTokenFromPlaintextCache(ssoTokenKey)
+	plainTextToken := GetValidSSOTokenFromPlaintextCache(rootProfile.SSOStartURL())
 
 	// store token to storage to avoid multiple logins
 	if plainTextToken != nil {

--- a/pkg/cfaws/cred-exporter.go
+++ b/pkg/cfaws/cred-exporter.go
@@ -72,7 +72,7 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 // ExportAccessTokenToCache will export access tokens to ~/.aws/sso/cache
 func ExportAccessTokenToCache(profile *Profile) error {
 	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
-	// Find the access token for the SSOStartURL
+	// Find the access token for the SSOStartURL and SSOSessionName
 	tokenKey := profile.AWSConfig.SSOStartURL + profile.AWSConfig.SSOSessionName
 	cachedToken := secureSSOTokenStorage.GetValidSSOToken(tokenKey)
 	ssoPlainTextOut := CreatePlainTextSSO(profile.AWSConfig, cachedToken)

--- a/pkg/cfaws/cred-exporter.go
+++ b/pkg/cfaws/cred-exporter.go
@@ -73,7 +73,8 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 func ExportAccessTokenToCache(profile *Profile) error {
 	secureSSOTokenStorage := securestorage.NewSecureSSOTokenStorage()
 	// Find the access token for the SSOStartURL
-	cachedToken := secureSSOTokenStorage.GetValidSSOToken(profile.AWSConfig.SSOStartURL)
+	tokenKey := profile.AWSConfig.SSOStartURL + profile.AWSConfig.SSOSessionName
+	cachedToken := secureSSOTokenStorage.GetValidSSOToken(tokenKey)
 	ssoPlainTextOut := CreatePlainTextSSO(profile.AWSConfig, cachedToken)
 	err := ssoPlainTextOut.DumpToCacheDirectory()
 


### PR DESCRIPTION
### What changed?
Updated `GetValidSSOToken` to use a combination of `SSOStartURL` and `SSOSessionName` and `GetValidSSOTokenFromPlaintextCache` to use `SSOStartURL` for lookup keys

### Why?
The lookup key for `GetValidSSOToken` has been updated and the code I pushed had the wrong lookup causing panic when trying to export sso as it was finding a `nil` token. Updated `GetValidSSOToken` to use the combination of `SSOStartURL` and `SSOSessionName` to find it properly. Also updated `GetValidSSOTokenFromPlaintextCache` to only use `SSOStartURL` as it's the valid value. Should move to use `SSOSessionName` in the future. Fix for issue #563.

### How did you test it?
```
sudo make clean
sudo make go-binary
sudo make cli
dassume --export-sso-token
```

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs