### PR TITLE
🔧 Add ExportSSOToken config

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -534,7 +534,7 @@ func AssumeCommand(c *cli.Context) error {
 
 		}
 
-		if assumeFlags.Bool("export-sso-token") {
+		if assumeFlags.Bool("export-sso-token") || cfg.ExportSSOToken {
 			err := cfaws.ExportAccessTokenToCache(profile)
 
 			if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	// denying access to assume a particular role.
 	//Set this to true to set `--export` to ~/.aws/credentials as default
 	ExportCredsToAWS bool `toml:",omitempty"`
+	// Set to true to export sso tokens to ~/.aws/sso/cache
+	ExportSSOToken bool `toml:",omitempty"`
 
 	AccessRequestURL string `toml:",omitempty"`
 


### PR DESCRIPTION
### What changed?
Adding `ExportSSOToken` setting so it could be set to true by default without needing to put in `--export-sso-token` on assume.

### Why?
Adding in config so passing in  `--export-sso-token`  flag for assume is no longer necessary

### How did you test it?
```
aws sso logout
dgranted settings set --setting ExportSSOToken --value true
dassume
aws s3 ls --profile test_profile
```

### Potential risks
Ideally [PR](https://github.com/common-fate/granted/pull/565) is addressed first before merging this one in.

### Is patch release candidate?


### Link to relevant docs PRs