### PR TITLE
Fix export lookup values when exporting credentials

### DIFF
--- a/pkg/cfaws/ssotoken.go
+++ b/pkg/cfaws/ssotoken.go
@@ -33,9 +33,12 @@ type SSOPlainTextOut struct {
 // purposes with other AWS tools.
 func CreatePlainTextSSO(awsConfig config.SharedConfig, token *securestorage.SSOToken) *SSOPlainTextOut {
 	ssoRegion := awsConfig.SSORegion
-	ssoStartURL := awsConfig.SSOStartURL
-	if awsConfig.SSOSession != nil {
+	if ssoRegion == "" && awsConfig.SSOSession != nil {
 		ssoRegion = awsConfig.SSOSession.SSORegion
+	}
+
+	ssoStartURL := awsConfig.SSOStartURL
+	if ssoStartURL == "" && awsConfig.SSOSession != nil {
 		ssoStartURL = awsConfig.SSOSession.SSOStartURL
 	}
 

--- a/pkg/cfaws/ssotoken.go
+++ b/pkg/cfaws/ssotoken.go
@@ -32,12 +32,19 @@ type SSOPlainTextOut struct {
 // we'll allow users to export a plaintext token from their keychain for compatibility
 // purposes with other AWS tools.
 func CreatePlainTextSSO(awsConfig config.SharedConfig, token *securestorage.SSOToken) *SSOPlainTextOut {
+	ssoRegion := awsConfig.SSORegion
+	ssoStartURL := awsConfig.SSOStartURL
+	if awsConfig.SSOSession != nil {
+		ssoRegion = awsConfig.SSOSession.SSORegion
+		ssoStartURL = awsConfig.SSOSession.SSOStartURL
+	}
+
 	return &SSOPlainTextOut{
 		AccessToken:    token.AccessToken,
 		ExpiresAt:      token.Expiry.Format(time.RFC3339),
-		Region:         awsConfig.Region,
+		Region:         ssoRegion,
 		SSOSessionName: awsConfig.SSOSessionName,
-		StartUrl:       awsConfig.SSOStartURL,
+		StartUrl:       ssoStartURL,
 	}
 }
 


### PR DESCRIPTION
### What changed?
When `session` is present on the config it should be where we get the `start_url` and `region`. Most configs will not have said config under `profile` if they have a session block. Session block takes priority for the configuration as it's considered as it's connecting profiles together.

Fix for #577

### Why?
Although it's working properly for `awscli` the generated token does not contain `sso_start_url` which could be problematic for other code that relies on that property when looking for a valid config.

### How did you test it?
`dassume --export-sso-token`

cat `~/.aws/sso/cache/<corresponding json>` should give out
```
{
   "accessToken"some_access_token",
   "expiresAt":"2023-12-20T19:31:16+10:00",
   "ssoSessionName":"test-session",
   "startUrl":"https://test.com",
   "region":"ap-southeast-2"
}
```

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs