### PR TITLE
Delete former credentials when rotating (`granted credentials rotate`)

### DIFF
--- a/pkg/granted/credentials.go
+++ b/pkg/granted/credentials.go
@@ -583,6 +583,11 @@ var RotateCredentialsCommand = cli.Command{
 			return err
 		}
 
+		_, err = iamClient.DeleteAccessKey(c.Context, &iam.DeleteAccessKeyInput{AccessKeyId: &t.AccessKeyID})
+		if err != nil {
+			return err
+		}
+
 		clio.Successf("Access Key of '%s' profile has been successfully rotated and updated in secure storage\n", profileName)
 
 		return nil

--- a/pkg/granted/credentials.go
+++ b/pkg/granted/credentials.go
@@ -519,7 +519,10 @@ var ExportCredentialsCommand = cli.Command{
 var RotateCredentialsCommand = cli.Command{
 	Name:  "rotate",
 	Usage: "Generates new access key for the profile in AWS, and updates the profile",
-	Flags: []cli.Flag{&cli.StringFlag{Name: "profile", Usage: "If provided, generates new access key for the specified profile"}},
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "profile", Usage: "If provided, generates new access key for the specified profile"},
+		&cli.BoolFlag{Name: "delete", Usage: "delete the previous active key"},
+	},
 	Action: func(c *cli.Context) error {
 		profileName := c.String("profile")
 
@@ -583,9 +586,11 @@ var RotateCredentialsCommand = cli.Command{
 			return err
 		}
 
-		_, err = iamClient.DeleteAccessKey(c.Context, &iam.DeleteAccessKeyInput{AccessKeyId: &t.AccessKeyID})
-		if err != nil {
-			return err
+		if c.Bool("delete") {
+			_, err = iamClient.DeleteAccessKey(c.Context, &iam.DeleteAccessKeyInput{AccessKeyId: &t.AccessKeyID})
+			if err != nil {
+				return err
+			}
 		}
 
 		clio.Successf("Access Key of '%s' profile has been successfully rotated and updated in secure storage\n", profileName)


### PR DESCRIPTION
### What changed?
Added code to delete old credentials.

### Why?

### How did you test it?
I rotated my own AWS credentials

### Potential risks

### Is patch release candidate?
No

### Link to relevant docs PRs