### PR TITLE
fix: assume --exec with multiple arguments/spaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 )
 
 require (
+	github.com/alessio/shellescape v1.4.2 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/common-fate/iso8601 v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
+github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/aws/aws-sdk-go-v2 v1.17.3/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.17.7/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.22.1 h1:sjnni/AuoTXxHitsIdT0FwmqUuNUuHtufcVDErVFT9U=

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/alessio/shellescape"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/common-fate/awsconfigfile"
@@ -545,7 +546,8 @@ func AssumeCommand(c *cli.Context) error {
 		}
 
 		if execCfg != nil {
-			output := PrepareStringsForShellScript([]string{creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken, "", region, "", "false", "", "", "", "", execCfg.Cmd + " " + strings.Join(execCfg.Args, "")})
+			escapedCmd := shellescape.QuoteCommand(append([]string{execCfg.Cmd}, execCfg.Args...))
+			output := PrepareStringsForShellScript([]string{creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken, "", region, "", "false", "", "", "", "", escapedCmd})
 			fmt.Printf("GrantedExec %s %s %s %s %s %s %s %s %s %s %s %s", output...)
 			return nil
 		}


### PR DESCRIPTION
### What changed?
The output from `goassume` when `--exec` is provided now returns the arguments with proper escaping/splitting to ensure they are evaluated when passed to `sh -c` in the `assume` script.

### Why?
Fixes the use of `assume --exec` when the command has multiple arguments or spaces. This issue was introduced by #549 and this PR resolves #575

### How did you test it?
When directly running `assumego` the final arguments can be seen to be concatenated together incorrectly and the single argument with spaces becomes multiple:
```
$ assumego <profile> --exec -- cmd with multiple 'arguments and spaces'
...None None cmd withmultiplearguments and spaces
```
After the fix the commands are properly escaped:
```
$ dassumego <profile> --exec -- cmd with multiple 'arguments and spaces'
...None None cmd with multiple 'arguments and spaces'
```

### Potential risks
If someone has come to rely on this broken concatenation/escaping since #549 it could break their usage.

### Is patch release candidate?
Yes

### Link to relevant docs PRs
N/A