### PR TITLE
Fix for registry sync issue #587

### DIFF
--- a/pkg/granted/registry/sync.go
+++ b/pkg/granted/registry/sync.go
@@ -220,6 +220,6 @@ func copyFile(from, to string) error {
 	}
 	defer copyTo.Close()
 
-	_, err = io.Copy(copyFrom, copyTo)
+	_, err = io.Copy(copyTo, copyFrom)
 	return err
 }


### PR DESCRIPTION
### What changed?
The copyFile function in sync.go had a mistake in the order of arguments when calling io.Copy. The io.Copy function takes the destination writer as the first argument and the source reader as the second argument. 

### Why?
Since this was misconfigured the profiles outside of the registry from `~/.aws/config` where not being copied

### How did you test it?
dgranted registry sync locally 

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs