### PR TITLE
Create ~/.aws/config if it does not exist

### DIFF
--- a/pkg/granted/registry/sync.go
+++ b/pkg/granted/registry/sync.go
@@ -68,7 +68,7 @@ func SyncProfileRegistries(shouldSilentLog bool, promptUserIfProfileDuplication 
 	if err := createFileIfNotExists(awsConfigPath); err != nil {
 		return err
 	}
-	if err := copyFile(tmpConfigPath, awsConfigPath); err != nil {
+	if err := copyFile(awsConfigPath, tmpConfigPath); err != nil {
 
 		return fmt.Errorf("failed to copy aws config to tempfile for update")
 	}
@@ -244,6 +244,6 @@ func copyFile(from, to string) error {
 	}
 	defer copyTo.Close()
 
-	_, err = io.Copy(copyFrom, copyTo)
+	_, err = io.Copy(copyTo, copyFrom)
 	return err
 }


### PR DESCRIPTION
### What changed?

Before copying `~/.aws/config` to the temp file, make sure that it exists, even if only as an empty file.

### Why?

Without this change, if `~/.aws/config` does not exist, sync fails with:

```
$ dgranted registry sync
[✘] failed to copy aws config to tempfile for update
```

### How did you test it?

Delete ~/.aws/config and run sync. Before, it failed. Now, it succeeds.

### Potential risks


### Is patch release candidate?

Yes

### Link to relevant docs PRs