### PR TITLE
Revert breaking change to 'granted login' with additional prompt for SSO scopes

### DIFF
--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -244,16 +244,6 @@ var LoginCommand = cli.Command{
 
 		ssoScopes := c.StringSlice("sso-scope")
 
-		if ssoScopes == nil {
-			var scopesString string
-			in2 := survey.Input{Message: "SSO Scopes", Default: "sso:account:access"}
-			err := testable.AskOne(&in2, &scopesString)
-			if err != nil {
-				return err
-			}
-			ssoScopes = strings.Split(scopesString, ",")
-		}
-
 		cfg := aws.NewConfig()
 		cfg.Region = ssoRegion
 

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 
 	"net/http"


### PR DESCRIPTION
This fixes an issue where 'granted login' would trigger an interactive prompt if --sso-scopes were not provided. This was 
an unintentional breaking change caused by #616.

This is an issue if you have written shell scripts that call `granted login`, because unless `--sso-scopes` is provided, the command will now hang and wait for user input.
