### PR TITLE
Add --so-scope in hint for granted sso login

### DIFF
--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -192,6 +193,11 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 		region := c.SSORegion()
 		if region != "" {
 			cmd += " --sso-region " + region
+		}
+
+		scopes := c.SSOScopes()
+		if len(scopes) > 0 {
+			cmd += " --sso-scope " + strings.Join(scopes, ",")
 		}
 
 		// if the token exists but is invalid, attempt to clear it so that next login works.


### PR DESCRIPTION
### What changed?

Add `-sso-scopes` in the login hint if the profile has it set


Example:

```
$ ./bin/dgranted credential-process --profile myprofile/myrole
[✘] error when retrieving credentials from custom process. please login using 'granted sso login --sso-start-url https://d-....awsapps.com/start --sso-region us-west-2 --sso-scope sso:account:access'
```


### Why?

When running granted without --auto-login, and if the token
is expired or missing, it will print a hint. This hint should
include --sso-scopes if the profile has this setting as
granted_sso_registration_scopes = ...

### How did you test it?

Manually, see above
### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs