### PR TITLE
feat: Use aws:username for IAM initiated federated console sessions.

### DIFF
--- a/pkg/cfaws/assumer_aws_iam_test.go
+++ b/pkg/cfaws/assumer_aws_iam_test.go
@@ -1,0 +1,66 @@
+package cfaws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getSessionTags(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		caller       *sts.GetCallerIdentityOutput
+		wantTags     []types.Tag
+		wantUserName string
+	}{
+		{
+			name: "ok",
+			caller: &sts.GetCallerIdentityOutput{
+				Account: aws.String("123456789012"),
+				Arn:     aws.String("arn:aws:iam::123456789012:user/example-user"),
+				UserId:  aws.String("XXXYYYZZZ"),
+			},
+			wantUserName: "example-user",
+			wantTags: []types.Tag{
+				{Key: aws.String("userID"), Value: aws.String("XXXYYYZZZ")},
+				{Key: aws.String("account"), Value: aws.String("123456789012")},
+				{Key: aws.String("principalArn"), Value: aws.String("arn:aws:iam::123456789012:user/example-user")},
+				{Key: aws.String("userName"), Value: aws.String("example-user")},
+			},
+		},
+		{
+			name: "falls_back_to_user_id_if_arn_invalid",
+			caller: &sts.GetCallerIdentityOutput{
+				Account: aws.String("123456789012"),
+				Arn:     aws.String("invalid arn"),
+				UserId:  aws.String("XXXYYYZZZ"),
+			},
+			wantUserName: "XXXYYYZZZ",
+			wantTags: []types.Tag{
+				{Key: aws.String("userID"), Value: aws.String("XXXYYYZZZ")},
+				{Key: aws.String("account"), Value: aws.String("123456789012")},
+				{Key: aws.String("principalArn"), Value: aws.String("invalid arn")},
+			},
+		},
+		{
+			name:         "wont_panic",
+			caller:       nil,
+			wantUserName: "",
+			wantTags:     nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTags, gotUserName := getSessionTags(tt.caller)
+			assert.Equal(t, tt.wantTags, gotTags)
+			if gotUserName != tt.wantUserName {
+				t.Errorf("getSessionTags() gotUserName = %v, want %v", gotUserName, tt.wantUserName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What changed?

Closes #625 

The changes refactor the way federation token ID is used for AWS IAM credentials. Instead of relying on the userID which was previously parsed, the code now uses the userName which is more easily attributable to the IAM user name in the Cloudtrail events list view.

Old:

![image](https://github.com/common-fate/granted/assets/47449406/3dd7a0a5-9f24-433e-9e92-eeccdc494d52)

New:

![image](https://github.com/common-fate/granted/assets/47449406/61c3b409-8dcc-457c-8664-753175d11779)


### Why?

In the Cloudtrail console's event history view, the IAM user name will now display in the `user name` column. Previously, the `user id` would display (e.g. AIDA.....).

### How did you test it?

1. Add IAM credential with `granted credentials add`.
2. Opened a console session with `assume -c`.
3. Created an S3 bucket through the S3 console.

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs