### PR TITLE
fix runtime error when sso token expires

### DIFF
--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -81,6 +81,9 @@ func (p *Profile) SSOStartURL() string {
 // However, the AWS v2 Go SDK does not support reading 'sso_registration_scopes', so in order
 // to support this we'll need to parse and lookup the `sso-session` entries in the config file separately.
 func (p *Profile) SSOScopes() []string {
+	if p.RawConfig == nil {
+		return nil
+	}
 	scopeKey, err := p.RawConfig.GetKey("granted_sso_registration_scopes")
 	if err != nil {
 		return nil


### PR DESCRIPTION
### What changed?
Added nil pointer handling

### Why?
Requesting access with a expired SSO token gave the following error: 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x100989ba4]

goroutine 1 [running]:
gopkg.in/ini%2ev1.(*Section).GetKey(0x0, {0x100b1fddd?, 0x16f8aaf6f?})
        /Users/runner/go/pkg/mod/gopkg.in/ini.v1@v1.67.0/section.go:109 +0x24
github.com/common-fate/granted/pkg/cfaws.(*Profile).SSOScopes(0x16f8aaf6f?)
```

### How did you test it?
Locally reproduced the error and tested that the fix works. 
How to test: 
- Delete sso token 
- run assume --sso --sso-start-url https://qwertyui.awsapps.com/start --sso-region ap-southeast-2 --account-id 123456789 --role-name AdministratorAccess (This will give error)
- run dassume --sso --sso-start-url https://qwertyui.awsapps.com/start --sso-region ap-southeast-2 --account-id 123456789 --role-name AdministratorAccess (fix)


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs