### PR TITLE
add a check for empty access key ID when caching

### DIFF
--- a/pkg/securestorage/session_credential_storage.go
+++ b/pkg/securestorage/session_credential_storage.go
@@ -1,6 +1,8 @@
 package securestorage
 
 import (
+	"errors"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
@@ -32,6 +34,9 @@ func (i *SessionCredentialSecureStorage) GetCredentials(profile string) (*aws.Cr
 }
 
 func (i *SessionCredentialSecureStorage) StoreCredentials(profile string, credentials aws.Credentials) (err error) {
+	if credentials.AccessKeyID == "" {
+		return errors.New("could not cache credentials: access key ID was empty")
+	}
 	err = i.SecureStorage.Store(profile, &credentials)
 	return
 }


### PR DESCRIPTION
### What changed?
adds a check to prevent caching credentials if the access key is empty

### Why?
prevents an issue where if the granted credential-process returned an empty JSON, Granted would cache it and require manually clearing the cache.

### How did you test it?
testing the granted credential-process integration. To reproduce, add a credential process which returns a JSON with an empty access key ID. The previous behaviour is that Granted will cache this, which causes the AWS CLI to stop working.

### Potential risks
Low risk as the access key should never be empty.

### Is patch release candidate?
Yes

### Link to relevant docs PRs