### PR TITLE
Ensure "firefoxstdout" doesn't get prefix-matched as "firefox"

### DIFF
--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -114,6 +114,9 @@ func GetBrowserKey(b string) string {
 	if strings.Contains(strings.ToLower(b), "edge") {
 		return EdgeKey
 	}
+	if strings.Contains(strings.ToLower(b), "firefoxstdout") {
+		return FirefoxStdoutKey
+	}
 	if strings.Contains(strings.ToLower(b), "firefox") || strings.Contains(strings.ToLower(b), "mozilla") {
 		return FirefoxKey
 	}
@@ -125,9 +128,6 @@ func GetBrowserKey(b string) string {
 	}
 	if strings.Contains(strings.ToLower(b), "safari") {
 		return SafariKey
-	}
-	if strings.Contains(strings.ToLower(b), "firefoxstdout") {
-		return FirefoxStdoutKey
 	}
 	if strings.Contains(strings.ToLower(b), "arc") {
 		return ArcKey


### PR DESCRIPTION
### What changed?
The `GetBrowserKey` function has been fixed to return the correct `FirefoxStdoutKey`.

### Why?
Previously, this value would never be returned as the function performs a `Contains` match, and `firefoxstdout` does contain the string "firefox" which would return the wrong key. 

### How did you test it?
Honestly, just visual inspection after finding that providing `FirefoxStdout` to `granted browser set` was still prompting for a path.

### Potential risks
None