### PR TITLE
Add apigateway to service map

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -5,6 +5,7 @@ package console
 var ServiceMap = map[string]string{
 	"":               "console",
 	"acm":            "acm",
+	"apigateway":     "apigateway",
 	"aos":            "aos",
 	"athena":         "athena",
 	"appsync":        "appsync",


### PR DESCRIPTION
### What changed?

Add a service map entry for AWS API Gateway (`apigateway`)