### PR TITLE
Propagate prefixDuplicateProfiles option

### DIFF
--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -72,7 +72,7 @@ var AddCommand = cli.Command{
 			Filename:                configFileName,
 			Ref:                     ref,
 			Priority:                priority,
-			PrefixDuplicateProfiles: prefixAllProfiles,
+			PrefixDuplicateProfiles: prefixDuplicateProfiles,
 			PrefixAllProfiles:       prefixAllProfiles,
 		}
 


### PR DESCRIPTION
### What changed?

Propagate prefixDuplicateProfiles option to configuration when adding a registry, fixes issue #638 

### Why?

--prefix-duplicate-profile flag does not have intended effect

### How did you test it?

1. Run with granted 0.23, `granted registry add ... --pdp`
2. Inspect ~/.granted/config, it will not have PDP set
3. Run with dgranted
4. Inspect ~/.dgranted/config, it will have PDP set

### Potential risks

None

### Is patch release candidate?

Seems likely

### Link to relevant docs PRs