### PR TITLE
Autoload fish completions and fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 	rm ${PREFIX}/bin/dassume
 	rm ${PREFIX}/bin/dassume.fish
 
-aws-credentials: 
+aws-credentials:
 	echo -e "\nAWS_ACCESS_KEY_ID=\"$$AWS_ACCESS_KEY_ID\"\nAWS_SECRET_ACCESS_KEY=\"$$AWS_SECRET_ACCESS_KEY\"\nAWS_SESSION_TOKEN=\"$$AWS_SESSION_TOKEN\"\nAWS_REGION=\"$$AWS_REGION\""
 
 test-browser-binary:
@@ -49,7 +49,7 @@ ci-cli-all-platforms: test-binaries
 
 ## This will use the 'granted' binary and 'assume' symlink for dev build.
 ## Helpful to use dev build using 'granted' and 'assume' before release.
-cli-act-prod: go-binary assume-binary
+cli-act-prod: go-binary
 	mv ./bin/dgranted ${PREFIX}/bin/granted
 	ln -s granted ${PREFIX}/bin/dassumego
 	# replace references to "assumego" (the production binary) with "dassumego"

--- a/pkg/granted/completion.go
+++ b/pkg/granted/completion.go
@@ -62,7 +62,7 @@ func installFishCompletions(c *cli.Context) error {
 	// try to fetch user home dir
 	user, _ := user.Current()
 
-	executableDir := user.HomeDir + "/.config/fish/completions/granted_completer_fish.fish"
+	executableDir := user.HomeDir + "/.config/fish/completions/granted.fish"
 
 	// Try to create a file
 	err := os.WriteFile(executableDir, []byte(combinedOutput), 0600)

--- a/pkg/granted/completion.go
+++ b/pkg/granted/completion.go
@@ -62,7 +62,7 @@ func installFishCompletions(c *cli.Context) error {
 	// try to fetch user home dir
 	user, _ := user.Current()
 
-	executableDir := user.HomeDir + "/.config/fish/completions/granted.fish"
+	executableDir := path.Join(user.HomeDir, ".config/fish/completions", fmt.Sprintf("%s.fish", c.App.Name))
 
 	// Try to create a file
 	err := os.WriteFile(executableDir, []byte(combinedOutput), 0600)


### PR DESCRIPTION
### What changed?
The fish completion generation script now writes the completions to `$HOME/.config/fish/completions/granted.fish`, meaning that fish will now autoload the completions, instead of requiring users to manually load the completions.

Additionally, a reference to a deleted Makefile task was deleted to fix the `cli-act-prod` task.

### Why?
fish uses the [file name of completion files](https://fishshell.com/docs/current/completions.html#where-to-put-completions) to determine which command the completions belong to when autoloading.. The previous file name mean that fish wasn't autoloading completions. Additionally, we can use the `path` library built-in to Go to handle constructing the appropriate path, rather than do string concatenation ourselves.

The `assume-binary` that was referenced as prerequisite for the `cli-act-prod` task no longer exists so to fix the task, it was removed.

### How did you test it?
I built the CLI locally, generated the completions by running `dgranted completion --shell=fish`, then opened a new fish shell and saw that the completions had been autoloaded for `dgranted`.

### Potential risks
If a user is relying on the previous filename for a script, that script will break, assuming they also delete the previous file. However, given that they were likely referencing the completions file to load the completions upon shell startup anyways, this commit will actually help them remove a line from their shell config.

### Is patch release candidate?
Yes. This commit doesn't change any APIs.

### Link to relevant docs PRs
N/A