### PR TITLE
Fix the default type for the 'granted registry add' command

### DIFF
--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -35,7 +35,7 @@ var AddCommand = cli.Command{
 		&cli.BoolFlag{Name: "prefix-duplicate-profiles", Aliases: []string{"pdp"}, Usage: "Provide this flag if you want to append registry name to duplicate profiles"},
 		&cli.BoolFlag{Name: "write-on-sync-failure", Aliases: []string{"wosf"}, Usage: "Always overwrite AWS config, even if sync fails (DEPRECATED)"},
 		&cli.StringSliceFlag{Name: "required-key", Aliases: []string{"r", "requiredKey"}, Usage: "Used to bypass the prompt or override user specific values"},
-		&cli.StringFlag{Name: "type", DefaultText: "git", Usage: "specify the type of granted registry source you want to set up. Default: git"}},
+		&cli.StringFlag{Name: "type", Value: "git", Usage: "specify the type of granted registry source you want to set up. Default: git"}},
 
 	ArgsUsage: "--name <registry_name> --url <repository_url> --type <registry_type>",
 	Action: func(c *cli.Context) error {


### PR DESCRIPTION
### What changed?

Change `DefaultText` to `Value` in `granted registry add`.

### Why?

`DefaultText` is not actually used as the default value, we need to use `Value` instead.

### How did you test it?
Will test via prerelease build on main.

### Potential risks
Low - default value change

### Is patch release candidate?
No, fixes an issue which has not yet been released.

