### PR TITLE
Fix panic due to nil pointer in frecency

### DIFF
--- a/pkg/cfaws/frecent_profiles.go
+++ b/pkg/cfaws/frecent_profiles.go
@@ -56,7 +56,11 @@ func (p *Profiles) GetFrecentProfiles() (*FrecentProfiles, []string) {
 
 	// add all frecent profile names in order if they are still present in the profileNames slice
 	for _, entry := range fr.Entries {
-		e := entry.Entry.(string)
+		e, ok := entry.Entry.(string)
+		if !ok {
+			continue
+		}
+
 		if p.HasProfile(e) {
 			names = append(names, e)
 			namesMap[e] = e


### PR DESCRIPTION
### What changed?
Check the interface conversion in `frecent_profiles.go`.

### Why?
Fixes #608.

There may still be a problem here as the interface should never be nil. This may be an issue on running Granted for the first time perhaps.

In any case, this fix will prevent a panic.

### How did you test it?
Currently untested but this is a low risk change, can be tested in prerelease after merged.

### Potential risks
Low

### Is patch release candidate?
Yes 

### Link to relevant docs PRs
N/A
