### PR TITLE
fix profile registry sync for registries without a type

### DIFF
--- a/pkg/granted/registry/registry.go
+++ b/pkg/granted/registry/registry.go
@@ -32,7 +32,7 @@ func GetProfileRegistries(interactive bool) ([]loadedRegistry, error) {
 	var registries []loadedRegistry
 	for _, r := range gConf.ProfileRegistry.Registries {
 
-		if r.Type == "git" {
+		if r.Type == "git" || r.Type == "" {
 			reg, err := gitregistry.New(gitregistry.Opts{
 				Name:        r.Name,
 				URL:         r.URL,


### PR DESCRIPTION
they should default to 'git'

### What changed?


### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs
