### PR TITLE
Allow custom reason to be provided on access request through granted

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -382,6 +382,8 @@ func AssumeCommand(c *cli.Context) error {
 		configOpts.Duration = d
 	}
 
+	reason := assumeFlags.String("reason")
+
 	cfg, err := config.Load()
 	if err != nil {
 		return err
@@ -409,7 +411,7 @@ func AssumeCommand(c *cli.Context) error {
 			clio.Debugw("received a No Access error", "error", err)
 			hook := accessrequesthook.Hook{}
 
-			retry, hookErr := hook.NoAccess(c.Context, profile)
+			retry, hookErr := hook.NoAccess(c.Context, profile, reason)
 			if hookErr != nil {
 				return hookErr
 			}
@@ -528,7 +530,7 @@ func AssumeCommand(c *cli.Context) error {
 			clio.Debugw("received a No Access error", "error", err)
 			hook := accessrequesthook.Hook{}
 
-			retry, hookErr := hook.NoAccess(c.Context, profile)
+			retry, hookErr := hook.NoAccess(c.Context, profile, reason)
 			if hookErr != nil {
 				return hookErr
 			}

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -51,6 +51,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "export-all-env-vars", Aliases: []string{"x"}, Usage: "Exports all available credentials to the terminal when used with a profile configured for credential-process. Without this flag, only the AWS_PROFILE will be configured"},
 		&cli.StringFlag{Name: "aws-config-file"},
 		&cli.StringFlag{Name: "chain", Usage: "Assume a given role ARN using the profile selected"},
+		&cli.StringFlag{Name: "reason", Usage: "Provide a reason for requesting access to the role"},
 	}
 }
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -155,8 +155,15 @@ func (h Hook) NoAccess(ctx context.Context, profile *cfaws.Profile) (retry bool,
 	si.Start()
 
 	var customReason string
+
+	msg := "Reason for access"
+	if validation != nil && validation.HasReason {
+		msg = msg + " (Required)"
+	} else {
+		msg = msg + " (Leave blank to use default reason)"
+	}
 	reasonPrompt := &survey.Input{
-		Message: "Reason for access:",
+		Message: msg,
 		Help:    "Will be stored in audit trails and associated with you",
 	}
 


### PR DESCRIPTION
### What changed?
When granted attempts to request access for a request that requires approval, it will now also ask for a reason for access

### Why?
Access Reason will improve security and help to understand why a request for an access is needed

### How did you test it?

Scenario where reason is supplied, and reason is required

```
calvinluy➜~/Git/granted(calvin/cf-3181-allow-custom-reasons-to-be-provided-when-using-granted-to✗)» dassume                                                                                           [11:59:59]

? Please select the profile you would like to assume: Audit/AWSAdministratorAccess                                  
[i] To assume this profile again later without needing to select it, run this command:
> assume Audit/AWSAdministratorAccess 
[i] You don't currently have access to Audit/AWSAdministratorAccess, checking if we can request access...       [target=AWS::Account::"125928628396", role=AWSAdministratorAccess, url=http://localhost:9090]
[WILL ACTIVATE] AWSAdministratorAccess access to Audit will be activated for 3m: http://localhost:8080/access/requests/req_2giBInWBqFiLPsjhuPk5hSOcUD1
[i] Access::Grant::"gra_2giBInFRuAkkXWdyIXa0eKMIRdC": All access is allowed
? Apply proposed access changes Yes
[i] Attempting to grant access...
? Reason for access (Required) Test Access Reason
[i] Access::Grant::"gra_2giBJgxBCv55k9TMOry50iwlIAD": All access is allowed
[ACTIVATED] AWSAdministratorAccess access to Audit was activated for 3m: http://localhost:8080/access/requests/req_2giBJgsfLi7rk6Q8Yb37DklwOqK
[i] Access::Grant::"gra_2giBJgxBCv55k9TMOry50iwlIAD": All access is allowed
[✔] [Audit/AWSAdministratorAccess](ap-southeast-2) session credentials will expire in 1 hour
```

Scenario where Reason is not required, and no reason is supplied:

```
calvinluy➜~/Git/granted(calvin/cf-3181-allow-custom-reasons-to-be-provided-when-using-granted-to✗)» dassume                                                                                           [10:19:08]

? Please select the profile you would like to assume: Audit/AWSAdministratorAccess                                  
[i] To assume this profile again later without needing to select it, run this command:
> assume Audit/AWSAdministratorAccess 
[i] You don't currently have access to Audit/AWSAdministratorAccess, checking if we can request access...       [target=AWS::Account::"125928628396", role=AWSAdministratorAccess, url=http://localhost:9090]
[WILL ACTIVATE] AWSAdministratorAccess access to Audit will be activated for 3m: http://localhost:8080/access/requests/req_2ghzJzlj0zqmJaB0EvP8AKIrw6H
[i] Access::Grant::"gra_2ghzK3BHiPLiXHqtGEhiMtQbKgA": All access is allowed
? Apply proposed access changes Yes
[i] Attempting to grant access...
[i] Access::Grant::"gra_2ghzKHSBQIDbzA58SP2Qeg31wKC": All access is allowed
[ACTIVATED] AWSAdministratorAccess access to Audit was activated for 3m: http://localhost:8080/access/requests/req_2ghzKEKNRxKlOd2CzizaIXWa6o8
[i] Access::Grant::"gra_2ghzKHSBQIDbzA58SP2Qeg31wKC": All access is allowed
[✔] [Audit/AWSAdministratorAccess](ap-southeast-2) session credentials will expire in 1 hour
```

Scenario where Reason is required, but no reason was supplied. Reason is then inputted after:

```
calvinluy➜~/Git/granted(calvin/cf-3181-allow-custom-reasons-to-be-provided-when-using-granted-to✗)» dassume                                                                                           [10:45:44]

? Please select the profile you would like to assume: Audit/AWSAdministratorAccess                                  
[i] To assume this profile again later without needing to select it, run this command:
> assume Audit/AWSAdministratorAccess 
[i] You don't currently have access to Audit/AWSAdministratorAccess, checking if we can request access...       [target=AWS::Account::"125928628396", role=AWSAdministratorAccess, url=http://localhost:9090]
[WILL ACTIVATE] AWSAdministratorAccess access to Audit will be activated for 3m: http://localhost:8080/access/requests/req_2gi3bDmNTwdTOKxqzXNXU0e6c6T
[i] Access::Grant::"gra_2gi3bEXrnoBxSfa4stATyvqbcU2": All access is allowed
? Apply proposed access changes Yes
[i] Attempting to grant access...
X Sorry, your reply was invalid: Value is required
? Reason for access (Required) Test Access Request Reason
[i] Access::Grant::"gra_2gi3fputlbz0lkCn8lfIc3eZT8s": All access is allowed
[ACTIVATED] AWSAdministratorAccess access to Audit was activated for 3m: http://localhost:8080/access/requests/req_2gi3foTg1hWc4d5mBOtazBeXCBZ
[i] Access::Grant::"gra_2gi3fputlbz0lkCn8lfIc3eZT8s": All access is allowed
[✔] [Audit/AWSAdministratorAccess](ap-southeast-2) session credentials will expire in 1 hour
```

TESTING for reason flag

Test with reason flag

calvinluy➜~/Git/granted(calvin/cf-3181-allow-custom-reasons-to-be-provided-when-using-granted-to✗)» dassume --reason "test 1 2 3"                                                                     [14:39:45]
```
? Please select the profile you would like to assume: Audit/AWSAdministratorAccess                                  
[i] To assume this profile again later without needing to select it, run this command:
> assume Audit/AWSAdministratorAccess --reason test 1 2 3
[i] You don't currently have access to Audit/AWSAdministratorAccess, checking if we can request access...       [target=AWS::Account::"125928628396", role=AWSAdministratorAccess, url=http://localhost:9090]
[WILL ACTIVATE] AWSAdministratorAccess access to Audit will be activated for 10m: http://localhost:8080/access/requests/req_2glK14bbkUuH00ejaKyPne25XBD
[i] Access::Grant::"gra_2glK17maKavVY43PqJImLYPVMfR": All access is allowed
? Apply proposed access changes Yes
[i] Attempting to grant access...
[i] Access::Grant::"gra_2glK1ZSZe5dmytx1VKqjSMT3ZxU": All access is allowed
[ACTIVATED] AWSAdministratorAccess access to Audit was activated for 3m: http://localhost:8080/access/requests/req_2glK1X0agBDrsyroWmbK5TNeAYD
[i] Access::Grant::"gra_2glK1ZSZe5dmytx1VKqjSMT3ZxU": All access is allowed
[✔] [Audit/AWSAdministratorAccess](ap-southeast-2) session credentials will expire in 1 hour
```

Testing without flag

```
calvinluy➜~/Git/granted(calvin/cf-3181-allow-custom-reasons-to-be-provided-when-using-granted-to✗)» dassume                                                                                           [14:41:56]

? Please select the profile you would like to assume: Audit/AWSAdministratorAccess                                  
[i] To assume this profile again later without needing to select it, run this command:
> assume Audit/AWSAdministratorAccess 
[i] You don't currently have access to Audit/AWSAdministratorAccess, checking if we can request access...       [target=AWS::Account::"125928628396", role=AWSAdministratorAccess, url=http://localhost:9090]
[WILL ACTIVATE] AWSAdministratorAccess access to Audit will be activated for 10m: http://localhost:8080/access/requests/req_2glK8y0omoREdh6LUzohQshsHoq
[i] Access::Grant::"gra_2glK91elw8S04kUI73eVVE7ZmiE": All access is allowed
? Apply proposed access changes Yes
[i] Attempting to grant access...
? Reason for access (Required) test mandatory reason
[i] Access::Grant::"gra_2glKB7uRUlbMZYjK80bEBcPM9p8": All access is allowed
[ACTIVATED] AWSAdministratorAccess access to Audit was activated for 3m: http://localhost:8080/access/requests/req_2glKB4WFt0P5t45euIKmAam1fnB
[i] Access::Grant::"gra_2glKB7uRUlbMZYjK80bEBcPM9p8": All access is allowed
[✔] [Audit/AWSAdministratorAccess](ap-southeast-2) session credentials will expire in 1 hour
```

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs