### PR TITLE
Duration flag now sets the duration of the access request

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -410,11 +410,14 @@ func AssumeCommand(c *cli.Context) error {
 			clio.Debugw("received a No Access error", "error", err)
 			hook := accessrequesthook.Hook{}
 
-			d, err := time.ParseDuration(duration)
-			if err != nil {
-				return err
+			var apiDuration *durationpb.Duration
+			if duration != "" {
+				d, err := time.ParseDuration(duration)
+				if err != nil {
+					return err
+				}
+				apiDuration = durationpb.New(d)
 			}
-			apiDuration := durationpb.New(d)
 
 			retry, hookErr := hook.NoAccess(c.Context, profile, apiDuration)
 			if hookErr != nil {
@@ -455,7 +458,7 @@ func AssumeCommand(c *cli.Context) error {
 		}
 
 		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.WaterfoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey || cfg.DefaultBrowser == browser.FirefoxDevEditionKey {
-			// tranform the URL into the Firefox Tab Container format.
+			// transform the URL into the Firefox Tab Container format.
 			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", containerProfile, url.QueryEscape(consoleURL), profile.CustomGrantedProperty("color"), profile.CustomGrantedProperty("icon"))
 		}
 
@@ -535,11 +538,14 @@ func AssumeCommand(c *cli.Context) error {
 			clio.Debugw("received a No Access error", "error", err)
 			hook := accessrequesthook.Hook{}
 
-			d, err := time.ParseDuration(duration)
-			if err != nil {
-				return err
+			var apiDuration *durationpb.Duration
+			if duration != "" {
+				d, err := time.ParseDuration(duration)
+				if err != nil {
+					return err
+				}
+				apiDuration = durationpb.New(d)
 			}
-			apiDuration := durationpb.New(d)
 
 			retry, hookErr := hook.NoAccess(c.Context, profile, apiDuration)
 			if hookErr != nil {

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -36,6 +36,7 @@ import (
 	"github.com/hako/durafmt"
 	sethRetry "github.com/sethvargo/go-retry"
 	"github.com/urfave/cli/v2"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	"gopkg.in/ini.v1"
 )
 
@@ -409,7 +410,13 @@ func AssumeCommand(c *cli.Context) error {
 			clio.Debugw("received a No Access error", "error", err)
 			hook := accessrequesthook.Hook{}
 
-			retry, hookErr := hook.NoAccess(c.Context, profile)
+			d, err := time.ParseDuration(duration)
+			if err != nil {
+				return err
+			}
+			apiDuration := durationpb.New(d)
+
+			retry, hookErr := hook.NoAccess(c.Context, profile, apiDuration)
 			if hookErr != nil {
 				return hookErr
 			}
@@ -528,7 +535,13 @@ func AssumeCommand(c *cli.Context) error {
 			clio.Debugw("received a No Access error", "error", err)
 			hook := accessrequesthook.Hook{}
 
-			retry, hookErr := hook.NoAccess(c.Context, profile)
+			d, err := time.ParseDuration(duration)
+			if err != nil {
+				return err
+			}
+			apiDuration := durationpb.New(d)
+
+			retry, hookErr := hook.NoAccess(c.Context, profile, apiDuration)
 			if hookErr != nil {
 				return hookErr
 			}

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
 	"google.golang.org/protobuf/encoding/protojson"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 )
 
 type Hook struct{}
@@ -55,7 +56,7 @@ func getCommonFateURL(profile *cfaws.Profile) (*url.URL, error) {
 	return u, nil
 }
 
-func (h Hook) NoAccess(ctx context.Context, profile *cfaws.Profile) (retry bool, err error) {
+func (h Hook) NoAccess(ctx context.Context, profile *cfaws.Profile, duration  *durationpb.Duration) (retry bool, err error) {
 	var cfg *sdkconfig.Context
 
 	cfURL, err := getCommonFateURL(profile)
@@ -111,6 +112,7 @@ func (h Hook) NoAccess(ctx context.Context, profile *cfaws.Profile) (retry bool,
 						Lookup: role,
 					},
 				},
+				Duration: duration,
 			},
 		},
 		Justification: &accessv1alpha1.Justification{


### PR DESCRIPTION
### What changed?

This PR allows the duration flag to set the duration of the access request, provided that the duration set is lower than the maximum permissible duration


### Why?


### How did you test it?

Testing assume with no duration set

```
calvinluy➜~/Git/granted(calvin/cf-3187-granted-cli-should-use-default-duration-rather-than-max✗)» dassume                                                                                             [18:26:14]

? Please select the profile you would like to assume: Audit/AWSAdministratorAccess                                  
[i] To assume this profile again later without needing to select it, run this command:
> assume Audit/AWSAdministratorAccess 
[i] You don't currently have access to Audit/AWSAdministratorAccess, checking if we can request access...       [target=AWS::Account::"125928628396", role=AWSAdministratorAccess, url=http://localhost:9090]
[WILL ACTIVATE] AWSAdministratorAccess access to Audit will be activated for 10m: http://localhost:8080/access/requests/req_2giwE2c9w2uHbVlbWGSY1EiZihW
[i] Access::Grant::"gra_2giwDzLTT5GlZapHPhOG71sXPxQ": All access is allowed
? Apply proposed access changes Yes
[i] Attempting to grant access...
[i] Access::Grant::"gra_2giwF3pmHqkZulfONoQkd0ecG9V": All access is allowed
[ACTIVATED] AWSAdministratorAccess access to Audit was activated for 3m: http://localhost:8080/access/requests/req_2giwF664sgk0ngJinUJrSvkRwb2
[i] Access::Grant::"gra_2giwF3pmHqkZulfONoQkd0ecG9V": All access is allowed
[✔] [Audit/AWSAdministratorAccess](ap-southeast-2) session credentials will expire in 1 hour
```

Testing assume with duration that is lower than max duration
```
calvinluy➜~/Git/granted(calvin/cf-3187-granted-cli-should-use-default-duration-rather-than-max✗)» dassume --duration 6m                                                                               [18:27:13]

? Please select the profile you would like to assume: Audit/AWSAdministratorAccess                                  
[i] To assume this profile again later without needing to select it, run this command:
> assume Audit/AWSAdministratorAccess --duration 6m
[i] You don't currently have access to Audit/AWSAdministratorAccess, checking if we can request access...       [target=AWS::Account::"125928628396", role=AWSAdministratorAccess, url=http://localhost:9090]
[WILL ACTIVATE] AWSAdministratorAccess access to Audit will be activated for 6m: http://localhost:8080/access/requests/req_2giwNnoRbJ83AlFAysAqvfq0slF
[i] Access::Grant::"gra_2giwNrH8ldDr6wJo62Jse85jR3b": All access is allowed
? Apply proposed access changes Yes
[i] Attempting to grant access...
[i] Access::Grant::"gra_2giwO8WRZJSjUbtxGF0ZdoS0VAb": All access is allowed
[ACTIVATED] AWSAdministratorAccess access to Audit was activated for 6m: http://localhost:8080/access/requests/req_2giwO738J9VARgFWCRb7VDpixp3
[i] Access::Grant::"gra_2giwO8WRZJSjUbtxGF0ZdoS0VAb": All access is allowed
[✔] [Audit/AWSAdministratorAccess](ap-southeast-2) session credentials will expire in 1 hour
```

Testing assume with duration higher than max duration
```
calvinluy➜~/Git/granted(calvin/cf-3187-granted-cli-should-use-default-duration-rather-than-max✗)» dassume --duration 79m                                                                              [18:29:52]

? Please select the profile you would like to assume: Audit/AWSAdministratorAccess                                  
[i] To assume this profile again later without needing to select it, run this command:
> assume Audit/AWSAdministratorAccess --duration 79m
[i] You don't currently have access to Audit/AWSAdministratorAccess, checking if we can request access...       [target=AWS::Account::"125928628396", role=AWSAdministratorAccess, url=http://localhost:9090]
[✘] error authorizing access: override duration cannot be greater than max duration. 10m0s
[✘] no access changes
```
### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs