### PR TITLE
Pull AWS credentials from multiple sources when building console url

### DIFF
--- a/cmd/granted/main.go
+++ b/cmd/granted/main.go
@@ -42,6 +42,7 @@ func main() {
 	default:
 		app = granted.GetCliApp()
 	}
+
 	// In development we can use FORCE_ASSUME_CLI to debug the assume command
 	if os.Getenv("FORCE_ASSUME_CLI") == "true" {
 		app = assume.GetCliApp()

--- a/pkg/cfaws/assumer_aws_google_auth.go
+++ b/pkg/cfaws/assumer_aws_google_auth.go
@@ -28,11 +28,14 @@ func (aia *AwsGoogleAuthAssumer) AssumeTerminal(ctx context.Context, c *Profile,
 	if err != nil {
 		return aws.Credentials{}, err
 	}
-	creds := GetEnvCredentials(ctx)
+	creds, err := GetAWSCredentials(ctx)
+	if err != nil {
+		return aws.Credentials{}, err
+	}
 	if !creds.HasKeys() {
 		return aws.Credentials{}, fmt.Errorf("no credentials exported to terminal when using %s to assume profile: %s", aia.Type(), c.Name)
 	}
-	return creds, nil
+	return *creds, nil
 }
 
 func (aia *AwsGoogleAuthAssumer) AssumeConsole(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {

--- a/pkg/granted/console.go
+++ b/pkg/granted/console.go
@@ -34,14 +34,17 @@ var ConsoleCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		ctx := c.Context
-		credentials := cfaws.GetEnvCredentials(ctx)
+		credentials, err := cfaws.GetAWSCredentials(ctx)
+		if err != nil {
+			return err
+		}
 		con := console.AWS{
 			Service:     c.String("service"),
 			Region:      c.String("region"),
 			Destination: c.String("destination"),
 		}
 
-		consoleURL, err := con.URL(credentials)
+		consoleURL, err := con.URL(*credentials)
 		if err != nil {
 			return err
 		}

--- a/pkg/granted/console.go
+++ b/pkg/granted/console.go
@@ -20,7 +20,7 @@ import (
 
 var ConsoleCommand = cli.Command{
 	Name:  "console",
-	Usage: "Generate an AWS console URL using credentials in the environment",
+	Usage: "Generate an AWS console URL using credentials in the environment or with a credential process.",
 	Flags: []cli.Flag{
 
 		&cli.StringFlag{Name: "service"},


### PR DESCRIPTION
### What changed?
Previously when building the console url with `assume -c` and `granted console`. It would build the console URL purely off the credentials in the environment. 

Now it will attempt to pull from the environment as well as using credential process.

### Why?
If the environment variables were not exported the console command would fail to build the federated URL for opening in the console. Returning a 400 error

### How did you test it?
With `DefaultExportAllEnvVar` set to false and tested with `granted console` confirmed it was working as intended. (This was returning 400 errors previously)

With `DefaultExportAllEnvVar` set to true, `granted console` was still working as it was before.

### Potential risks
- console command not completing due to the environment variable function prematurely returning an error. This has been tested and it will always attempt to return from the environment first before trying to source credentials from anywhere else.

### Is patch release candidate?


### Link to relevant docs PRs