### PR TITLE
feature/use-aws-user-id-sso

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -288,6 +288,7 @@ func AssumeCommand(c *cli.Context) error {
 		MFATokenCode: assumeFlags.String("mfa-token"),
 		Args:         assumeFlags.StringSlice("pass-through"),
 		DisableCache: assumeFlags.Bool("no-cache"),
+		UseUserId:    assumeFlags.Bool("use-user-id"),
 	}
 
 	// attempt to get session duration from profile

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -56,6 +56,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "wait", Usage: "When using Granted with Common Fate the assume will halt while waiting for the access request to be approved."},
 		&cli.BoolFlag{Name: "no-cache", Usage: "Disables caching of session credentials and forces a refresh", EnvVars: []string{"GRANTED_NO_CACHE"}},
 		&cli.StringSliceFlag{Name: "browser-launch-template-arg", Usage: "Additional arguments to provide to the browser launch template command in key=value format, e.g. '--browser-launch-template-arg foo=bar"},
+		&cli.BoolFlag{Name: "use-user-id", Aliases: []string{"uu"}, Usage: "Whether to use the AWS user ID", DefaultText: "false" },
 	}
 }
 

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -27,6 +27,7 @@ type ConfigOpts struct {
 	ShouldRetryAssuming        *bool
 	MFATokenCode               string
 	DisableCache               bool
+	UseUserId                  bool
 }
 
 type Profile struct {


### PR DESCRIPTION
Firstly to caveat this is my first time contributing to a project and also my first time writing anything in go so please bear with me. 

My knowledge isn't great enough to foresee any untoward complications but we ran into several issues related to the randomised gtnd user id and thought I would give it a crack.

Any guidance or feedback would be greatly appreciated and understand that more work may be required on my part (or you can just outright dismiss this 😆 if it's stupid or my approach is wildly off)

Primarily the issues that we faced were the same as outlined within this issue: https://github.com/common-fate/granted/issues/614


### What changed?

- Optionally call stsClient.GetCallerIdentity when assuming to fetch the user id attach that via the role session name
- Provide a config flag (uu) so this can optionally be used within the cli
- Called Getenv to check for the env file flag to permanently within global environment variables

### Why?

- Firstly the random gtnd user id effectively made cloudtrail tracing by user physically impossible, each individual session had its own id and it was very difficult to attribute individual user actions to a specific user. This posed security concerns for us as we couldn;t  use global deny all policies on these roles as there was no user specific attribute to add into the iam.
- Some things within the aws console are specific to the user the created them. A few examples of this live within the lambda console itself. Private saved events for triggering are unique to the user and thus only exist for the lifespan on the unique gtnd user id. Some of our data team also wish to manually edit lambda function code in console within non production accounts to quickly iteration on solutions, but these are also unique to the specific user.

Thus finding a method of attributing a userId that was unique to the user rather to the session is imperative for us to continue using this package.


### How did you test it?

- Building the package locally with the proposed changes and adding in the config flag followed by running sts's get caller identity outputted the the random gtnd id without the flag and my specific user with the flag
- Adding in `GRANTED_USE_USER_ID=true` within my zshrc defaulted this to always specific user when I assumed
- Assuming into a variety of our accounts and checking cloudtrail in each of these environments allowed my to search specifically for my user id
- Adding in an explicit deny all policy to a role I had actively assumed that was specifically attributed to my user id immediately blocked all permissions within aws

### Potential risks
- Error catching
- Splitting of the called.UserId by `:` rather than a more thorough approach
- Unsure and more feedback would be greatly appreciated!

### Is patch release candidate?


### Link to relevant docs PRs