### PR TITLE
Allow automatic login to be specified globally

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,14 @@ type Config struct {
 		Registries              []Registry        `toml:",omitempty"`
 	} `toml:",omitempty"`
 
+	// CredentialProcessAutoLogin, if 'true', will automatically attempt to
+	// authenticate to IAM Identity Center if your AWS SSO
+	// access token is expired.
+	//
+	// Do not set this to 'true' on headless systems, as it
+	// will cause Granted to hang during the login process.
+	CredentialProcessAutoLogin bool `toml:",omitempty"`
+
 	SSO map[string]AWSSSOConfiguration `toml:",omitempty"`
 }
 

--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -41,7 +41,7 @@ var CredentialProcess = cli.Command{
 		}
 
 		profileName := c.String("profile")
-		autoLogin := c.Bool("auto-login")
+		autoLogin := c.Bool("auto-login") || cfg.CredentialProcessAutoLogin
 		secureSessionCredentialStorage := securestorage.NewSecureSessionCredentialStorage()
 		clio.Debugw("running credential process with config", "profile", profileName, "url", c.String("url"), "window", c.Duration("window"), "disableCredentialProcessCache", cfg.DisableCredentialProcessCache)
 


### PR DESCRIPTION
### What changed?
Adds `CredentialProcessAutoLogin` field to `~/.granted/config`. It is equivalent to specifying the `--auto-login=true` flag for the `granted credential-process` command.

### Why?
Allows this to be set globally, rather than specified per-profile which is more cumbersome (and doesn't play nicely with automatic profile generation).

### How did you test it?
Currently untested, requires a prerelease test.

### Potential risks
Quite low as it is an optional flag change

