### PR TITLE
Fix newline in version print output

### DIFF
--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -57,7 +57,7 @@ func GlobalFlags() []cli.Flag {
 
 func GetCliApp() *cli.App {
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Printf("Granted version: %s", build.Version)
+		fmt.Printf("Granted version: %s\n", build.Version)
 	}
 
 	app := &cli.App{

--- a/pkg/granted/entrypoint.go
+++ b/pkg/granted/entrypoint.go
@@ -24,7 +24,7 @@ import (
 
 func GetCliApp() *cli.App {
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Printf("Granted version: %s", build.Version)
+		fmt.Printf("Granted version: %s\n", build.Version)
 	}
 
 	flags := []cli.Flag{


### PR DESCRIPTION
### What changed?
Print a newline at the end of the `granted -v` version output.

### Why?
Should make automated parsing of the version output easier.

### How did you test it?
`granted -v`

### Potential risks
None

### Is patch release candidate?
Yes

### Link to relevant docs PRs
