### PR TITLE
update error messages and auto login when grant token is expired

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/common-fate/clio v1.2.3
 	github.com/common-fate/common-fate v0.15.13
 	github.com/common-fate/glide-cli v0.6.0
-	github.com/common-fate/sdk v1.33.2
+	github.com/common-fate/sdk v1.37.1-0.20240603005726-756f0133ad62
 	github.com/fatih/color v1.16.0
 	github.com/lithammer/fuzzysearch v1.1.5
 	github.com/schollz/progressbar/v3 v3.13.1

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/common-fate/clio v1.2.3
 	github.com/common-fate/common-fate v0.15.13
 	github.com/common-fate/glide-cli v0.6.0
-	github.com/common-fate/sdk v1.37.1-0.20240603005726-756f0133ad62
+	github.com/common-fate/sdk v1.37.0
 	github.com/fatih/color v1.16.0
 	github.com/lithammer/fuzzysearch v1.1.5
 	github.com/schollz/progressbar/v3 v3.13.1

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/common-fate/iso8601 v1.1.0 h1:nrej9shsK1aB4IyOAjZl68xGk8yDuUxVwQjoDzx
 github.com/common-fate/iso8601 v1.1.0/go.mod h1:DU4mvUEkkWZUUSJq2aCuNqM1luSb0Pwyb2dLzXS+img=
 github.com/common-fate/sdk v1.33.2 h1:r2IPUyr/yRfQKFc3yIKDUkiHThCxISN9DvCQel6XUg0=
 github.com/common-fate/sdk v1.33.2/go.mod h1:GY+u9RSpn25gHbQX8wVuSXjYpyPY8sjohaFUmEGrqqY=
+github.com/common-fate/sdk v1.37.1-0.20240603005726-756f0133ad62 h1:yvUY746FktoUOSpKGLFKcDfYPYJ+ae8TtvyuQ3hZSwQ=
+github.com/common-fate/sdk v1.37.1-0.20240603005726-756f0133ad62/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/common-fate/updatecheck v0.3.5 h1:UGIKMnYwuHjbhhCaisLz1pNPg8Z1nXEoWcfqT+4LkAg=
 github.com/common-fate/updatecheck v0.3.5/go.mod h1:fru9yoUXmM3QVAUdDDqKQeDoln20Pkji/7EH64gVHMs=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/common-fate/iso8601 v1.1.0 h1:nrej9shsK1aB4IyOAjZl68xGk8yDuUxVwQjoDzx
 github.com/common-fate/iso8601 v1.1.0/go.mod h1:DU4mvUEkkWZUUSJq2aCuNqM1luSb0Pwyb2dLzXS+img=
 github.com/common-fate/sdk v1.33.2 h1:r2IPUyr/yRfQKFc3yIKDUkiHThCxISN9DvCQel6XUg0=
 github.com/common-fate/sdk v1.33.2/go.mod h1:GY+u9RSpn25gHbQX8wVuSXjYpyPY8sjohaFUmEGrqqY=
+github.com/common-fate/sdk v1.37.0 h1:pn4S2MkwbYFglYg5/bMY/55qMclUamui1H1g8/KftkA=
+github.com/common-fate/sdk v1.37.0/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/common-fate/sdk v1.37.1-0.20240603005726-756f0133ad62 h1:yvUY746FktoUOSpKGLFKcDfYPYJ+ae8TtvyuQ3hZSwQ=
 github.com/common-fate/sdk v1.37.1-0.20240603005726-756f0133ad62/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/common-fate/updatecheck v0.3.5 h1:UGIKMnYwuHjbhhCaisLz1pNPg8Z1nXEoWcfqT+4LkAg=

--- a/go.sum
+++ b/go.sum
@@ -64,12 +64,8 @@ github.com/common-fate/grab v1.3.0 h1:vGNBMfhAVAWtrLuH1stnhL4LsDb73drhegC/060q+O
 github.com/common-fate/grab v1.3.0/go.mod h1:6zH8GckZGFrOKfZzL4Y/2OTvxwFeL6cDtsztM0GGC2Y=
 github.com/common-fate/iso8601 v1.1.0 h1:nrej9shsK1aB4IyOAjZl68xGk8yDuUxVwQjoDzxSK2c=
 github.com/common-fate/iso8601 v1.1.0/go.mod h1:DU4mvUEkkWZUUSJq2aCuNqM1luSb0Pwyb2dLzXS+img=
-github.com/common-fate/sdk v1.33.2 h1:r2IPUyr/yRfQKFc3yIKDUkiHThCxISN9DvCQel6XUg0=
-github.com/common-fate/sdk v1.33.2/go.mod h1:GY+u9RSpn25gHbQX8wVuSXjYpyPY8sjohaFUmEGrqqY=
 github.com/common-fate/sdk v1.37.0 h1:pn4S2MkwbYFglYg5/bMY/55qMclUamui1H1g8/KftkA=
 github.com/common-fate/sdk v1.37.0/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
-github.com/common-fate/sdk v1.37.1-0.20240603005726-756f0133ad62 h1:yvUY746FktoUOSpKGLFKcDfYPYJ+ae8TtvyuQ3hZSwQ=
-github.com/common-fate/sdk v1.37.1-0.20240603005726-756f0133ad62/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/common-fate/updatecheck v0.3.5 h1:UGIKMnYwuHjbhhCaisLz1pNPg8Z1nXEoWcfqT+4LkAg=
 github.com/common-fate/updatecheck v0.3.5/go.mod h1:fru9yoUXmM3QVAUdDDqKQeDoln20Pkji/7EH64gVHMs=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -433,7 +433,7 @@ func AssumeCommand(c *cli.Context) error {
 			if retry {
 
 				b := sethRetry.NewFibonacci(time.Second)
-				b = sethRetry.WithMaxDuration(time.Second*1, b)
+				b = sethRetry.WithMaxDuration(time.Minute*1, b)
 				err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {
 					creds, err = profile.AssumeConsole(c.Context, configOpts)
 					if err == nil {

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -433,7 +433,7 @@ func AssumeCommand(c *cli.Context) error {
 			if retry {
 
 				b := sethRetry.NewFibonacci(time.Second)
-				b = sethRetry.WithMaxDuration(time.Minute*1, b)
+				b = sethRetry.WithMaxDuration(time.Second*1, b)
 				err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {
 					creds, err = profile.AssumeConsole(c.Context, configOpts)
 					if err == nil {

--- a/pkg/granted/auth/auth.go
+++ b/pkg/granted/auth/auth.go
@@ -1,7 +1,10 @@
 package auth
 
 import (
+	"strings"
+
 	"github.com/common-fate/cli/cmd/cli/command"
+	"github.com/common-fate/clio"
 	"github.com/common-fate/sdk/config"
 	"github.com/common-fate/sdk/loginflow"
 	"github.com/urfave/cli/v2"
@@ -24,6 +27,15 @@ var loginCommand = cli.Command{
 	Usage: "Authenticate to an OIDC provider",
 	Action: func(c *cli.Context) error {
 		cfg, err := config.LoadDefault(c.Context)
+
+		if err != nil && strings.Contains(err.Error(), "config file does not exist") {
+			clio.Debugw("prompting user login because token is expired", "error_details", err.Error())
+			// NOTE(chrnorm): ideally we'll bubble up a more strongly typed error in future here, to avoid the string comparison on the error message.
+
+			// the OAuth2.0 token is expired so we should prompt the user to log in
+			clio.Infof("Config file not found. To get set up with Common Fate run `granted auth configure https://cf.demo.io`")
+
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/granted/auth/auth.go
+++ b/pkg/granted/auth/auth.go
@@ -26,7 +26,7 @@ var loginCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		cfg, err := config.LoadDefault(c.Context)
 		if err == config.ErrConfigFileNotFound {
-			clio.Errorf("The Common Fate config file (~/.cf/config by default) was not found. To fix this, run 'granted auth configure https://url.of.your.commonfate.deployment.example.com' (replacing the URL in the command with your Common Fate deployment URL")
+			clio.Errorf("The Common Fate config file (~/.cf/config by default) was not found. To fix this, run 'granted auth configure https://commonfate.example.com' (replacing the URL in the command with your Common Fate deployment URL")
 		}
 		if err != nil {
 			return err
@@ -44,7 +44,7 @@ var logoutCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		cfg, err := config.LoadDefault(c.Context)
 		if err == config.ErrConfigFileNotFound {
-			clio.Errorf("The Common Fate config file (~/.cf/config by default) was not found. To fix this, run 'granted auth configure https://url.of.your.commonfate.deployment.example.com' (replacing the URL in the command with your Common Fate deployment URL")
+			clio.Errorf("The Common Fate config file (~/.cf/config by default) was not found. To fix this, run 'granted auth configure https://commonfate.example.com' (replacing the URL in the command with your Common Fate deployment URL")
 		}
 		if err != nil {
 			return err

--- a/pkg/granted/auth/auth.go
+++ b/pkg/granted/auth/auth.go
@@ -1,8 +1,6 @@
 package auth
 
 import (
-	"strings"
-
 	"github.com/common-fate/cli/cmd/cli/command"
 	"github.com/common-fate/clio"
 	"github.com/common-fate/sdk/config"
@@ -27,14 +25,8 @@ var loginCommand = cli.Command{
 	Usage: "Authenticate to an OIDC provider",
 	Action: func(c *cli.Context) error {
 		cfg, err := config.LoadDefault(c.Context)
-
-		if err != nil && strings.Contains(err.Error(), "config file does not exist") {
-			clio.Debugw("prompting user login because token is expired", "error_details", err.Error())
-			// NOTE(chrnorm): ideally we'll bubble up a more strongly typed error in future here, to avoid the string comparison on the error message.
-
-			// the OAuth2.0 token is expired so we should prompt the user to log in
-			clio.Infof("Config file not found. To get set up with Common Fate run `granted auth configure https://cf.demo.io`")
-
+		if err == config.ErrConfigFileNotFound {
+			clio.Errorf("The Common Fate config file (~/.cf/config by default) was not found. To fix this, run 'granted auth configure https://url.of.your.commonfate.deployment.example.com' (replacing the URL in the command with your Common Fate deployment URL")
 		}
 		if err != nil {
 			return err
@@ -51,6 +43,9 @@ var logoutCommand = cli.Command{
 	Usage: "Log out of an OIDC provider",
 	Action: func(c *cli.Context) error {
 		cfg, err := config.LoadDefault(c.Context)
+		if err == config.ErrConfigFileNotFound {
+			clio.Errorf("The Common Fate config file (~/.cf/config by default) was not found. To fix this, run 'granted auth configure https://url.of.your.commonfate.deployment.example.com' (replacing the URL in the command with your Common Fate deployment URL")
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -123,7 +123,7 @@ func (h Hook) NoAccess(ctx context.Context, input NoAccessInput) (retry bool, er
 	}
 
 	hasChanges, validation, err := DryRun(ctx, apiURL, accessclient, &req, false)
-	if err != nil && strings.Contains(err.Error(), "oauth2: token expired") {
+	if err != nil && strings.Contains(err.Error(), "oauth2: token expired") || strings.Contains(err.Error(), "oauth2: invalid grant") {
 		clio.Debugw("prompting user login because token is expired", "error_details", err.Error())
 		// NOTE(chrnorm): ideally we'll bubble up a more strongly typed error in future here, to avoid the string comparison on the error message.
 


### PR DESCRIPTION
### What changed?
Adds a case when using `assume` with Common Fate to handle automatically trying to login in when token has expired.

Also includes an improvement to the error message to be more informational on next steps to fix the error.

### Why?
Some users were getting errors when using the integration which required prior set up with the cf cli. This has now been included in Granted. Extra information given in error messages to assist in the process.

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs