### PR TITLE
Improve Granted startup time when HTTP registry is used

### DIFF
--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -166,7 +166,7 @@ var AddCommand = cli.Command{
 			return nil
 		} else {
 
-			registry, err := cfregistry.New(cfregistry.Opts{
+			registry := cfregistry.New(cfregistry.Opts{
 				Name: name,
 				URL:  URL,
 			})

--- a/pkg/granted/registry/registry.go
+++ b/pkg/granted/registry/registry.go
@@ -50,14 +50,10 @@ func GetProfileRegistries(interactive bool) ([]loadedRegistry, error) {
 			})
 		} else {
 			//set up a common fate registry
-			reg, err := cfregistry.New(cfregistry.Opts{
+			reg := cfregistry.New(cfregistry.Opts{
 				Name: r.Name,
 				URL:  r.URL,
 			})
-
-			if err != nil {
-				return nil, err
-			}
 			registries = append(registries, loadedRegistry{
 				Config:   r,
 				Registry: reg,


### PR DESCRIPTION
### What changed?
Defers calling `config.LoadDefault()` every time `assume` is called, which makes startup instant rather than taking ~1s to obtain an access token.

### Why?
Makes `assume` run a *lot* faster when HTTP Profile Registries are used.

### How did you test it?
Confirmed locally, by running `GRANTED_LOG=debug dassume`. Here's the latest release -- you can see in the debug logs that we fetch a token every time Granted runs:

```
❯ GRANTED_LOG=debug assume
[DEBUG] configured config sources  	sources:[env,file]
[DEBUG] loading config  	path:/Users/chrisnorman/.cf/config
[DEBUG] loaded config  	cfg:{CurrentContext:default Contexts:map[default:{name:default APIURL:https://internal.commonfate.io AccessURL:https://commonfate.example.com AuthzURL: OIDCIssuer:https://auth.example.com OIDCClientID:XXXXXXX OIDCClientSecret: HTTPClient:<nil> OIDCProvider:<nil> TokenSource:<nil> TokenStore:<nil>}]}
[DEBUG] attempting to fetch token: https://auth.example.com
```

Whereas the dev build no longer fetches the token:

```
❯ GRANTED_LOG=debug dassume
[DEBUG] checking if autosync has been run for the day
[DEBUG] skipping profile registry sync until tomorrow=%s/Users/chrisnorman/Library/Application Support/commonfate/registry-sync
[DEBUG] process args  	execFlag:	osargs:[dassumego]	c.args:[]
[DEBUG] processed profile name
[DEBUG] exec config:<nil>
```

### Potential risks
Affects the HTTP profile registry component of Granted.

### Is patch release candidate?
Yes
