### PR TITLE
Add retry logic to credential process where an active request exists in Common Fate

### DIFF
--- a/pkg/cfcfg/cfcfg.go
+++ b/pkg/cfcfg/cfcfg.go
@@ -1,0 +1,59 @@
+package cfcfg
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/common-fate/clio"
+	"github.com/common-fate/granted/pkg/cfaws"
+	sdkconfig "github.com/common-fate/sdk/config"
+)
+
+func getCommonFateURL(profile *cfaws.Profile) (*url.URL, error) {
+	if profile == nil {
+		clio.Debugw("skipping loading Common Fate SDK from URL", "reason", "profile was nil")
+		return nil, nil
+	}
+	if profile.RawConfig == nil {
+		clio.Debugw("skipping loading Common Fate SDK from URL", "reason", "profile.RawConfig was nil")
+		return nil, nil
+	}
+	if !profile.RawConfig.HasKey("common_fate_url") {
+		clio.Debugw("skipping loading Common Fate SDK from URL", "reason", "profile does not have key common_fate_url", "profile_keys", profile.RawConfig.KeyStrings())
+		return nil, nil
+	}
+	key, err := profile.RawConfig.GetKey("common_fate_url")
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := url.Parse(key.Value())
+	if err != nil {
+		return nil, fmt.Errorf("invalid common_fate_url (%s): %w", key.Value(), err)
+	}
+
+	return u, nil
+}
+
+func Load(ctx context.Context, profile *cfaws.Profile) (*sdkconfig.Context, error) {
+	cfURL, err := getCommonFateURL(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfURL != nil {
+		cfURL = cfURL.JoinPath("config.json")
+
+		clio.Debugw("configuring Common Fate SDK from URL", "url", cfURL.String())
+
+		return sdkconfig.New(ctx, sdkconfig.Opts{
+			ConfigSources: []string{cfURL.String()},
+		})
+	} else {
+		// if we can't load the Common Fate SDK config (e.g. if `~/.cf/config` is not present)
+		// we can't request access through the Common Fate platform.
+		return sdkconfig.LoadDefault(ctx)
+
+	}
+}

--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -156,7 +156,6 @@ var CredentialProcess = cli.Command{
 			if err != nil {
 				return err
 			}
-			return nil
 		}
 		if !cfg.DisableCredentialProcessCache {
 			clio.Debugw("storing refreshed credentials in credential process cache", "expires", credentials.Expires.String(), "canExpire", credentials.CanExpire, "timeNow", time.Now().String())

--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -6,13 +6,20 @@ import (
 	"fmt"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/pkg/errors"
 
 	"github.com/common-fate/clio"
+	"github.com/common-fate/grab"
 	"github.com/common-fate/granted/pkg/cfaws"
+	"github.com/common-fate/granted/pkg/cfcfg"
 	"github.com/common-fate/granted/pkg/config"
 	"github.com/common-fate/granted/pkg/securestorage"
+	"github.com/common-fate/sdk/eid"
+	accessv1alpha1 "github.com/common-fate/sdk/gen/commonfate/access/v1alpha1"
+	"github.com/common-fate/sdk/service/access/grants"
+	identitysvc "github.com/common-fate/sdk/service/identity"
 	sethRetry "github.com/sethvargo/go-retry"
 	"github.com/urfave/cli/v2"
 )
@@ -86,8 +93,59 @@ var CredentialProcess = cli.Command{
 
 		credentials, err := profile.AssumeTerminal(c.Context, cfaws.ConfigOpts{Duration: duration, UsingCredentialProcess: true, CredentialProcessAutoLogin: autoLogin})
 		if err != nil {
+			// We first check if there was an active grant for this profile, and if there was, allow 30s of retries before bailing out
+			cfg, cfConfigErr := cfcfg.Load(c.Context, profile)
+			if err != nil {
+				if cfConfigErr != nil {
+					clio.Debugw("failed to load cfconfig, skipping check for active grants in a common fate deployment", "error", cfConfigErr)
+				}
+				return err
+			}
+
+			grantsClient := grants.NewFromConfig(cfg)
+			idClient := identitysvc.NewFromConfig(cfg)
+			callerID, callerIDErr := idClient.GetCallerIdentity(c.Context, connect.NewRequest(&accessv1alpha1.GetCallerIdentityRequest{}))
+			if callerIDErr != nil {
+				clio.Debugw("failed to load caller identity for user", "error", callerIDErr)
+				// return the original error
+				return err
+			}
+			grants, queryGrantsErr := grab.AllPages(c.Context, func(ctx context.Context, nextToken *string) ([]*accessv1alpha1.Grant, *string, error) {
+				grants, err := grantsClient.QueryGrants(c.Context, connect.NewRequest(&accessv1alpha1.QueryGrantsRequest{
+					Principal: callerID.Msg.Principal.Eid,
+					Target:    eid.New("AWS::Account", profile.AWSConfig.SSOAccountID).ToAPI(),
+					// This API needs to be updated to use specifiers, for now, fetch all active grants and check for a match on the role name
+					// Role:      eid.New("AWS::Account", profile.AWSConfig.SSOAccountID).ToAPI(),
+					Status: accessv1alpha1.GrantStatus_GRANT_STATUS_ACTIVE.Enum(),
+				}))
+				if err != nil {
+					return nil, nil, err
+				}
+				return grants.Msg.Grants, &grants.Msg.NextPageToken, nil
+			})
+
+			if queryGrantsErr != nil {
+				clio.Debugw("failed to query for active grants", "error", queryGrantsErr)
+				// return the original error
+				return err
+			}
+
+			var foundActiveGrant bool
+			for _, grant := range grants {
+				if grant.Role.Name == profile.AWSConfig.SSORoleName {
+					clio.Debugw("found active grant matching the profile, will retry assuming role", "grant", grant)
+					foundActiveGrant = true
+					break
+				}
+			}
+			if !foundActiveGrant {
+				clio.Debug("did not find any matching active grants for the profile, will not retry assuming role")
+				return err
+			}
+
+			// there is an active grant so retry assuming because the error may be transient
 			b := sethRetry.NewFibonacci(time.Second)
-			b = sethRetry.WithMaxDuration(time.Minute*1, b)
+			b = sethRetry.WithMaxDuration(time.Second*30, b)
 			err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {
 				credentials, err = profile.AssumeTerminal(c.Context, cfaws.ConfigOpts{Duration: duration, UsingCredentialProcess: true, CredentialProcessAutoLogin: autoLogin})
 				if err == nil {
@@ -98,7 +156,7 @@ var CredentialProcess = cli.Command{
 			if err != nil {
 				return err
 			}
-			return err
+			return nil
 		}
 		if !cfg.DisableCredentialProcessCache {
 			clio.Debugw("storing refreshed credentials in credential process cache", "expires", credentials.Expires.String(), "canExpire", credentials.CanExpire, "timeNow", time.Now().String())


### PR DESCRIPTION
### What changed?
Adds a retry step to the credential process when granted fails to AssumeTerminal. The retry will run only if an active grant exists in a linked Common Fate deployment, otherwise, the original error is returned.

### Why?
Users reported that the credential process would return an error sometimes when used immediately after activating an access request in Common Fate.

### How did you test it?
Request access in CF, the use the credential process.
I also ran tests of the code path by simulating and error in AWS, this shows the grant was correctly matched and the Assume call was retried.

### Potential risks


### Is patch release candidate?
yes

### Link to relevant docs PRs