### PR TITLE
fix a bad error check in the credential process

### DIFF
--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -95,10 +95,8 @@ var CredentialProcess = cli.Command{
 		if err != nil {
 			// We first check if there was an active grant for this profile, and if there was, allow 30s of retries before bailing out
 			cfg, cfConfigErr := cfcfg.Load(c.Context, profile)
-			if err != nil {
-				if cfConfigErr != nil {
-					clio.Debugw("failed to load cfconfig, skipping check for active grants in a common fate deployment", "error", cfConfigErr)
-				}
+			if cfConfigErr != nil {
+				clio.Debugw("failed to load cfconfig, skipping check for active grants in a common fate deployment", "error", cfConfigErr)
 				return err
 			}
 


### PR DESCRIPTION
### What changed?
Patches an issue where the error check would always match because it checked for the wrong error

### Why?
Fixes and unreleased issue in #677 

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs