### PR TITLE
Fix error checks on retry logic for assuming roles with common fate

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -425,6 +425,7 @@ func AssumeCommand(c *cli.Context) error {
 				Profile:  profile,
 				Reason:   reason,
 				Duration: apiDuration,
+				Confirm:  assumeFlags.Bool("confirm"),
 			})
 			if hookErr != nil {
 				return hookErr
@@ -436,7 +437,7 @@ func AssumeCommand(c *cli.Context) error {
 				b = sethRetry.WithMaxDuration(time.Minute*1, b)
 				err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {
 					creds, err = profile.AssumeConsole(c.Context, configOpts)
-					if err == nil {
+					if err != nil {
 						return sethRetry.RetryableError(err)
 					}
 					return nil
@@ -557,6 +558,7 @@ func AssumeCommand(c *cli.Context) error {
 				Profile:  profile,
 				Reason:   reason,
 				Duration: apiDuration,
+				Confirm:  assumeFlags.Bool("confirm"),
 			})
 			if hookErr != nil {
 				return hookErr
@@ -568,7 +570,7 @@ func AssumeCommand(c *cli.Context) error {
 				b = sethRetry.WithMaxDuration(time.Minute*1, b)
 				err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {
 					creds, err = profile.AssumeTerminal(c.Context, configOpts)
-					if err == nil {
+					if err != nil {
 						return sethRetry.RetryableError(err)
 					}
 					return nil

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -52,6 +52,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "aws-config-file"},
 		&cli.StringFlag{Name: "chain", Usage: "Assume a given role ARN using the profile selected"},
 		&cli.StringFlag{Name: "reason", Usage: "Provide a reason for requesting access to the role"},
+		&cli.StringFlag{Name: "confirm", Usage: "Use this to skip confirmation prompts for access requests"},
 	}
 }
 

--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -152,7 +152,7 @@ var CredentialProcess = cli.Command{
 			b = sethRetry.WithMaxDuration(time.Second*30, b)
 			err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {
 				credentials, err = profile.AssumeTerminal(c.Context, cfaws.ConfigOpts{Duration: duration, UsingCredentialProcess: true, CredentialProcessAutoLogin: autoLogin})
-				if err == nil {
+				if err != nil {
 					return sethRetry.RetryableError(err)
 				}
 				return nil


### PR DESCRIPTION
### What changed?
Fixes error checks in retry logic incorrectly skipping retrying when assuming fails

### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs