### PR TITLE
add flag that waits for access to be active

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -429,11 +429,12 @@ func AssumeCommand(c *cli.Context) error {
 			}
 
 			noAccessInput := accessrequesthook.NoAccessInput{
-				Profile:  profile,
-				Reason:   reason,
-				Duration: apiDuration,
-				Confirm:  assumeFlags.Bool("confirm"),
-				Wait:     wait,
+				Profile:   profile,
+				Reason:    reason,
+				Duration:  apiDuration,
+				Confirm:   assumeFlags.Bool("confirm"),
+				Wait:      wait,
+				StartTime: time.Now(),
 			}
 			retry, hookErr := hook.NoAccess(c.Context, noAccessInput)
 			if hookErr != nil {
@@ -441,8 +442,10 @@ func AssumeCommand(c *cli.Context) error {
 			}
 
 			if retry {
+				// reset the start time for the timer (otherwise it shows 2s, 7s, 12s etc)
+				noAccessInput.StartTime = time.Now()
 
-				b := sethRetry.NewConstant(time.Second)
+				b := sethRetry.NewConstant(5 * time.Second)
 				b = sethRetry.WithMaxDuration(retryDuration, b)
 				err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {
 
@@ -571,11 +574,12 @@ func AssumeCommand(c *cli.Context) error {
 				apiDuration = durationpb.New(d)
 			}
 			noAccessInput := accessrequesthook.NoAccessInput{
-				Profile:  profile,
-				Reason:   reason,
-				Duration: apiDuration,
-				Confirm:  assumeFlags.Bool("confirm"),
-				Wait:     wait,
+				Profile:   profile,
+				Reason:    reason,
+				Duration:  apiDuration,
+				Confirm:   assumeFlags.Bool("confirm"),
+				Wait:      wait,
+				StartTime: time.Now(),
 			}
 			retry, hookErr := hook.NoAccess(c.Context, noAccessInput)
 			if hookErr != nil {
@@ -583,6 +587,9 @@ func AssumeCommand(c *cli.Context) error {
 			}
 
 			if retry {
+				// reset the start time for the timer (otherwise it shows 2s, 7s, 12s etc)
+				noAccessInput.StartTime = time.Now()
+
 				b := sethRetry.NewConstant(time.Second * 5)
 				b = sethRetry.WithMaxDuration(retryDuration, b)
 				err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -53,6 +53,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "chain", Usage: "Assume a given role ARN using the profile selected"},
 		&cli.StringFlag{Name: "reason", Usage: "Provide a reason for requesting access to the role"},
 		&cli.StringFlag{Name: "confirm", Usage: "Use this to skip confirmation prompts for access requests"},
+		&cli.BoolFlag{Name: "wait", Usage: "When using Granted with Common Fate the assume will halt while waiting for the access request to be approved."},
 	}
 }
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -35,6 +35,7 @@ type NoAccessInput struct {
 	Reason   string
 	Duration *durationpb.Duration
 	Confirm  bool
+	Wait     bool
 }
 
 func (h Hook) NoAccess(ctx context.Context, input NoAccessInput) (retry bool, err error) {
@@ -176,7 +177,13 @@ func (h Hook) NoAccess(ctx context.Context, input NoAccessInput) (retry bool, er
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_REQUESTED:
 			color.New(color.BgHiYellow, color.FgBlack).Fprintf(os.Stderr, "[REQUESTED]")
-			color.New(color.FgYellow).Fprintf(os.Stderr, " %s requires approval: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
+			color.New(color.FgYellow).Fprintf(os.Stderr, " %s requires approval: %s\n\n", g.Grant.Name, requestURL(apiURL, g.Grant))
+
+			if input.Wait {
+
+				clio.Infow("Waiting for request to be approved and activated...")
+				return true, nil
+			}
 
 			return false, errors.New("applying access was attempted but the resources requested require approval before activation")
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -264,7 +264,7 @@ func (h Hook) RetryAccess(ctx context.Context, input NoAccessInput) error {
 
 		// if grant is approved but the change is unspecified then the user is not able to automatically activate
 		if g.Grant.Approved && g.Change == accessv1alpha1.GrantChange_GRANT_CHANGE_UNSPECIFIED {
-			clio.Infof("Request was approved but failed to activate, user might not have permission to activate. Waiting for activation. [%s elapsed]", elapsed)
+			clio.Infof("Request was approved but failed to activate, you might not have permission to activate. You can try and activate the access using the Common Fate web console. [%s elapsed]", elapsed)
 		}
 
 		if !g.Grant.Approved {

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -257,6 +257,8 @@ func (h Hook) RetryAccess(ctx context.Context, input NoAccessInput) error {
 		return err
 	}
 
+	clio.Debugw("batch ensure response", "res", res.Msg)
+
 	now := time.Now()
 	elapsed := now.Sub(input.StartTime).Round(time.Second * 10)
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -263,7 +263,7 @@ func (h Hook) RetryAccess(ctx context.Context, input NoAccessInput) error {
 	for _, g := range res.Msg.Grants {
 
 		// if grant is approved but the change is unspecified then the user is not able to automatically activate
-		if g.Grant.Approved && g.Change == accessv1alpha1.GrantChange_GRANT_CHANGE_UNSPECIFIED {
+		if g.Grant.Approved && g.Change == accessv1alpha1.GrantChange_GRANT_CHANGE_UNSPECIFIED && g.Grant.ProvisioningStatus != accessv1alpha1.ProvisioningStatus_PROVISIONING_STATUS_SUCCESSFUL {
 			clio.Infof("Request was approved but failed to activate, you might not have permission to activate. You can try and activate the access using the Common Fate web console. [%s elapsed]", elapsed)
 		}
 


### PR DESCRIPTION
### What changed?
New flag added to the assume command `--wait` which when used with a Common Fate integration, will wait for 15 minutes reattempting to grab credentials. 

### Why?
This flag can be used when requesting access that requires manual approval and activation, removing the need to run the assume command twice.

### How did you test it?
See below.

### Potential risks
This changes the retry logic to use a constant retry rather than Fibonacci. There is a possibility that the constant attempt at requesting access could cause 429 errors, but in testing this did not happen (over a 10 minute period)

### Is patch release candidate?


### Link to relevant docs PRs