### PR TITLE
Add support for Firefox Nightly

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -464,7 +464,7 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 
-		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.WaterfoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey || cfg.DefaultBrowser == browser.FirefoxDevEditionKey {
+		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.WaterfoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey || cfg.DefaultBrowser == browser.FirefoxDevEditionKey || cfg.DefaultBrowser == browser.FirefoxNightlyKey {
 			// transform the URL into the Firefox Tab Container format.
 			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", containerProfile, url.QueryEscape(consoleURL), profile.CustomGrantedProperty("color"), profile.CustomGrantedProperty("icon"))
 		}
@@ -498,6 +498,10 @@ func AssumeCommand(c *cli.Context) error {
 			l = launcher.Arc{}
 		case browser.FirefoxDevEditionKey:
 			l = launcher.FirefoxDevEdition{
+				ExecutablePath: browserPath,
+			}
+		case browser.FirefoxNightlyKey:
+			l = launcher.FirefoxNightly{
 				ExecutablePath: browserPath,
 			}
 		case browser.CommonFateKey:

--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -19,6 +19,7 @@ const (
 	FirefoxStdoutKey     string = "FIREFOX_STDOUT"
 	ArcKey               string = "ARC"
 	FirefoxDevEditionKey string = "FIREFOX_DEV"
+	FirefoxNightlyKey    string = "FIREFOX_NIGHTLY"
 	CommonFateKey        string = "COMMON_FATE"
 )
 
@@ -42,6 +43,10 @@ var FirefoxPathWindows = []string{`\Program Files\Mozilla Firefox\firefox.exe`}
 var FirefoxDevPathMac = []string{"/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox"}
 var FirefoxDevPathLinux = []string{`/usr/bin/firefox-developer`, `/../../mnt/c/Program Files/Firefox Developer Edition/firefox.exe`}
 var FirefoxDevPathWindows = []string{`\Program Files\Firefox Developer Edition\firefox.exe`}
+
+var FirefoxNightlyPathMac = []string{"/Applications/Firefox Nightly.app/Contents/MacOS/firefox"}
+var FirefoxNightlyPathLinux = []string{`/usr/bin/firefox-nightly`, `/../../mnt/c/Program Files/Firefox Nightly/firefox.exe`}
+var FirefoxNightlyPathWindows = []string{`\Program Files\Firefox Nightly\firefox.exe`}
 
 var WaterfoxPathMac = []string{"/Applications/Waterfox.app/Contents/MacOS/waterfox"}
 var WaterfoxPathLinux = []string{`/usr/bin/waterfox`, `/../../mnt/c/Program Files/Waterfox/waterfox.exe`}
@@ -146,6 +151,24 @@ func FirefoxDevPathDefaults() ([]string, error) {
 		return FirefoxDevPathMac, nil
 	case "linux":
 		return FirefoxDevPathLinux, nil
+	default:
+		return nil, errors.New("os not supported")
+	}
+}
+
+func FirefoxNightlyPathDefaults() ([]string, error) {
+	// check linuxpath for binary install
+	path, err := exec.LookPath("firefox-nightly")
+	if err == nil {
+		return []string{path}, nil
+	}
+	switch runtime.GOOS {
+	case "windows":
+		return FirefoxNightlyPathWindows, nil
+	case "darwin":
+		return FirefoxNightlyPathMac, nil
+	case "linux":
+		return FirefoxNightlyPathLinux, nil
 	default:
 		return nil, errors.New("os not supported")
 	}

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -50,7 +50,7 @@ func HandleManualBrowserSelection() (string, error) {
 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 	in := survey.Select{
 		Message: "Select one of the browsers from the list",
-		Options: []string{"Chrome", "Brave", "Edge", "Firefox", "Waterfox", "Chromium", "Safari", "Stdout", "FirefoxStdout", "Firefox Developer Edition", "Arc"},
+		Options: []string{"Chrome", "Brave", "Edge", "Firefox", "Waterfox", "Chromium", "Safari", "Stdout", "FirefoxStdout", "Firefox Developer Edition", "Firefox Nightly", "Arc"},
 	}
 	var selection string
 	clio.NewLine()
@@ -108,6 +108,10 @@ func GetBrowserKey(b string) string {
 		return FirefoxDevEditionKey
 	}
 
+	if strings.ToLower(b) == "firefox nightly" {
+		return FirefoxNightlyKey
+	}
+
 	if strings.Contains(strings.ToLower(b), "brave") {
 		return BraveKey
 	}
@@ -159,6 +163,8 @@ func DetectInstallation(browserKey string) (string, bool) {
 		bPath, _ = ArcPathDefaults()
 	case FirefoxDevEditionKey:
 		bPath, _ = FirefoxDevPathDefaults()
+	case FirefoxNightlyKey:
+		bPath, _ = FirefoxNightlyPathDefaults()
 	default:
 		return "", false
 	}
@@ -241,7 +247,7 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 			browserPath = customBrowserPath
 		}
 
-		if browserKey == FirefoxKey || browserKey == WaterfoxKey || browserKey == FirefoxDevEditionKey {
+		if browserKey == FirefoxKey || browserKey == WaterfoxKey || browserKey == FirefoxDevEditionKey || browserKey == FirefoxNightlyKey {
 			err := RunFirefoxExtensionPrompts(browserPath, browserName)
 			if err != nil {
 				return err

--- a/pkg/launcher/firefox_nightly.go
+++ b/pkg/launcher/firefox_nightly.go
@@ -1,0 +1,15 @@
+package launcher
+
+type FirefoxNightly struct {
+	ExecutablePath string
+}
+
+func (l FirefoxNightly) LaunchCommand(url string, profile string) []string {
+	return []string{
+		l.ExecutablePath,
+		"--new-tab",
+		url,
+	}
+}
+
+func (l FirefoxNightly) UseForkProcess() bool { return true }


### PR DESCRIPTION
### What changed?
Added support for Firefox Nightly

### Why?
Couldn't get granted to work with Firefox Nightly
Selecting Firefox and manually setting Firefox Nightly's path would produce the same error as in #380

### How did you test it?
1. `make cli`
2. `dgranted browser set` and select the new option Firefox Nightly
3. `dassume -c`
4. Granted opens Firefox Nightly with the right session on its own container

Only tested on MacOS but I checked that the binary paths for other OS are correct

### Potential risks
None

### Is patch release candidate?
Yes, no breaking changes

### Link to relevant docs PRs