### PR TITLE
Update file backend password prompt, add option to clear the entire Granted cache

### DIFF
--- a/pkg/securestorage/securestorage.go
+++ b/pkg/securestorage/securestorage.go
@@ -6,11 +6,9 @@ import (
 	"path"
 
 	"github.com/99designs/keyring"
-	"github.com/AlecAivazis/survey/v2"
 
 	"github.com/common-fate/clio"
 	"github.com/common-fate/granted/pkg/config"
-	"github.com/common-fate/granted/pkg/testable"
 	"github.com/pkg/errors"
 )
 
@@ -135,13 +133,14 @@ func (s *SecureStorage) openKeyring() (keyring.Keyring, error) {
 
 		// Fallback encrypted file
 		FileDir: secureStoragePath,
-		FilePasswordFunc: func(s string) (string, error) {
-			in := survey.Password{Message: s}
-			var out string
-			withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
-			err := testable.AskOne(&in, &out, withStdio)
-			return out, err
-		},
+		// FilePasswordFunc: func(s string) (string, error) {
+		// 	in := survey.Password{Message: s}
+		// 	var out string
+		// 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+		// 	err := testable.AskOne(&in, &out, withStdio)
+		// 	return out, err
+		// },
+		FilePasswordFunc: keyring.FixedStringPrompt(os.Getenv("CF_KEYRING_FILE_PASSWORD")),
 	}
 
 	// enable debug logging if the verbose flag is set in the CLI

--- a/pkg/securestorage/securestorage.go
+++ b/pkg/securestorage/securestorage.go
@@ -133,13 +133,7 @@ func (s *SecureStorage) openKeyring() (keyring.Keyring, error) {
 
 		// Fallback encrypted file
 		FileDir: secureStoragePath,
-		// FilePasswordFunc: func(s string) (string, error) {
-		// 	in := survey.Password{Message: s}
-		// 	var out string
-		// 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
-		// 	err := testable.AskOne(&in, &out, withStdio)
-		// 	return out, err
-		// },
+
 		FilePasswordFunc: keyring.FixedStringPrompt(os.Getenv("CF_KEYRING_FILE_PASSWORD")),
 	}
 


### PR DESCRIPTION
### What changed?
Updates the function used for retrieving the file backend password.
Adds a `--all` flag to the `granted cache clear` command to clear all the credentials in the backend

### Why?
Adds an easier way to access the file backend.
Adds an easer method of clearing the entire cache.

### How did you test it?
assuming a role with my backend as file. 
Was not prompted for a password

Ran `granted cache clear --all` and it cleared out all the credentials for a storage type

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs