### PR TITLE
Handle nested parameters in granted settings set command

### DIFF
--- a/pkg/granted/settings/set.go
+++ b/pkg/granted/settings/set.go
@@ -47,6 +47,7 @@ var SetConfigCommand = cli.Command{
 					fieldName = parent + "." + fieldType.Name
 				}
 
+				//subfield structs reflect as a pointer
 				if kind == reflect.Ptr {
 					// Dereference the pointer to get the underlying value
 					if !fieldValue.IsNil() {
@@ -90,9 +91,10 @@ var SetConfigCommand = cli.Command{
 		var value interface{}
 		var prompt survey.Prompt
 		selectedFieldType := selectedField.ftype.Type
+		//optional fields are pointers
 		isPointer := selectedFieldType.Kind() == reflect.Ptr
 		if isPointer {
-			selectedFieldType = selectedFieldType.Elem() // Dereference the pointer type
+			selectedFieldType = selectedFieldType.Elem()
 		}
 		switch selectedFieldType.Kind() {
 		case reflect.Bool:

--- a/pkg/granted/settings/set_test.go
+++ b/pkg/granted/settings/set_test.go
@@ -1,8 +1,10 @@
 package settings
 
 import (
+	"slices"
 	"testing"
 
+	"github.com/common-fate/grab"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,7 +13,7 @@ func TestFieldOptions(t *testing.T) {
 		A string
 		B struct {
 			C string
-			D string
+			D *string
 		}
 	}
 	tests := []struct {
@@ -23,12 +25,26 @@ func TestFieldOptions(t *testing.T) {
 		{
 			name:  "ok",
 			input: input{},
-			want:  []string{"A", "B.C", "B.D"},
+			want:  []string{"A", "B.C"},
 		},
 		{
 			name:  "ok",
 			input: &input{},
-			want:  []string{"A", "B.C", "B.D"},
+			want:  []string{"A", "B.C"},
+		},
+		{
+			name: "ok",
+			input: &input{
+				A: "A",
+				B: struct {
+					C string
+					D *string
+				}{
+					C: "C",
+					D: grab.Ptr("D"),
+				},
+			},
+			want: []string{"A", "B.C", "B.D"},
 		},
 	}
 	for _, tt := range tests {
@@ -38,6 +54,9 @@ func TestFieldOptions(t *testing.T) {
 			for k := range got {
 				keys = append(keys, k)
 			}
+
+			//sort to make sure the keys are in the correct order for the test
+			slices.Sort(keys)
 
 			assert.Equal(t, tt.want, keys)
 		})

--- a/pkg/granted/settings/set_test.go
+++ b/pkg/granted/settings/set_test.go
@@ -1,0 +1,40 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldOptions(t *testing.T) {
+	type input struct {
+		A string
+		B struct {
+			C string
+			D *string
+		}
+	}
+	tests := []struct {
+		name  string
+		input any
+		want  []string
+		want1 map[string]field
+	}{
+		{
+			name:  "ok",
+			input: input{},
+			want:  []string{"A", "B.C", "B.D"},
+		},
+		{
+			name:  "ok",
+			input: &input{},
+			want:  []string{"A", "B.C", "B.D"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := FieldOptions(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/granted/settings/set_test.go
+++ b/pkg/granted/settings/set_test.go
@@ -11,7 +11,7 @@ func TestFieldOptions(t *testing.T) {
 		A string
 		B struct {
 			C string
-			D *string
+			D string
 		}
 	}
 	tests := []struct {
@@ -33,8 +33,13 @@ func TestFieldOptions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := FieldOptions(tt.input)
-			assert.Equal(t, tt.want, got)
+			got := FieldOptions(tt.input)
+			keys := make([]string, 0, len(got))
+			for k := range got {
+				keys = append(keys, k)
+			}
+
+			assert.Equal(t, tt.want, keys)
 		})
 	}
 }


### PR DESCRIPTION
### What changed?
The `granted settings set` command will now handle nested parameters. For example `Backend.Keychain`. Dot notation is used for setting a nested value.

eg. `granted settings set --setting Keyring.Backend --value File`

Nested attributes will also show up in the list when running `granted settings set` without any flags:
 
```
❯ granted settings set
? Select the configuration to change  [Use arrows to move, type to filter]
> DefaultBrowser
  CustomBrowserPath
  CustomSSOBrowserPath
  Keyring.Backend
  Ordering
  ExportCredentialSuffix
  ExportCredsToAWS
```
### Why?
Previously there was no way to set these nested programatically and the `~/.granted/config`
 file would need to be manually edited.
### How did you test it?
`dgranted settings set` and setting the value of Keyring.Backend to a new value

`dgranted settings set --setting=Keyring.Backend --value=File`

```
❯ dgranted settings set --setting=Keyring.Backend --value=File
[i] Updating the value of Keyring.Backend to File
[✔] Config updated successfully
```
### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs