### PR TITLE
Fix --confirm flag

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -429,11 +429,12 @@ func AssumeCommand(c *cli.Context) error {
 			}
 
 			noAccessInput := accessrequesthook.NoAccessInput{
-				Profile:  profile,
-				Reason:   reason,
-				Duration: apiDuration,
-				Confirm:  assumeFlags.Bool("confirm"),
-				Wait:     wait,
+				Profile:   profile,
+				Reason:    reason,
+				Duration:  apiDuration,
+				Confirm:   assumeFlags.Bool("confirm"),
+				Wait:      wait,
+				StartTime: time.Now(),
 			}
 			retry, hookErr := hook.NoAccess(c.Context, noAccessInput)
 			if hookErr != nil {
@@ -441,8 +442,10 @@ func AssumeCommand(c *cli.Context) error {
 			}
 
 			if retry {
+				// reset the start time for the timer (otherwise it shows 2s, 7s, 12s etc)
+				noAccessInput.StartTime = time.Now()
 
-				b := sethRetry.NewConstant(time.Second)
+				b := sethRetry.NewConstant(5 * time.Second)
 				b = sethRetry.WithMaxDuration(retryDuration, b)
 				err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {
 
@@ -571,11 +574,12 @@ func AssumeCommand(c *cli.Context) error {
 				apiDuration = durationpb.New(d)
 			}
 			noAccessInput := accessrequesthook.NoAccessInput{
-				Profile:  profile,
-				Reason:   reason,
-				Duration: apiDuration,
-				Confirm:  assumeFlags.Bool("confirm"),
-				Wait:     wait,
+				Profile:   profile,
+				Reason:    reason,
+				Duration:  apiDuration,
+				Confirm:   assumeFlags.Bool("confirm"),
+				Wait:      wait,
+				StartTime: time.Now(),
 			}
 			retry, hookErr := hook.NoAccess(c.Context, noAccessInput)
 			if hookErr != nil {
@@ -583,6 +587,9 @@ func AssumeCommand(c *cli.Context) error {
 			}
 
 			if retry {
+				// reset the start time for the timer (otherwise it shows 2s, 7s, 12s etc)
+				noAccessInput.StartTime = time.Now()
+
 				b := sethRetry.NewConstant(time.Second * 5)
 				b = sethRetry.WithMaxDuration(retryDuration, b)
 				err = sethRetry.Do(c.Context, b, func(ctx context.Context) (err error) {

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -52,7 +52,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "aws-config-file"},
 		&cli.StringFlag{Name: "chain", Usage: "Assume a given role ARN using the profile selected"},
 		&cli.StringFlag{Name: "reason", Usage: "Provide a reason for requesting access to the role"},
-		&cli.StringFlag{Name: "confirm", Usage: "Use this to skip confirmation prompts for access requests"},
+		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "Skip confirmation prompts for access requests"},
 		&cli.BoolFlag{Name: "wait", Usage: "When using Granted with Common Fate the assume will halt while waiting for the access request to be approved."},
 	}
 }

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -53,6 +53,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "chain", Usage: "Assume a given role ARN using the profile selected"},
 		&cli.StringFlag{Name: "reason", Usage: "Provide a reason for requesting access to the role"},
 		&cli.StringFlag{Name: "confirm", Usage: "Use this to skip confirmation prompts for access requests"},
+		&cli.BoolFlag{Name: "wait", Usage: "When using Granted with Common Fate the assume will halt while waiting for the access request to be approved."},
 	}
 }
 

--- a/pkg/granted/request/request.go
+++ b/pkg/granted/request/request.go
@@ -35,7 +35,7 @@ var latestCommand = cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "reason", Usage: "A reason for access"},
 		&cli.DurationFlag{Name: "duration", Usage: "Duration of request, defaults to max duration of the access rule."},
-		&cli.BoolFlag{Name: "confirm", Usage: "Confirm requesting access"},
+		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "Skip confirmation prompts for access requests"},
 	},
 	Action: func(c *cli.Context) error {
 		latest, err := accessrequest.LatestProfile()

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -370,7 +370,7 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 
 	if !confirm {
 		if !IsTerminal(os.Stdin.Fd()) {
-			return false, nil, errors.New("detected a noninteractive terminal: to apply the planned changes please re-run with the --confirm-access-request flag")
+			return false, nil, errors.New("detected a noninteractive terminal: to apply the planned changes please re-run with the --confirm flag")
 		}
 
 		withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -35,6 +35,7 @@ type NoAccessInput struct {
 	Reason   string
 	Duration *durationpb.Duration
 	Confirm  bool
+	Wait     bool
 }
 
 func (h Hook) NoAccess(ctx context.Context, input NoAccessInput) (retry bool, err error) {
@@ -176,7 +177,13 @@ func (h Hook) NoAccess(ctx context.Context, input NoAccessInput) (retry bool, er
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_REQUESTED:
 			color.New(color.BgHiYellow, color.FgBlack).Fprintf(os.Stderr, "[REQUESTED]")
-			color.New(color.FgYellow).Fprintf(os.Stderr, " %s requires approval: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
+			color.New(color.FgYellow).Fprintf(os.Stderr, " %s requires approval: %s\n\n", g.Grant.Name, requestURL(apiURL, g.Grant))
+
+			if input.Wait {
+
+				clio.Infow("Waiting for request to be approved and activated...")
+				return true, nil
+			}
 
 			return false, errors.New("applying access was attempted but the resources requested require approval before activation")
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -264,7 +264,7 @@ func (h Hook) RetryAccess(ctx context.Context, input NoAccessInput) error {
 
 		// if grant is approved but the change is unspecified then the user is not able to automatically activate
 		if g.Grant.Approved && g.Change == accessv1alpha1.GrantChange_GRANT_CHANGE_UNSPECIFIED {
-			clio.Infof("Request was approved but failed to activate, user might not have permission to activate. Waiting for activation. [%s elapsed]", elapsed)
+			clio.Infof("Request was approved but failed to activate, you might not have permission to activate. You can try and activate the access using the Common Fate web console. [%s elapsed]", elapsed)
 		}
 
 		if !g.Grant.Approved {


### PR DESCRIPTION
- Fix panic due to nil pointer dereference (#675)
- Add retry logic to credential process where an active request exists in Common Fate (#677)
- Credential process prompts to use 'granted request latest' when possible (#679)
- fix a bad error check in the credential process (#678)
- Fix error checks on retry logic for assuming roles with common fate (#681)
- add flag that waits for access to be active
- add check to see if request is activated and assume once it is
- add elapsed time printout
- make error message more user friendly
- Fix `--confirm` flag parsing
- use the correct '--confirm' flag

### What changed?


### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs