### PR TITLE
Fix --confirm flag parsing

### DIFF
--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -52,7 +52,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "aws-config-file"},
 		&cli.StringFlag{Name: "chain", Usage: "Assume a given role ARN using the profile selected"},
 		&cli.StringFlag{Name: "reason", Usage: "Provide a reason for requesting access to the role"},
-		&cli.StringFlag{Name: "confirm", Usage: "Use this to skip confirmation prompts for access requests"},
+		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "Skip confirmation prompts for access requests"},
 		&cli.BoolFlag{Name: "wait", Usage: "When using Granted with Common Fate the assume will halt while waiting for the access request to be approved."},
 	}
 }

--- a/pkg/granted/request/request.go
+++ b/pkg/granted/request/request.go
@@ -35,7 +35,7 @@ var latestCommand = cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "reason", Usage: "A reason for access"},
 		&cli.DurationFlag{Name: "duration", Usage: "Duration of request, defaults to max duration of the access rule."},
-		&cli.BoolFlag{Name: "confirm", Usage: "Confirm requesting access"},
+		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "Skip confirmation prompts for access requests"},
 	},
 	Action: func(c *cli.Context) error {
 		latest, err := accessrequest.LatestProfile()

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -372,7 +372,7 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 
 	if !confirm {
 		if !IsTerminal(os.Stdin.Fd()) {
-			return false, nil, errors.New("detected a noninteractive terminal: to apply the planned changes please re-run with the --confirm-access-request flag")
+			return false, nil, errors.New("detected a noninteractive terminal: to apply the planned changes please re-run with the --confirm flag")
 		}
 
 		withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)


### PR DESCRIPTION
### What changed?
- Fix `--confirm` flag parsing
- Fix the prompt when a noninteractive terminal is used to use `--confirm`


### Why?
`--confirm` was not working as intended

### How did you test it?
Confirmed on my machine that `dassume --confirm` works to skip the prompt.

### Potential risks
None - bug fix

### Is patch release candidate?
Yes

