### PR TITLE
Fix default duration when requesting access with Granted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/common-fate/clio v1.2.3
 	github.com/common-fate/common-fate v0.15.13
 	github.com/common-fate/glide-cli v0.6.0
-	github.com/common-fate/sdk v1.37.0
+	github.com/common-fate/sdk v1.40.2-0.20240625075744-48540f6115cf
 	github.com/fatih/color v1.16.0
 	github.com/lithammer/fuzzysearch v1.1.5
 	github.com/schollz/progressbar/v3 v3.13.1

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/common-fate/iso8601 v1.1.0 h1:nrej9shsK1aB4IyOAjZl68xGk8yDuUxVwQjoDzx
 github.com/common-fate/iso8601 v1.1.0/go.mod h1:DU4mvUEkkWZUUSJq2aCuNqM1luSb0Pwyb2dLzXS+img=
 github.com/common-fate/sdk v1.37.0 h1:pn4S2MkwbYFglYg5/bMY/55qMclUamui1H1g8/KftkA=
 github.com/common-fate/sdk v1.37.0/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
+github.com/common-fate/sdk v1.40.2-0.20240625075744-48540f6115cf h1:rNAW5DxQI7ioLTs6vZKXI3GF0sYoSbQw3WuVH1SO2BE=
+github.com/common-fate/sdk v1.40.2-0.20240625075744-48540f6115cf/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/common-fate/updatecheck v0.3.5 h1:UGIKMnYwuHjbhhCaisLz1pNPg8Z1nXEoWcfqT+4LkAg=
 github.com/common-fate/updatecheck v0.3.5/go.mod h1:fru9yoUXmM3QVAUdDDqKQeDoln20Pkji/7EH64gVHMs=
 github.com/common-fate/useragent v0.1.0 h1:RLmkIiJXcOUJAUyXWc/zCaGbrGmlCbHBGMx99ztQ3ZU=

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -12,7 +12,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/briandowns/spinner"
-	accesscmd "github.com/common-fate/cli/cmd/cli/command/access"
 	"github.com/common-fate/cli/printdiags"
 	"github.com/common-fate/clio"
 	"github.com/common-fate/granted/pkg/cfaws"
@@ -155,8 +154,12 @@ func (h Hook) NoAccess(ctx context.Context, input NoAccessInput) (retry bool, er
 
 		exp := "<invalid expiry>"
 
-		if g.Grant.ExpiresAt != nil {
-			exp = accesscmd.ShortDur(time.Until(g.Grant.ExpiresAt.AsTime()))
+		if res.Msg.DurationConfiguration != nil {
+			exp = ShortDur(res.Msg.DurationConfiguration.MaxDuration.AsDuration())
+			if res.Msg.DurationConfiguration.DefaultDuration != nil {
+				exp = ShortDur(res.Msg.DurationConfiguration.DefaultDuration.AsDuration())
+
+			}
 		}
 
 		switch g.Change {
@@ -319,8 +322,11 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 
 		exp := "<invalid expiry>"
 
-		if g.Grant.ExpiresAt != nil {
-			exp = ShortDur(time.Until(g.Grant.ExpiresAt.AsTime()))
+		if res.Msg.DurationConfiguration != nil {
+			exp = ShortDur(res.Msg.DurationConfiguration.MaxDuration.AsDuration())
+			if res.Msg.DurationConfiguration.DefaultDuration != nil {
+				exp = ShortDur(res.Msg.DurationConfiguration.DefaultDuration.AsDuration())
+			}
 		}
 
 		if g.Change > 0 {


### PR DESCRIPTION
### What changed?
Fixes the default duration when requesting access with Granted - extracted this change from #691 so it can be merged separately, as it depends on an SDK change which needs to be approved.

### Why?
Granted uses the maximum duration for JIT access rather than the default duration

### How did you test it?
Untested locally

### Potential risks
May affect JIT access durations

### Is patch release candidate?
Yes

