### PR TITLE
added flag to disable cache lookup and saving

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -287,6 +287,7 @@ func AssumeCommand(c *cli.Context) error {
 		Duration:     time.Hour,
 		MFATokenCode: assumeFlags.String("mfa-token"),
 		Args:         assumeFlags.StringSlice("pass-through"),
+		DisableCache: assumeFlags.Bool("no-cache"),
 	}
 
 	// attempt to get session duration from profile

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -54,7 +54,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "reason", Usage: "Provide a reason for requesting access to the role"},
 		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "Skip confirmation prompts for access requests"},
 		&cli.BoolFlag{Name: "wait", Usage: "When using Granted with Common Fate the assume will halt while waiting for the access request to be approved."},
-		&cli.BoolFlag{Name: "no-cache", Usage: "Disables caching of session credentials and forces a refresh"},
+		&cli.BoolFlag{Name: "no-cache", Usage: "Disables caching of session credentials and forces a refresh", EnvVars: []string{"GRANTED_NO_CACHE"}},
 	}
 }
 

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -54,6 +54,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "reason", Usage: "Provide a reason for requesting access to the role"},
 		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "Skip confirmation prompts for access requests"},
 		&cli.BoolFlag{Name: "wait", Usage: "When using Granted with Common Fate the assume will halt while waiting for the access request to be approved."},
+		&cli.BoolFlag{Name: "no-cache", Usage: "Disables caching of session credentials and forces a refresh"},
 	}
 }
 

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -26,6 +26,7 @@ type ConfigOpts struct {
 	Args                       []string
 	ShouldRetryAssuming        *bool
 	MFATokenCode               string
+	DisableCache               bool
 }
 
 type Profile struct {

--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -43,6 +43,7 @@ var CredentialProcess = cli.Command{
 		&cli.StringFlag{Name: "url"},
 		&cli.DurationFlag{Name: "window", Value: 15 * time.Minute},
 		&cli.BoolFlag{Name: "auto-login", Usage: "automatically open the configured browser to log in if needed"},
+		&cli.BoolFlag{Name: "no-cache", Usage: "Disables caching of session credentials and forces a refresh", EnvVars: []string{"GRANTED_NO_CACHE"}},
 	},
 	Action: func(c *cli.Context) error {
 		cfg, err := config.Load()
@@ -55,7 +56,8 @@ var CredentialProcess = cli.Command{
 		secureSessionCredentialStorage := securestorage.NewSecureSessionCredentialStorage()
 		clio.Debugw("running credential process with config", "profile", profileName, "url", c.String("url"), "window", c.Duration("window"), "disableCredentialProcessCache", cfg.DisableCredentialProcessCache)
 
-		useCache := !cfg.DisableCredentialProcessCache
+		cliNoCache := c.Bool("no-cache")
+		useCache := !cfg.DisableCredentialProcessCache || !cliNoCache
 
 		if useCache {
 			// try and look up session credentials from the secure storage cache.

--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -57,7 +57,7 @@ var CredentialProcess = cli.Command{
 		clio.Debugw("running credential process with config", "profile", profileName, "url", c.String("url"), "window", c.Duration("window"), "disableCredentialProcessCache", cfg.DisableCredentialProcessCache)
 
 		cliNoCache := c.Bool("no-cache")
-		useCache := !cfg.DisableCredentialProcessCache || !cliNoCache
+		useCache := !(cfg.DisableCredentialProcessCache || cliNoCache)
 
 		if useCache {
 			// try and look up session credentials from the secure storage cache.


### PR DESCRIPTION
### What changed?
Adds `--no-cache` flag which disables saving and pulling cached tokens from storage and forces a relogin. 

### Why?
Some users have found stale sso tokens are being pulled blocking them from getting valid credentials using sso. This is a potential work around for when this occurs

### How did you test it?
Using assume with the --no-cache flag and having to login.
Omitting the flag assume works as normal

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs