### PR TITLE
pass in stdio to dupe profile prompt

### DIFF
--- a/pkg/granted/registry/sync.go
+++ b/pkg/granted/registry/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/common-fate/clio"
@@ -73,7 +74,8 @@ func SyncProfileRegistries(ctx context.Context, interactive bool) error {
 
 			in := survey.Select{Message: "Please select which option would you like to choose to resolve: ", Options: options}
 			var selected string
-			err = testable.AskOne(&in, &selected)
+			withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+			err = testable.AskOne(&in, &selected, withStdio)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### What changed?
Bugfix for the profile registry prompt that was not showing up correctly due to printing to the wrong io

### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs