### PR TITLE
updated granted cache clear --all

### DIFF
--- a/pkg/granted/cache.go
+++ b/pkg/granted/cache.go
@@ -57,13 +57,42 @@ var ClearCommand = cli.Command{
 	Name:  "clear",
 	Usage: "Clear cached credential from the secure storage",
 	Flags: []cli.Flag{
-		&cli.BoolFlag{Name: "all", Usage: "clears all of the cached credentials from storage"},
+		&cli.BoolFlag{Name: "all", Usage: "clears all of the cached credentials from all secure storage"},
 		&cli.StringFlag{Name: "storage", Usage: "Specify the storage type"},
 		&cli.StringFlag{Name: "profile", Usage: "Specify the profile name of the credential which should be cleared"},
 	},
 	Action: func(c *cli.Context) error {
 
 		withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+
+		storageToNameMap := map[string]securestorage.SecureStorage{
+			"aws-iam-credentials": securestorage.NewSecureIAMCredentialStorage().SecureStorage,
+			"sso-token":           securestorage.NewSecureSSOTokenStorage().SecureStorage,
+			"session-credentials": securestorage.NewSecureSessionCredentialStorage().SecureStorage,
+		}
+
+		clearAll := c.Bool("all")
+
+		if clearAll {
+			for name, storage := range storageToNameMap {
+				keys, err := storage.ListKeys()
+				if err != nil {
+					return err
+				}
+				if len(keys) == 0 {
+					continue
+				}
+				for _, key := range keys {
+					err = storage.Clear(key)
+					if err != nil {
+						return err
+					}
+				}
+				clio.Debugw("clear flag provided clearing cache for all credentials in storage", "storage", name)
+			}
+			clio.Infow("cleared cache for all credentials in storage", "storage", "all")
+			return nil
+		}
 
 		selection := c.String("storage")
 		if selection == "" {
@@ -78,18 +107,6 @@ var ClearCommand = cli.Command{
 			}
 		}
 
-		clearAll := c.Bool("all")
-
-		if clearAll {
-			clio.Debugw("clear flag provided clearing cache for all credentials in storage", "storage", selection)
-		}
-
-		storageToNameMap := map[string]securestorage.SecureStorage{
-			"aws-iam-credentials": securestorage.NewSecureIAMCredentialStorage().SecureStorage,
-			"sso-token":           securestorage.NewSecureSSOTokenStorage().SecureStorage,
-			"session-credentials": securestorage.NewSecureSessionCredentialStorage().SecureStorage,
-		}
-
 		// store the credentials in secure storage
 		selectedStorage := storageToNameMap[selection]
 
@@ -101,18 +118,6 @@ var ClearCommand = cli.Command{
 		if len(keys) == 0 {
 			clio.Warnf("You do not have any cached credentials for %s storage", selection)
 			return nil
-		}
-
-		if clearAll {
-			for _, key := range keys {
-				err = selectedStorage.Clear(key)
-				if err != nil {
-					return err
-				}
-			}
-			clio.Infow("cleared cache for all credentials in storage", "storage", selection)
-			return nil
-
 		}
 
 		selectedProfile := c.String("profile")


### PR DESCRIPTION
### What changed?
Updated `granted cache clear --all` clears all of the cached credentials from all secure storage insead of only selected secure storage

### Why?
Easy useage

### How did you test it?
Locally

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs