### PR TITLE
The NoAccess hook should not return an error when a user does not use Common Fate

### DIFF
--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -41,7 +41,8 @@ type NoAccessInput struct {
 func (h Hook) NoAccess(ctx context.Context, input NoAccessInput) (retry bool, err error) {
 	cfg, err := cfcfg.Load(ctx, input.Profile)
 	if err != nil {
-		return false, err
+		clio.Debugw("failed to load cfconfig, skipping check for active grants in a common fate deployment", "error", err)
+		return false, nil
 	}
 
 	target := eid.New("AWS::Account", input.Profile.AWSConfig.SSOAccountID)


### PR DESCRIPTION
### What changed?
Brings the assume command in line with the credential process behaviour when a user does not have Common Fate deployment configured. Will now log the config error to debug and skip the check for an active request.

### Why?
Users reported that they were getting a config file error which is related to Common Fate despite them not having A deployment configured.

Our code was incorrectly handling an error loading a config file for CF in the assume command, despite it working for the credential process.

### How did you test it?
existing behaviour
```
assume Audit/AWSAdministratorAccess
[✘] config file does not exist
```

new behaviour
```
❯ dassume Audit/AWSAdministratorAccess
[✘] no access: operation error SSO: GetRoleCredentials, https response error StatusCode: 403, RequestID: bed86fbe-ec59-407d-8e50-399acea0acb2, api error ForbiddenException: No access

```


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs