### PR TITLE
Sanity check error matching of invalid_grant

### DIFF
--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -420,6 +420,13 @@ func shouldRefreshLogin(err error) bool {
 	if strings.Contains(err.Error(), "oauth2: invalid grant") {
 		return true
 	}
+	// Sanity check that error message is matching correctly. See: https://linear.app/common-fate/issue/CF-3379/granted-should-auto-login-when-receiving-an-invalid-grant-error
+	if strings.Contains(err.Error(), `oauth2: "token_expired"`) {
+		return true
+	}
+	if strings.Contains(err.Error(), `oauth2: "invalid_grant"`) {
+		return true
+	}
 
 	return false
 }

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -420,7 +420,7 @@ func shouldRefreshLogin(err error) bool {
 	if strings.Contains(err.Error(), "oauth2: invalid grant") {
 		return true
 	}
-	// Sanity check that error message is matching correctly. See: https://linear.app/common-fate/issue/CF-3379/granted-should-auto-login-when-receiving-an-invalid-grant-error
+	// Sanity check that error message is matching correctly
 	if strings.Contains(err.Error(), `oauth2: "token_expired"`) {
 		return true
 	}


### PR DESCRIPTION
### What changed?

Added a sanity check to the error matching of `invalid_grant`, as a user reported that they were seeing this error but were not able to trigger the auth login flow. 

Given the user error of `Unavailable: oauth2: "invalid_grant"` on version 0.29.0, it could have possibly not matched on the error, therefore, not invoking the auth login flow afterwards.

### Why?

A user reported seeing error message `Unavailable: oauth2: "invalid_grant"`.

### How did you test it?

I could not reproduce the error on version 0.29.0. 

Attempted:

- `granted auth logout` then try to assume the role
- Intentionally break access token
- Intentionally expire access token

### Potential risks

This code is relatively safe as it is a sanity check

### Is patch release candidate?

Yes

### Link to relevant docs PRs
