### PR TITLE
fix issue causing credential process to break

### DIFF
--- a/pkg/granted/awsmerge/merge_from_registry.go
+++ b/pkg/granted/awsmerge/merge_from_registry.go
@@ -189,6 +189,12 @@ func (m Merger) WithRegistry(src *ini.File, dst *ini.File, opts RegistryOpts) (*
 			return nil, err
 		}
 
+		//after the section has been copied, update the credential process if it exists to the new profile name
+
+		if f.HasKey("credential_process") {
+			f.Key("credential_process").SetValue(strings.Replace(f.Key("credential_process").Value(), sec.Name(), f.Name(), 1))
+		}
+
 		if f.Comment == "" {
 			f.Comment = "# profile name has been prefixed due to duplication"
 		} else {

--- a/pkg/granted/awsmerge/merge_from_registry.go
+++ b/pkg/granted/awsmerge/merge_from_registry.go
@@ -189,7 +189,7 @@ func (m Merger) WithRegistry(src *ini.File, dst *ini.File, opts RegistryOpts) (*
 			return nil, err
 		}
 
-		//after the section has been copied, update the credential process if it exists to the new profile name
+		// after the section has been copied, update the credential process if it exists to the new profile name
 
 		if f.HasKey("credential_process") {
 			f.Key("credential_process").SetValue(strings.Replace(f.Key("credential_process").Value(), sec.Name(), f.Name(), 1))

--- a/pkg/granted/registry/cfregistry/cfregistry.go
+++ b/pkg/granted/registry/cfregistry/cfregistry.go
@@ -37,11 +37,21 @@ func (r *Registry) getClient() (awsv1alpha1connect.ProfileRegistryServiceClient,
 	if r.client != nil {
 		return r.client, nil
 	}
-	cfg, err := config.LoadDefault(context.Background())
+
+	err := config.SwitchContext(r.opts.Name)
 	if err != nil {
 		return nil, err
 	}
 
+	// ctx, err := config.GetContextByURL(r.opts.URL)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	cfg, err := config.LoadDefault(context.Background())
+	if err != nil {
+		return nil, err
+	}
 	accountClient := grantedv1alpha1.NewFromConfig(cfg)
 
 	r.mu.Lock()

--- a/pkg/granted/registry/cfregistry/cfregistry.go
+++ b/pkg/granted/registry/cfregistry/cfregistry.go
@@ -38,11 +38,6 @@ func (r *Registry) getClient() (awsv1alpha1connect.ProfileRegistryServiceClient,
 		return r.client, nil
 	}
 
-	err := config.SwitchContext(r.opts.Name)
-	if err != nil {
-		return nil, err
-	}
-
 	cfg, err := config.LoadDefault(context.Background())
 	if err != nil {
 		return nil, err

--- a/pkg/granted/registry/cfregistry/cfregistry.go
+++ b/pkg/granted/registry/cfregistry/cfregistry.go
@@ -43,11 +43,6 @@ func (r *Registry) getClient() (awsv1alpha1connect.ProfileRegistryServiceClient,
 		return nil, err
 	}
 
-	// ctx, err := config.GetContextByURL(r.opts.URL)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	cfg, err := config.LoadDefault(context.Background())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What changed?
Bugfix: Fixed issue when duplicate profiles are found and the duplicate prefix was not applied to the credential process when using Granted registry 

### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs