### PR TITLE
Granted caching fixes

### DIFF
--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -63,7 +63,7 @@ var CredentialProcess = cli.Command{
 			// try and look up session credentials from the secure storage cache.
 			cachedCreds, err := secureSessionCredentialStorage.GetCredentials(profileName)
 			if err != nil {
-				clio.Debugw("error loading cached credentials", "error", err)
+				clio.Debugw("error loading cached credentials", "error", err, "profile", profileName)
 			} else if cachedCreds == nil {
 				clio.Debugw("refreshing credentials", "reason", "cachedCreds was nil")
 			} else if cachedCreds.CanExpire && cachedCreds.Expires.Add(-c.Duration("window")).Before(time.Now()) {
@@ -77,6 +77,12 @@ var CredentialProcess = cli.Command{
 
 		if !useCache {
 			clio.Debugw("refreshing credentials", "reason", "credential process cache is disabled via config")
+		}
+
+		// purge the credentials from the cache
+		err = secureSessionCredentialStorage.SecureStorage.Clear(profileName)
+		if err != nil {
+			clio.Debugw("error clearing cached credentials", "error", err, "profile", profileName)
 		}
 
 		profiles, err := cfaws.LoadProfiles()

--- a/pkg/granted/request/check.go
+++ b/pkg/granted/request/check.go
@@ -9,6 +9,7 @@ import (
 	"github.com/common-fate/grab"
 	"github.com/common-fate/granted/pkg/cfaws"
 	"github.com/common-fate/granted/pkg/cfcfg"
+	"github.com/common-fate/granted/pkg/securestorage"
 	"github.com/common-fate/sdk/eid"
 	accessv1alpha1 "github.com/common-fate/sdk/gen/commonfate/access/v1alpha1"
 	"github.com/common-fate/sdk/service/access/grants"
@@ -77,6 +78,14 @@ var checkCommand = cli.Command{
 				return nil
 			}
 		}
+
+		// no active Access Request exists, so the session token cache should be cleared for the profile.
+		cache := securestorage.NewSecureSessionCredentialStorage()
+		err = cache.SecureStorage.Clear(profileName)
+		if err != nil {
+			return fmt.Errorf("no active Access Request found for target %s and role %s: error clearing cache for profile %q: %w", target, profile.AWSConfig.SSORoleName, profileName, err)
+		}
+
 		return fmt.Errorf("no active Access Request found for target %s and role %s", target, profile.AWSConfig.SSORoleName)
 	},
 }

--- a/pkg/granted/request/check.go
+++ b/pkg/granted/request/check.go
@@ -1,0 +1,82 @@
+package request
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/common-fate/clio"
+	"github.com/common-fate/grab"
+	"github.com/common-fate/granted/pkg/cfaws"
+	"github.com/common-fate/granted/pkg/cfcfg"
+	"github.com/common-fate/sdk/eid"
+	accessv1alpha1 "github.com/common-fate/sdk/gen/commonfate/access/v1alpha1"
+	"github.com/common-fate/sdk/service/access/grants"
+	identitysvc "github.com/common-fate/sdk/service/identity"
+	"github.com/urfave/cli/v2"
+)
+
+var checkCommand = cli.Command{
+	Name:  "check",
+	Usage: "Check the Common Fate JIT backend to see whether Just-In-Time access to a particular entitlement is active",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "aws-profile", Required: true, Usage: "Check for access for a particular AWS profile"},
+	},
+	Action: func(c *cli.Context) error {
+		profiles, err := cfaws.LoadProfiles()
+		if err != nil {
+			return err
+		}
+
+		profileName := c.String("aws-profile")
+
+		profile, err := profiles.LoadInitialisedProfile(c.Context, profileName)
+		if err != nil {
+			return err
+		}
+
+		cfg, cfConfigErr := cfcfg.Load(c.Context, profile)
+		if cfConfigErr != nil {
+			clio.Debugw("failed to load cfconfig, skipping check for active grants in a common fate deployment", "error", cfConfigErr)
+			return err
+		}
+
+		grantsClient := grants.NewFromConfig(cfg)
+		idClient := identitysvc.NewFromConfig(cfg)
+		callerID, callerIDErr := idClient.GetCallerIdentity(c.Context, connect.NewRequest(&accessv1alpha1.GetCallerIdentityRequest{}))
+		if callerIDErr != nil {
+			return err
+		}
+		target := eid.New("AWS::Account", profile.AWSConfig.SSOAccountID)
+
+		grants, queryGrantsErr := grab.AllPages(c.Context, func(ctx context.Context, nextToken *string) ([]*accessv1alpha1.Grant, *string, error) {
+			grants, err := grantsClient.QueryGrants(c.Context, connect.NewRequest(&accessv1alpha1.QueryGrantsRequest{
+				Principal: callerID.Msg.Principal.Eid,
+				Target:    target.ToAPI(),
+				// This API needs to be updated to use specifiers, for now, fetch all active grants and check for a match on the role name
+				// Role:      eid.New("AWS::Account", profile.AWSConfig.SSOAccountID).ToAPI(),
+				Status: accessv1alpha1.GrantStatus_GRANT_STATUS_ACTIVE.Enum(),
+			}))
+			if err != nil {
+				return nil, nil, err
+			}
+			return grants.Msg.Grants, &grants.Msg.NextPageToken, nil
+		})
+
+		if queryGrantsErr != nil {
+			clio.Debugw("failed to query for active grants", "error", queryGrantsErr)
+			// return the original error
+			return err
+		}
+
+		for _, grant := range grants {
+			if grant.Role.Name == profile.AWSConfig.SSORoleName {
+				clio.Debugw("found active grant matching the profile, will retry assuming role", "grant", grant)
+				clio.Successf("access to target %s and role %s is currently active", target, profile.AWSConfig.SSORoleName)
+				fmt.Println(grant.AccessRequestId)
+				return nil
+			}
+		}
+		return fmt.Errorf("no active Access Request found for target %s and role %s", target, profile.AWSConfig.SSORoleName)
+	},
+}

--- a/pkg/granted/request/request.go
+++ b/pkg/granted/request/request.go
@@ -26,6 +26,7 @@ var Command = cli.Command{
 	Usage: "Request access to a role",
 	Subcommands: []*cli.Command{
 		&latestCommand,
+		&checkCommand,
 	},
 }
 


### PR DESCRIPTION


### What changed?
- fixes an issue where existing cached credentials weren't purged when we refetch credentials
- adds 'granted request check' to check the current status of JIT profiles
- fixes to 'granted cache clear'

This PR removes some of the interactivity around 'granted cache clear' - it *is* a breaking API change but given that the previous API required manual user input, we do not believe this should be an issue for any users.

### Why?
Issues seeing `InvalidClientTokenId` and general Granted caching issues when using Granted with Common Fate JIT backend.

### How did you test it?
Verified that cache was being cleared properly, manually tested the `granted request check` command.

### Potential risks
May impact cache refreshing in credential process

### Is patch release candidate?


### Link to relevant docs PRs