### PR TITLE
Prevent a panic due to configFile being nil

### DIFF
--- a/pkg/granted/registry/sync.go
+++ b/pkg/granted/registry/sync.go
@@ -48,6 +48,13 @@ func SyncProfileRegistries(ctx context.Context, interactive bool) error {
 		return err
 	}
 
+	if configFile == nil {
+		// prevent a panic reported by a user due to configFile being empty.
+		// It is likely this is caused by Granted being run for the first time on
+		// a device that does not have AWS profiles set up.
+		return nil
+	}
+
 	m := awsmerge.Merger{}
 
 	for _, r := range registries {


### PR DESCRIPTION
### What changed?
Returns early if `configFile` is nil in `SyncProfileRegistries` to prevent a panic.

### Why?
Fixes a panic reported by a Granted user.


### How did you test it?
Untested locally but this code path will only be triggered by the edge case where `configFile` is nil, and this change avoids Granted panicking entirely.

### Potential risks
May impact profile registry sync but low risk as `configFile` should never be nil in normal operation

### Is patch release candidate?
Yes

