### PR TITLE
feat: support Flatpak Firefox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX?=${HOME}/.local
+PREFIX?=/usr/local
 
 go-binary:
 	go build -o ./bin/dgranted cmd/granted/main.go

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX?=/usr/local
+PREFIX?=${HOME}/.local
 
 go-binary:
 	go build -o ./bin/dgranted cmd/granted/main.go

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -468,7 +468,6 @@ func AssumeCommand(c *cli.Context) error {
 		printFlagUsage(con.Region, con.Service)
 		clio.Infof("Opening a console for %s in your browser...", profile.Name)
 
-		clio.Infof("Opening console for %s in %s", profile.Name, cfg.DefaultBrowser)
 		// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
 		args := l.LaunchCommand(consoleURL, containerProfile)
 

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -405,7 +405,12 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 
-		if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.WaterfoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey || cfg.DefaultBrowser == browser.FirefoxDevEditionKey || cfg.DefaultBrowser == browser.FirefoxNightlyKey {
+		if cfg.DefaultBrowser == browser.FirefoxKey ||
+			cfg.DefaultBrowser == browser.WaterfoxKey ||
+			cfg.DefaultBrowser == browser.FirefoxStdoutKey ||
+			cfg.DefaultBrowser == browser.FirefoxDevEditionKey ||
+			cfg.DefaultBrowser == browser.FirefoxNightlyKey ||
+			cfg.DefaultBrowser == browser.FlatpakFirefoxKey {
 			// transform the URL into the Firefox Tab Container format.
 			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", containerProfile, url.QueryEscape(consoleURL), profile.CustomGrantedProperty("color"), profile.CustomGrantedProperty("icon"))
 		}
@@ -450,6 +455,12 @@ func AssumeCommand(c *cli.Context) error {
 				// for CommonFate, executable path must be set as custom browser path
 				ExecutablePath: browserPath,
 			}
+		case browser.FlatpakFirefoxKey:
+			l = launcher.Flatpak{
+				ExecutablePath: browserPath,
+				FlatpakID:      cfg.FlatpakBrowserAppID,
+				BrowserType:    browser.FirefoxKey,
+			}
 		default:
 			l = launcher.Open{}
 		}
@@ -457,12 +468,15 @@ func AssumeCommand(c *cli.Context) error {
 		printFlagUsage(con.Region, con.Service)
 		clio.Infof("Opening a console for %s in your browser...", profile.Name)
 
+		clio.Infof("Opening console for %s in %s", profile.Name, cfg.DefaultBrowser)
 		// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
 		args := l.LaunchCommand(consoleURL, containerProfile)
+		clio.Infof("Launch Args: %s", args)
 
 		var startErr error
 		if l.UseForkProcess() {
 			clio.Debugf("running command using forkprocess: %s", args)
+
 			cmd, err := forkprocess.New(args...)
 			if err != nil {
 				return err

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -471,12 +471,10 @@ func AssumeCommand(c *cli.Context) error {
 		clio.Infof("Opening console for %s in %s", profile.Name, cfg.DefaultBrowser)
 		// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
 		args := l.LaunchCommand(consoleURL, containerProfile)
-		clio.Infof("Launch Args: %s", args)
 
 		var startErr error
 		if l.UseForkProcess() {
 			clio.Debugf("running command using forkprocess: %s", args)
-
 			cmd, err := forkprocess.New(args...)
 			if err != nil {
 				return err

--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -21,6 +21,7 @@ const (
 	FirefoxDevEditionKey string = "FIREFOX_DEV"
 	FirefoxNightlyKey    string = "FIREFOX_NIGHTLY"
 	CommonFateKey        string = "COMMON_FATE"
+	FlatpakFirefoxKey    string = "FLATPAK_FIREFOX"
 )
 
 // A few default paths to check for the browser
@@ -59,6 +60,8 @@ var ChromiumPathWindows = []string{`\Program Files\Chromium\chromium.exe`}
 var SafariPathMac = []string{"/Applications/Safari.app/Contents/MacOS/Safari"}
 
 var ArcPathMac = []string{"/Applications/Arc.app/Contents/MacOS/Arc"}
+
+var FlatpakPathLinux = []string{`/usr/bin/flatpak`}
 
 func ChromePathDefaults() ([]string, error) {
 	// check linuxpath for binary install
@@ -133,6 +136,21 @@ func FirefoxPathDefaults() ([]string, error) {
 		return FirefoxPathMac, nil
 	case "linux":
 		return FirefoxPathLinux, nil
+	default:
+		return nil, errors.New("os not supported")
+	}
+}
+
+func FlatpakPathDefaults() ([]string, error) {
+	// check linuxpath for binary install
+	path, err := exec.LookPath("flatpak")
+	if err == nil {
+		return []string{path}, nil
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		return FlatpakPathLinux, nil
 	default:
 		return nil, errors.New("os not supported")
 	}

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -125,7 +125,13 @@ func GetBrowserKey(b string) string {
 	if strings.EqualFold(b, FirefoxNightlyKey) {
 		return FirefoxNightlyKey
 	}
-
+	if strings.HasPrefix(strings.ToLower(b), "flatpak") {
+		clio.Infof("Returning %s", FlatpakFirefoxKey)
+		switch b {
+		case "Flatpak - Firefox":
+			return FlatpakFirefoxKey
+		}
+	}
 	if strings.EqualFold(b, BraveKey) {
 		return BraveKey
 	}
@@ -135,7 +141,7 @@ func GetBrowserKey(b string) string {
 	if strings.EqualFold(b, FirefoxStdoutKey) {
 		return FirefoxStdoutKey
 	}
-	if strings.EqualFold(b, FirefoxKey) || strings.ToLower(b) == "mozilla" {
+	if strings.EqualFold(b, FirefoxKey) || strings.Contains(strings.ToLower(b), "mozilla") {
 		return FirefoxKey
 	}
 	if strings.EqualFold(b, WaterfoxKey) {
@@ -149,9 +155,6 @@ func GetBrowserKey(b string) string {
 	}
 	if strings.EqualFold(b, ArcKey) {
 		return ArcKey
-	}
-	if strings.EqualFold(b, FlatpakFirefoxKey) {
-		return FlatpakFirefoxKey
 	}
 
 	return StdoutKey
@@ -184,6 +187,7 @@ func DetectInstallation(browserKey string) (string, bool) {
 		bPath, _ = FirefoxNightlyPathDefaults()
 	case FlatpakFirefoxKey:
 		bPath, _ = FlatpakPathDefaults()
+		clio.Infof("Flatpak path: %s", bPath)
 	default:
 		return "", false
 	}

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -248,7 +248,6 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Flatpak app id: %s\n", flatpakAppID)
 		browserPath, err = exec.LookPath("flatpak")
 		if err != nil {
 			return errors.Wrap(err, "flatpak not found")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	// used to override the builtin filepaths for custom installation locations
 	CustomBrowserPath      string
 	CustomSSOBrowserPath   string
+	FlatpakBrowserAppID    string
+	FlatpakSSOBrowserAppID string
 	Keyring                *KeyringConfig `toml:",omitempty"`
 	Ordering               string
 	ExportCredentialSuffix string

--- a/pkg/launcher/flatpak.go
+++ b/pkg/launcher/flatpak.go
@@ -1,0 +1,29 @@
+package launcher
+
+type Flatpak struct {
+	// ExecutablePath is the path to the Flatpak binary on the system.
+	ExecutablePath string
+
+	// FlatpakID is the ID of the Flatpak to run.
+	FlatpakID string
+
+	// BrowserType is the type of browser to expect (e.g. FIREFOX).
+	BrowserType string
+}
+
+func (l Flatpak) LaunchCommand(url string, profile string) []string {
+	switch l.BrowserType {
+	case "FIREFOX":
+		return []string{
+			l.ExecutablePath,
+			"run",
+			l.FlatpakID,
+			"--new-tab",
+			url,
+		}
+	default:
+		return []string{}
+	}
+}
+
+func (l Flatpak) UseForkProcess() bool { return true }


### PR DESCRIPTION
### What changed?

Initial support for Flatpak-based browsers, in this PR, this is scoped to only Firefox.

This implementation treats Flatpak as a browser, which is invoked with the app ID.  It doesn't make too much sense logically, but it follows the existing conventions.  Otherwise it would have required far larger changes I am unable to commit to at this time.

### Why?

Linux users don't always have a browser installed as a system package.  It's getting more and more common to use Flatpaks installed from Flathub (you can think of it as the Linux app store)

### How did you test it?

On a machine with a Flatpak Firefox installation, I ran `make cli`, `dgranted set browser` and selected "Flatpak - Firefox".  
This prompts the user to enter the app ID (since it can therefore support all variations of Flatpak Firefox (dev, nightly etc).

Once that is done, I validated the `~/.dgranted/config` file contained the required parameters:
```
DefaultBrowser = "FLATPAK_FIREFOX"
CustomBrowserPath = "/usr/bin/flatpak"
CustomSSOBrowserPath = ""
FlatpakBrowserAppID = "org.mozilla.firefox"
FlatpakSSOBrowserAppID = ""
Ordering = ""
ExportCredentialSuffix = ""
```

And finally, I ran `gdassume -c <role>` which opened up a Flatpak Firefox browser.

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs