### PR TITLE
keep in logic for backwards compatability in common fate timings

### DIFF
--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -389,6 +389,9 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 			if res.Msg.DurationConfiguration.DefaultDuration != nil {
 				exp = ShortDur(res.Msg.DurationConfiguration.DefaultDuration.AsDuration())
 			}
+		} else {
+			//attempt to work out duration from expiry to preserve backyards compatability
+			exp = ShortDur(time.Until(g.Grant.ExpiresAt.AsTime()))
 		}
 
 		if g.Change > 0 {

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -390,7 +390,7 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 				exp = ShortDur(res.Msg.DurationConfiguration.DefaultDuration.AsDuration())
 			}
 		} else if g.Grant.ExpiresAt != nil {
-			//attempt to work out duration from expiry to preserve backyards compatability with older common fate versions
+			//attempt to work out duration from expiry to preserve backwards compatability with older common fate versions
 			exp = ShortDur(time.Until(g.Grant.ExpiresAt.AsTime()))
 		}
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -389,8 +389,8 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 			if res.Msg.DurationConfiguration.DefaultDuration != nil {
 				exp = ShortDur(res.Msg.DurationConfiguration.DefaultDuration.AsDuration())
 			}
-		} else {
-			//attempt to work out duration from expiry to preserve backyards compatability
+		} else if g.Grant.ExpiresAt != nil {
+			//attempt to work out duration from expiry to preserve backyards compatability with older common fate versions
 			exp = ShortDur(time.Until(g.Grant.ExpiresAt.AsTime()))
 		}
 


### PR DESCRIPTION
### What changed?
In Common Fate versions > 2.1.0 there was an api change to alter how the expiry is calculated for access requests. This PR keeps in the logic to allow users running versions < 2.1.0 to still get the expiry time come through in logging messages.

### Why?
Users are no longer seeing expiry information if they are on a version < 2.1.0

### How did you test it?
tested without the change and got `<invalid expiry>` Then with the change got the correct expiry.

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs