### PR TITLE
WIP: Add bash completion

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -169,6 +169,52 @@ func SetupZSHAutoCompleteFolderGranted() (string, error) {
 	return zshPath, nil
 }
 
+// checks and or creates the config folder on startup
+func SetupBashAutoCompleteFolderAssume() (string, error) {
+	grantedFolder, err := GrantedConfigFolder()
+	if err != nil {
+		return "", err
+	}
+	bashPath := path.Join(grantedFolder, "bash_autocomplete")
+	if _, err := os.Stat(bashPath); os.IsNotExist(err) {
+		err := os.Mkdir(bashPath, 0700)
+		if err != nil {
+			return "", err
+		}
+	}
+	bashPath = path.Join(bashPath, build.AssumeScriptName())
+	if _, err := os.Stat(bashPath); os.IsNotExist(err) {
+		err := os.Mkdir(bashPath, 0700)
+		if err != nil {
+			return "", err
+		}
+	}
+	return bashPath, nil
+}
+
+// checks and or creates the config folder on startup
+func SetupBashAutoCompleteFolderGranted() (string, error) {
+	grantedFolder, err := GrantedConfigFolder()
+	if err != nil {
+		return "", err
+	}
+	bashPath := path.Join(grantedFolder, "bash_autocomplete")
+	if _, err := os.Stat(bashPath); os.IsNotExist(err) {
+		err := os.Mkdir(bashPath, 0700)
+		if err != nil {
+			return "", err
+		}
+	}
+	bashPath = path.Join(bashPath, build.GrantedBinaryName())
+	if _, err := os.Stat(bashPath); os.IsNotExist(err) {
+		err := os.Mkdir(bashPath, 0700)
+		if err != nil {
+			return "", err
+		}
+	}
+	return bashPath, nil
+}
+
 func GrantedConfigFolder() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/pkg/granted/templates/bash_autocomplete_assume.tmpl
+++ b/pkg/granted/templates/bash_autocomplete_assume.tmpl
@@ -1,0 +1,35 @@
+#! /bin/bash
+# adapted from https://github.com/urfave/cli/blob/main/autocomplete/bash_autocomplete  
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+_cli_init_completion() {
+  COMPREPLY=()
+  _get_comp_words_by_ref "$@" cur prev words cword
+}
+
+_cli_bash_autocomplete() { 
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base words
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if declare -F _init_completion >/dev/null 2>&1; then
+      _init_completion -n "=:" || return
+    else
+      _cli_init_completion -n "=:" || return
+    fi
+    words=("${words[@]:0:$cword}")
+    if [[ "$cur" == "-"* ]]; then
+      requestComp="FORCE_NO_ALIAS=true ${words[*]} ${cur} --generate-bash-completion"
+    else
+      requestComp="FORCE_NO_ALIAS=true ${words[*]} --generate-bash-completion"
+    fi
+    opts=$(eval "${requestComp}" 2>/dev/null)
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG

--- a/pkg/granted/templates/bash_autocomplete_granted.tmpl
+++ b/pkg/granted/templates/bash_autocomplete_granted.tmpl
@@ -1,0 +1,35 @@
+#! /bin/bash
+# adapted from https://github.com/urfave/cli/blob/main/autocomplete/bash_autocomplete  
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+_cli_init_completion() {
+  COMPREPLY=()
+  _get_comp_words_by_ref "$@" cur prev words cword
+}
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base words
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if declare -F _init_completion >/dev/null 2>&1; then
+      _init_completion -n "=:" || return
+    else
+      _cli_init_completion -n "=:" || return
+    fi
+    words=("${words[@]:0:$cword}")
+    if [[ "$cur" == "-"* ]]; then
+      requestComp="${words[*]} ${cur} --generate-bash-completion"
+    else
+      requestComp="${words[*]} --generate-bash-completion"
+    fi
+    opts=$(eval "${requestComp}" 2>/dev/null)
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG


### PR DESCRIPTION
### What changed?
Add some initial code to support bash completion following the guide here https://cli.urfave.org/v2/examples/bash-completions/


On Mac OS I install bash completion support using brew https://formulae.brew.sh/formula/bash-completion however this led me to an error with `nosort` I followed this guide  https://rakhesh.com/mac/bash-complete-nosort-invalid-option-name/ to identify the completions that were causing this issue.
removing them from the folder made the error go away.

I'm on mac using bash 3.2

To get this working, we need to figure out exactly what the install steps and prerequisits are for bash complete to work on each platform and with which versions of bash.

We need to codify this, so thats generating the completion scripts and moving it to the correct location so that it gets loaded when bash starts.

In ZSH we had some extra behaviour for handling arguments and for assume, forcing no shell alias, this needs to be tested once we can get the completions to run in a dev environment.


### Why?


### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs