### PR TITLE
Access Request should not immediately extend after request has just been activated

### DIFF
--- a/pkg/granted/rds/rds.go
+++ b/pkg/granted/rds/rds.go
@@ -161,7 +161,7 @@ var proxyCommand = cli.Command{
 			StartTime: time.Now(),
 		}
 		hook := accessrequesthook.Hook{}
-		retry, result, err := hook.NoEntitlementAccess(ctx, cfg, input)
+		retry, result, _, err := hook.NoEntitlementAccess(ctx, cfg, input)
 		if err != nil {
 			return err
 		}

--- a/pkg/granted/request/request.go
+++ b/pkg/granted/request/request.go
@@ -103,7 +103,7 @@ var latestCommand = cli.Command{
 			apiDuration = durationpb.New(duration)
 		}
 
-		_, err = hook.NoAccess(c.Context, accessrequesthook.NoAccessInput{
+		_, _, err = hook.NoAccess(c.Context, accessrequesthook.NoAccessInput{
 			Profile:  profile,
 			Reason:   reason,
 			Duration: apiDuration,


### PR DESCRIPTION
### What changed?
Previously, access requests that had just been activated would automatically be extended, since the batch ensure API is called twice. This was not an issue before we deprecated `try_extend_after_seconds`, which would not allow a user to extend until x seconds after activation. However, since that has now been deprecated, it lead to this undesirable behaviour.

This PR will not attempt another batch ensure api call if the grant has just been activated.

### How did you test it?

Testing evidence:

Before it would immediately extend an activated request when using assuming.

![image](https://github.com/user-attachments/assets/d2926de2-2262-462a-982f-229936f247c1)

After the changes, when running the assume command:

```
calvinluy➜~/Git/granted(calvin/cf-3453-access-extension-does-not-work✗)» dassume                                                          [16:41:21]

? Please select the profile you would like to assume: CommonFateDemo/AWSReadOnlyAccess                
[i] To assume this profile again later without needing to select it, run this command:
> assume CommonFateDemo/AWSReadOnlyAccess 
[i] You don't currently have access to CommonFateDemo/AWSReadOnlyAccess, checking if we can request access...   [target=AWS::Account::"975050289140", role=AWSReadOnlyAccess, url=https://internal.commonfate.io]
[WILL ACTIVATE] AWSReadOnlyAccess access to CommonFateDemo will be activated for 1h: https://internal.commonfate.io/access/requests/req_2kEEiG50qjxxt3selokLIOzKtj5
[i] Access::Grant::"gra_2kEEiEFtWkRPQE5y4aC8AbL7M3E": read only AWS access is automatically approved
? Apply proposed access changes Yes
[i] Attempting to grant access...
? Reason for access (Required) Test that it should not automatically extend the request upon activation.
[i] Access::Grant::"gra_2kEElPHPwGD1tp3e0dS06BM64lJ": read only AWS access is automatically approved
[ACTIVATED] AWSReadOnlyAccess access to CommonFateDemo was activated for 1h: https://internal.commonfate.io/access/requests/req_2kEElJqAxlVCOmAii8ZLhFZM2EU
[i] Access::Grant::"gra_2kEElPHPwGD1tp3e0dS06BM64lJ": read only AWS access is automatically approved
[✔] [CommonFateDemo/AWSReadOnlyAccess](ap-southeast-2) session credentials will expire in 1 hour
```

It will behave as expected:
<img width="589" alt="Screenshot 2024-08-05 at 4 49 06 PM" src="https://github.com/user-attachments/assets/947593f9-777c-4b2d-9ccc-962005fdda62">


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs