### PR TITLE
Support multiple Common Fate profile Registries

### DIFF
--- a/pkg/cfcfg/cfcfg.go
+++ b/pkg/cfcfg/cfcfg.go
@@ -57,3 +57,17 @@ func Load(ctx context.Context, profile *cfaws.Profile) (*sdkconfig.Context, erro
 
 	}
 }
+
+func LoadURL(ctx context.Context, cfURL string) (*sdkconfig.Context, error) {
+	u, err := url.Parse(cfURL)
+	if err != nil {
+		return nil, err
+	}
+	u = u.JoinPath("config.json")
+
+	clio.Debugw("configuring Common Fate SDK from URL", "url", u.String())
+
+	return sdkconfig.New(ctx, sdkconfig.Opts{
+		ConfigSources: []string{u.String()},
+	})
+}

--- a/pkg/granted/registry/cfregistry/cfregistry.go
+++ b/pkg/granted/registry/cfregistry/cfregistry.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"connectrpc.com/connect"
-	"github.com/common-fate/sdk/config"
+	"github.com/common-fate/granted/pkg/cfcfg"
 	awsv1alpha1 "github.com/common-fate/sdk/gen/granted/registry/aws/v1alpha1"
 	"github.com/common-fate/sdk/gen/granted/registry/aws/v1alpha1/awsv1alpha1connect"
 	grantedv1alpha1 "github.com/common-fate/sdk/service/granted/registry"
@@ -38,10 +38,12 @@ func (r *Registry) getClient() (awsv1alpha1connect.ProfileRegistryServiceClient,
 		return r.client, nil
 	}
 
-	cfg, err := config.LoadDefault(context.Background())
+	// Load the config from the deployment URL
+	cfg, err := cfcfg.LoadURL(context.Background(), r.opts.URL)
 	if err != nil {
 		return nil, err
 	}
+
 	accountClient := grantedv1alpha1.NewFromConfig(cfg)
 
 	r.mu.Lock()


### PR DESCRIPTION
### What changed?
The granted registry process now sources the Common Fate config directly via the URL rather than loading the default profile from the config file.

This fixes the issue where granted would ignore the URL in the registry config

### Why?
There is an issue where granted reads the config from file instead of from the URL, leading to multiple registries all being sourced from the default config file source

### How did you test it?
Tested by adding 2 registries and seeing that the profiles are correctly pulled from each.
Tested auth by confirming I did not need to re authenticate as a result of reading the config from URL instead of the file

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs