### PR TITLE
Add support for XDG directories

### DIFF
--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -97,6 +97,7 @@ func GetCliApp() *cli.App {
 				return err
 			}
 
+			// TODO Set to XDG_STATE_HOME if variable defined
 			grantedFolder, err := config.GrantedConfigFolder()
 			if err != nil {
 				return err

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -97,8 +97,8 @@ func GetCliApp() *cli.App {
 				return err
 			}
 
-			// TODO Set to XDG_STATE_HOME if variable defined
-			grantedFolder, err := config.GrantedConfigFolder()
+			// TODO Verify change works
+			grantedFolder, err := config.GrantedStateFolder()
 			if err != nil {
 				return err
 			}

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -97,7 +97,6 @@ func GetCliApp() *cli.App {
 				return err
 			}
 
-			// TODO Verify change works
 			grantedFolder, err := config.GrantedStateFolder()
 			if err != nil {
 				return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 
 	"github.com/BurntSushi/toml"
 
@@ -224,6 +225,22 @@ func GrantedStateFolder() (string, error) {
 	return stateDir, nil
 }
 
+// GrantedFolders creates a slice of directories created during installation and removes duplicates
+func GrantedFolders() ([]string, error) {
+	var grantedDirs []string
+	configDir, _ := GrantedConfigFolder()
+	cacheDir, _ := GrantedCacheFolder()
+	stateDir, _ := GrantedStateFolder()
+	grantedDirs = append(grantedDirs, configDir)
+	grantedDirs = append(grantedDirs, cacheDir)
+	grantedDirs = append(grantedDirs, stateDir)
+
+	grantedDirs = slices.Compact(grantedDirs)
+
+	return grantedDirs, nil
+}
+
+// pathExists checks if a given file exists and returns true or false
 func pathExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,7 +178,7 @@ func GrantedConfigFolder() (string, error) {
 
 	configDir := filepath.Join(home, build.ConfigFolderName)
 	if xdgConfigDir := os.Getenv("XDG_CONFIG_HOME"); !pathExists(configDir) && xdgConfigDir != "" {
-		// ? Should this be "build.ConfigFolderName" or "granted". Directory names in XDG_CONFIG_HOME usually omit the dot. 
+		// ? Should this be "build.ConfigFolderName" or "granted". Directory names in XDG_CONFIG_HOME usually omit the dot prefix. 
 		configDir = filepath.Join(xdgConfigDir, build.ConfigFolderName)
 	}
 
@@ -192,6 +192,36 @@ func GrantedConfigFilePath() (string, error) {
 	}
 	configFilePath := path.Join(grantedFolder, "config")
 	return configFilePath, nil
+}
+
+func GrantedCacheFolder() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	cacheDir := filepath.Join(home, build.ConfigFolderName)
+	if xdgCacheDir := os.Getenv("XDG_CACHE_HOME"); !pathExists(cacheDir) && xdgCacheDir != "" {
+		// ? Should this be "build.ConfigFolderName" or "granted". Directory names in XDG_CACHE_HOME usually omit the dot prefix. 
+		cacheDir = filepath.Join(xdgCacheDir, build.ConfigFolderName)
+	}
+
+	return cacheDir, nil
+}
+
+func GrantedStateFolder() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	stateDir := filepath.Join(home, build.ConfigFolderName)
+	if xdgStateDir := os.Getenv("XDG_STATE_HOME"); !pathExists(stateDir) && xdgStateDir != "" {
+		// ? Should this be "build.ConfigFolderName" or "granted". Directory names in XDG_STATE_HOME usually omit the dot prefix. 
+		stateDir = filepath.Join(xdgStateDir, build.ConfigFolderName)
+	}
+
+	return stateDir, nil
 }
 
 func pathExists(path string) bool {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -169,6 +169,7 @@ func SetupZSHAutoCompleteFolderGranted() (string, error) {
 	return zshPath, nil
 }
 
+// TODO Set to XDG_CONFIG_HOME if defined
 func GrantedConfigFolder() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,8 +179,7 @@ func GrantedConfigFolder() (string, error) {
 
 	configDir := filepath.Join(home, build.ConfigFolderName)
 	if xdgConfigDir := os.Getenv("XDG_CONFIG_HOME"); !pathExists(configDir) && xdgConfigDir != "" {
-		// ? Should this be "build.ConfigFolderName" or "granted". Directory names in XDG_CONFIG_HOME usually omit the dot prefix. 
-		configDir = filepath.Join(xdgConfigDir, build.ConfigFolderName)
+		configDir = filepath.Join(xdgConfigDir, "granted")
 	}
 
 	return configDir, nil
@@ -203,8 +202,7 @@ func GrantedCacheFolder() (string, error) {
 
 	cacheDir := filepath.Join(home, build.ConfigFolderName)
 	if xdgCacheDir := os.Getenv("XDG_CACHE_HOME"); !pathExists(cacheDir) && xdgCacheDir != "" {
-		// ? Should this be "build.ConfigFolderName" or "granted". Directory names in XDG_CACHE_HOME usually omit the dot prefix. 
-		cacheDir = filepath.Join(xdgCacheDir, build.ConfigFolderName)
+		cacheDir = filepath.Join(xdgCacheDir, "granted")
 	}
 
 	return cacheDir, nil
@@ -218,8 +216,7 @@ func GrantedStateFolder() (string, error) {
 
 	stateDir := filepath.Join(home, build.ConfigFolderName)
 	if xdgStateDir := os.Getenv("XDG_STATE_HOME"); !pathExists(stateDir) && xdgStateDir != "" {
-		// ? Should this be "build.ConfigFolderName" or "granted". Directory names in XDG_STATE_HOME usually omit the dot prefix. 
-		stateDir = filepath.Join(xdgStateDir, build.ConfigFolderName)
+		stateDir = filepath.Join(xdgStateDir, "granted")
 	}
 
 	return stateDir, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ package config
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/BurntSushi/toml"
@@ -169,14 +170,19 @@ func SetupZSHAutoCompleteFolderGranted() (string, error) {
 	return zshPath, nil
 }
 
-// TODO Set to XDG_CONFIG_HOME if defined
 func GrantedConfigFolder() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	// check if the .granted folder already exists
-	return path.Join(home, build.ConfigFolderName), nil
+
+	configDir := filepath.Join(home, build.ConfigFolderName)
+	if xdgConfigDir := os.Getenv("XDG_CONFIG_HOME"); !pathExists(configDir) && xdgConfigDir != "" {
+		// ? Should this be "build.ConfigFolderName" or "granted". Directory names in XDG_CONFIG_HOME usually omit the dot. 
+		configDir = filepath.Join(xdgConfigDir, build.ConfigFolderName)
+	}
+
+	return configDir, nil
 }
 
 func GrantedConfigFilePath() (string, error) {
@@ -186,6 +192,11 @@ func GrantedConfigFilePath() (string, error) {
 	}
 	configFilePath := path.Join(grantedFolder, "config")
 	return configFilePath, nil
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func Load() (*Config, error) {

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -62,8 +62,8 @@ func (store *FrecencyStore) GetFrecentEntriess(optionalLimit *int) []interface{}
 
 func Load(fecencyStoreKey string) (*FrecencyStore, error) {
 	c := FrecencyStore{MaxFrequency: 1, OldestDate: time.Now()}
-	// TODO Set to XDG_CACHE_HOME if defined
-	configFolder, err := config.GrantedConfigFolder()
+	// TODO Verify change works
+	configFolder, err := config.GrantedCacheFolder()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -62,6 +62,7 @@ func (store *FrecencyStore) GetFrecentEntriess(optionalLimit *int) []interface{}
 
 func Load(fecencyStoreKey string) (*FrecencyStore, error) {
 	c := FrecencyStore{MaxFrequency: 1, OldestDate: time.Now()}
+	// TODO Set to XDG_CACHE_HOME if defined
 	configFolder, err := config.GrantedConfigFolder()
 	if err != nil {
 		return nil, err

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -62,7 +62,6 @@ func (store *FrecencyStore) GetFrecentEntriess(optionalLimit *int) []interface{}
 
 func Load(fecencyStoreKey string) (*FrecencyStore, error) {
 	c := FrecencyStore{MaxFrequency: 1, OldestDate: time.Now()}
-	// TODO Verify change works
 	configFolder, err := config.GrantedCacheFolder()
 	if err != nil {
 		return nil, err
@@ -71,7 +70,7 @@ func Load(fecencyStoreKey string) (*FrecencyStore, error) {
 
 	// check if the providers file exists
 	if _, err = os.Stat(c.path); os.IsNotExist(err) {
-
+		os.MkdirAll(configFolder, 0700)
 		return &c, nil
 	}
 

--- a/pkg/granted/entrypoint.go
+++ b/pkg/granted/entrypoint.go
@@ -68,7 +68,6 @@ func GetCliApp() *cli.App {
 			}
 			clio.SetLevelFromEnv("GRANTED_LOG")
 
-			// TODO Verify change works
 			grantedFolder, err := config.GrantedStateFolder()
 			if err != nil {
 				return err

--- a/pkg/granted/entrypoint.go
+++ b/pkg/granted/entrypoint.go
@@ -68,8 +68,8 @@ func GetCliApp() *cli.App {
 			}
 			clio.SetLevelFromEnv("GRANTED_LOG")
 
-			// TODO Set to XDG_STATE_HOME if variable defined
-			grantedFolder, err := config.GrantedConfigFolder()
+			// TODO Verify change works
+			grantedFolder, err := config.GrantedStateFolder()
 			if err != nil {
 				return err
 			}

--- a/pkg/granted/entrypoint.go
+++ b/pkg/granted/entrypoint.go
@@ -68,6 +68,7 @@ func GetCliApp() *cli.App {
 			}
 			clio.SetLevelFromEnv("GRANTED_LOG")
 
+			// TODO Set to XDG_STATE_HOME if variable defined
 			grantedFolder, err := config.GrantedConfigFolder()
 			if err != nil {
 				return err

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -735,8 +735,8 @@ func updateCachedAccessRule(ctx context.Context, opts updateCacheOpts) error {
 }
 
 func getCacheFolder(depID string) (string, error) {
-	// TODO Set to XDG_CACHE_HOME if defined
-	configFolder, err := config.GrantedConfigFolder()
+	// TODO Verify change works
+	configFolder, err := config.GrantedCacheFolder()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -735,6 +735,7 @@ func updateCachedAccessRule(ctx context.Context, opts updateCacheOpts) error {
 }
 
 func getCacheFolder(depID string) (string, error) {
+	// TODO Set to XDG_CACHE_HOME if defined
 	configFolder, err := config.GrantedConfigFolder()
 	if err != nil {
 		return "", err

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -735,7 +735,6 @@ func updateCachedAccessRule(ctx context.Context, opts updateCacheOpts) error {
 }
 
 func getCacheFolder(depID string) (string, error) {
-	// TODO Verify change works
 	configFolder, err := config.GrantedCacheFolder()
 	if err != nil {
 		return "", err

--- a/pkg/granted/uninstall.go
+++ b/pkg/granted/uninstall.go
@@ -40,9 +40,9 @@ var UninstallCommand = cli.Command{
 				if err != nil {
 					return err
 				}
-			}
 
-			clio.Successf("Removed Granted config folder %s\n", grantedFolder)
+				clio.Successf("Removed Granted config folder %s", dir)
+			}
 		}
 		return nil
 	},

--- a/pkg/granted/uninstall.go
+++ b/pkg/granted/uninstall.go
@@ -30,14 +30,16 @@ var UninstallCommand = cli.Command{
 			if err != nil {
 				clio.Error(err.Error())
 			}
-			// TODO Remove all XDG folders
-			grantedFolder, err := config.GrantedConfigFolder()
+			grantedFolder, err := config.GrantedFolders()
 			if err != nil {
 				return err
 			}
-			err = os.RemoveAll(grantedFolder)
-			if err != nil {
-				return err
+
+			for _, dir := range grantedFolder {
+				err = os.RemoveAll(dir)
+				if err != nil {
+					return err
+				}
 			}
 
 			clio.Successf("Removed Granted config folder %s\n", grantedFolder)

--- a/pkg/granted/uninstall.go
+++ b/pkg/granted/uninstall.go
@@ -30,6 +30,7 @@ var UninstallCommand = cli.Command{
 			if err != nil {
 				clio.Error(err.Error())
 			}
+			// TODO Remove all XDG folders
 			grantedFolder, err := config.GrantedConfigFolder()
 			if err != nil {
 				return err


### PR DESCRIPTION
### What changed?
Updates have been made to make use of the XDG Base directory specification if the environment variables are set on the users host machine.

config file is stored in `$XDG_CONFIG_HOME`
log file is stored in `$XDG_STATE_HOME`
FrecencyStore is stored in `$XDG_CACHE_HOME`

### Why?
To de-clutter a users `$HOME` directory.
To attempt to resolve #570 

### How did you test it?
Tested locally with `make cli` with the environment variables set and unset. Went through initial configuration, assuming roles and uninstalling on macOS. I can install, setup, assume roles and uninstall with only 1 problem:

With the XDG environment variables set, I see the following error in the log file:

```json
{"level":"debug","ts":"2024-08-07T13:57:19Z","msg":"upserting entry to frecency: open /Users/chris.harrison6/.cache/.dgranted/aws_profiles_frecency: no such file or directory"}
```

I must be missing a step somewhere because `~/.cache/.dgranted` isn't being created. I'm fairly new to go and programming in general so any assistance would be very welcome. No doubt there will be a better way to achieve some of this, but thought I would get the ball rolling :smiley:

### Potential risks
Unknown

### Is patch release candidate?
Unknown

### Link to relevant docs PRs
https://specifications.freedesktop.org/basedir-spec/latest/
https://wiki.archlinux.org/title/XDG_Base_Directory