### PR TITLE
initial attempt at tcsh support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,13 @@ cli: go-binary
 	# replace references to "assumego" (the production symlink) with "dassumego"
 	cat scripts/assume | sed 's/assumego/dassumego/g' > ${PREFIX}/bin/dassume && chmod +x ${PREFIX}/bin/dassume
 	cat scripts/assume.fish | sed 's/assumego/dassumego/g' > ${PREFIX}/bin/dassume.fish && chmod +x ${PREFIX}/bin/dassume.fish
+	cat scripts/assume.tcsh | sed 's/assumego/dassumego/g' > ${PREFIX}/bin/dassume.tcsh && chmod +x ${PREFIX}/bin/dassume.tcsh
 
 clean:
 	rm ${PREFIX}/bin/dassumego
 	rm ${PREFIX}/bin/dassume
 	rm ${PREFIX}/bin/dassume.fish
+	rm ${PREFIX}/bin/dassume.tcsh
 
 aws-credentials:
 	echo -e "\nAWS_ACCESS_KEY_ID=\"$$AWS_ACCESS_KEY_ID\"\nAWS_SECRET_ACCESS_KEY=\"$$AWS_SECRET_ACCESS_KEY\"\nAWS_SESSION_TOKEN=\"$$AWS_SESSION_TOKEN\"\nAWS_REGION=\"$$AWS_REGION\""
@@ -42,8 +44,10 @@ ci-cli-all-platforms: test-binaries
 	# replace references to "assumego" (the production symlink) with "dassumego"
 	cat scripts/assume | sed 's/assumego/dassumego/g' > bin/linux/dassume && chmod +x bin/linux/dassume
 	cat scripts/assume.fish | sed 's/assumego/dassumego/g' > bin/linux/dassume.fish && chmod +x bin/linux/dassume.fish
+	cat scripts/assume.tcsh | sed 's/assumego/dassumego/g' > bin/linux/dassume.tcsh && chmod +x bin/linux/dassume.tcsh
 	cp bin/linux/dassume bin/macos/dassume
 	cp bin/linux/dassume.fish bin/macos/dassume.fish
+	cp bin/linux/dassume.tcsh bin/macos/dassume.tcsh
 	cat scripts/assume.bat | sed 's/assumego/dassumego/g' > bin/windows/dassume.bat
 	cat scripts/assume.ps1 | sed 's/assumego/dassumego/g' > bin/windows/dassume.ps1
 
@@ -55,5 +59,7 @@ cli-act-prod: go-binary
 	# replace references to "assumego" (the production binary) with "dassumego"
 	cat scripts/assume | sed 's/assumego/dassumego/g' > ${PREFIX}/bin/dassume && chmod +x ${PREFIX}/bin/dassume
 	cat scripts/assume.fish | sed 's/assumego/dassumego/g' > ${PREFIX}/bin/dassume.fish && chmod +x ${PREFIX}/bin/dassume.fish
+	cat scripts/assume.tcsh | sed 's/assumego/dassumego/g' > ${PREFIX}/bin/dassume.tcsh && chmod +x ${PREFIX}/bin/dassume.tcsh
 	mv ${PREFIX}/bin/dassume ${PREFIX}/bin/assume
 	mv ${PREFIX}/bin/dassume.fish ${PREFIX}/bin/assume.fish
+	mv ${PREFIX}/bin/dassume.tcsh ${PREFIX}/bin/assume.tcsh

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -31,11 +31,14 @@ func init() {
 }
 
 const fishAlias = `alias assume="source /usr/local/bin/assume.fish"`
+const tcshAlias = `alias assume 'source /usr/local/bin/assume.tcsh'`
 
 const defaultAlias = `alias assume=". assume"`
 const fishAliasBrew = `alias assume="source (brew --prefix)/bin/assume.fish"`
+const tcshAliasBrew = `alias assume 'source (brew --prefix)/bin/assume.tcsh'`
 
 const devFishAlias = `alias dassume="source /usr/local/bin/dassume.fish"`
+const devTcshAlias = `alias dassume 'source /usr/local/bin/dassume.tcsh'`
 const devDefaultAlias = `alias dassume=". dassume"`
 
 func GetDefaultAlias() string {
@@ -56,6 +59,19 @@ func GetFishAlias() string {
 	}
 
 	return fishAlias
+}
+func GetTcshAlias() string {
+	if build.IsDev() {
+		return devTcshAlias
+	}
+
+	// if 'brew' exists on the path, use the brew prefix rather than /usr/local/bin when installing the alias.
+	// chrnorm: there's not really a better way to determine if we've been installed with brew or not.
+	if _, err := exec.LookPath("brew"); err == nil {
+		return tcshAliasBrew
+	}
+
+	return tcshAlias
 }
 
 type Config struct {
@@ -88,6 +104,8 @@ func GetShellFromShellEnv(shellEnv string) (string, error) {
 
 	} else if strings.Contains(shellEnv, "zsh") {
 		return "zsh", nil
+	} else if strings.Contains(shellEnv, "tcsh") {
+		return "tcsh", nil
 	} else if strings.Contains(shellEnv, "sh") {
 		// Fallback to POSIX
 		return "posix", nil
@@ -109,6 +127,9 @@ func GetShellAlias(shell string) (Config, error) {
 		file, err = shells.GetBashConfigFile()
 	case "zsh":
 		file, err = shells.GetZshConfigFile()
+	case "tcsh":
+		file, err = shells.GetTcshConfigFile()
+		alias = GetTcshAlias()
 	case "posix":
 		file, err = shells.GetPosixConfigFile()
 	default:

--- a/pkg/granted/completion.go
+++ b/pkg/granted/completion.go
@@ -24,7 +24,7 @@ var flags = []cli.Flag{
 	&cli.StringFlag{
 		Name:     "shell",
 		Aliases:  []string{"s"},
-		Usage:    "Shell to install completions for (fish, zsh, bash)",
+		Usage:    "Shell to install completions for (fish, zsh, tcsh, bash)",
 		Required: true,
 	},
 }
@@ -40,6 +40,8 @@ var CompletionCommand = cli.Command{
 			err = installFishCompletions(c)
 		case "zsh":
 			err = installZSHCompletions(c)
+		case "tcsh":
+			err = installTcshCompletions(c)
 		case "bash":
 			err = installBashCompletions(c)
 		default:
@@ -141,5 +143,10 @@ func installZSHCompletions(c *cli.Context) error {
 
 func installBashCompletions(c *cli.Context) error {
 	clio.Info("We don't have completion support for bash yet, check out our docs to find out how to let us know you want this feature https://granted.dev/autocompletion")
+	return nil
+}
+
+func installTcshCompletions(c *cli.Context) error {
+	clio.Info("We don't have completion support for tcsh yet, check out our docs to find out how to let us know you want this feature https://granted.dev/autocompletion")
 	return nil
 }

--- a/pkg/shells/find_config.go
+++ b/pkg/shells/find_config.go
@@ -49,6 +49,24 @@ func GetFishConfigFile() (string, error) {
 	return file, nil
 }
 
+func GetTcshConfigFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	file := path.Join(home, ".tcshrc")
+
+	// check that the file exists; create it if not
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		f, err := os.Create(file)
+		if err != nil {
+			return "", err
+		}
+		defer f.Close()
+	}
+	return file, nil
+}
+
 func GetBashConfigFile() (string, error) {
 
 	bashLoginFiles := []string{

--- a/scripts/assume.tcsh
+++ b/scripts/assume.tcsh
@@ -1,0 +1,100 @@
+#!/bin/tcsh
+
+#this is set to true because the alias will be configured to point to the tcsh script in a previous step
+#this happens in the assume script
+setenv GRANTED_ALIAS_CONFIGURED "true"
+
+set GRANTED_OUTPUT = `assumego $argv`
+set GRANTED_STATUS = $status
+set GRANTED_FLAG = $GRANTED_OUTPUT[1]
+
+if ( "$GRANTED_FLAG" == "NAME:" ) then
+  assumego $argv
+else if ( "$GRANTED_FLAG" == "GrantedDesume" ) then
+  unsetenv AWS_ACCESS_KEY_ID
+  unsetenv AWS_SECRET_ACCESS_KEY
+  unsetenv AWS_SESSION_TOKEN
+  unsetenv AWS_PROFILE
+  unsetenv AWS_REGION
+  unsetenv AWS_DEFAULT_REGION
+  unsetenv AWS_SESSION_EXPIRATION
+  unsetenv AWS_CREDENTIAL_EXPIRATION
+  unsetenv GRANTED_SSO
+  unsetenv GRANTED_SSO_START_URL
+  unsetenv GRANTED_SSO_ROLE_NAME
+  unsetenv GRANTED_SSO_REGION
+  unsetenv GRANTED_SSO_ACCOUNT_ID
+else if ( "$GRANTED_FLAG" == "GrantedAssume" ) then
+  unsetenv AWS_ACCESS_KEY_ID
+  unsetenv AWS_SECRET_ACCESS_KEY
+  unsetenv AWS_SESSION_TOKEN
+  unsetenv AWS_PROFILE
+  unsetenv AWS_REGION
+  unsetenv AWS_DEFAULT_REGION
+  unsetenv AWS_SESSION_EXPIRATION
+  unsetenv AWS_CREDENTIAL_EXPIRATION
+  unsetenv GRANTED_SSO
+  unsetenv GRANTED_SSO_START_URL
+  unsetenv GRANTED_SSO_ROLE_NAME
+  unsetenv GRANTED_SSO_REGION
+  unsetenv GRANTED_SSO_ACCOUNT_ID
+
+  setenv GRANTED_COMMAND $argv
+  if ( "$GRANTED_OUTPUT[2]" != "None" ) then
+    setenv AWS_ACCESS_KEY_ID $GRANTED_OUTPUT[2]
+  endif
+  if ( "$GRANTED_OUTPUT[3]" != "None" ) then
+    setenv AWS_SECRET_ACCESS_KEY $GRANTED_OUTPUT[3]
+  endif
+  if ( "$GRANTED_OUTPUT[4]" != "None" ) then
+    setenv AWS_SESSION_TOKEN $GRANTED_OUTPUT[4]
+  endif
+  if ( "$GRANTED_OUTPUT[5]" != "None" ) then
+    setenv AWS_PROFILE $GRANTED_OUTPUT[5]
+  endif
+  if ( "$GRANTED_OUTPUT[6]" != "None" ) then
+    setenv AWS_REGION $GRANTED_OUTPUT[6]
+    setenv AWS_DEFAULT_REGION $GRANTED_OUTPUT[6]
+  endif
+  if ( "$GRANTED_OUTPUT[7]" != "None" ) then
+    setenv AWS_SESSION_EXPIRATION $GRANTED_OUTPUT[7]
+    setenv AWS_CREDENTIAL_EXPIRATION $GRANTED_OUTPUT[7]
+  endif
+  if ( "$GRANTED_OUTPUT[8]" != "None" ) then
+    setenv GRANTED_SSO $GRANTED_OUTPUT[8]
+  endif
+  if ( "$GRANTED_OUTPUT[9]" != "None" ) then
+    setenv GRANTED_SSO_START_URL $GRANTED_OUTPUT[9]
+  endif
+  if ( "$GRANTED_OUTPUT[10]" != "None" ) then
+    setenv GRANTED_SSO_ROLE_NAME $GRANTED_OUTPUT[10]
+  endif
+  if ( "$GRANTED_OUTPUT[11]" != "None" ) then
+    setenv GRANTED_SSO_REGION $GRANTED_OUTPUT[11]
+  endif
+  if ( "$GRANTED_OUTPUT[12]" != "None" ) then
+    setenv GRANTED_SSO_ACCOUNT_ID $GRANTED_OUTPUT[12]
+  endif
+
+else if ( "$GRANTED_FLAG" == "GrantedOutput" ) then
+  foreach line ($GRANTED_OUTPUT)
+      if ( "$line" != "GrantedOutput" ) then
+        echo $line
+      endif
+  end
+
+
+else if ( "$GRANTED_FLAG" == "GrantedExec" ) then
+  # Set GRANTED_OUTPUT[13] with a command to execute, for example, "bash -c 'some_command'"
+  # Make sure to properly escape quotes if needed and pass arguments.
+
+  # Set and export the AWS variables only for the duration of the 'sh -c' command
+  env AWS_ACCESS_KEY_ID=$GRANTED_OUTPUT[2] \
+    AWS_SECRET_ACCESS_KEY=$GRANTED_OUTPUT[3] \
+    AWS_SESSION_TOKEN=$GRANTED_OUTPUT[4] \
+    AWS_REGION=$GRANTED_OUTPUT[6] \
+    AWS_DEFAULT_REGION=$GRANTED_OUTPUT[6] \
+    sh -c "$GRANTED_OUTPUT[13]"
+endif
+
+exit $GRANTED_STATUS


### PR DESCRIPTION
Fixes common-fate/granted#728

### What changed?
Adds support for the `tcsh` shell.

### Why?
tcsh is a well-established shell that is shipped on many systems (MacOS, FreeBSD, etc) and predates bash.

### How did you test it?
```sh
[Jeffs-MacBook-Pro:~] % aws sts get-caller-identity
{
    "UserId": "AIDAT7OI5REDACTED",
    "Account": "273689999999",
    "Arn": "arn:aws:iam::273689999999:user/my.user.name"
}
[Jeffs-MacBook-Pro:~] % emacs ~/.aws/config
[Jeffs-MacBook-Pro:~] % dassume fdd-staging
? MFA Token 566999
[✔] [fdd-staging](us-east-1) session credentials will expire in 4 hours
[Jeffs-MacBook-Pro:~] jeff.lawson% aws sts get-caller-identity
{
    "UserId": "AROAWSN23QREDACTED:gntd-2kLo4ezkp8REDACTED",
    "Account": "4519999999",
    "Arn": "arn:aws:sts::4519999999:assumed-role/IMS_POWER_ROLE/gntd-2kLo4ezkp8REDACTED"
}
[Jeffs-MacBook-Pro:~] % env |grep SHELL
SHELL=/bin/tcsh
[Jeffs-MacBook-Pro:~] % uname -a
Darwin Jeffs-MacBook-Pro.local 23.6.0 Darwin Kernel Version 23.6.0: Fri Jul  5 17:56:41 PDT 2024; root:xnu-10063.141.1~2/RELEASE_ARM64_T6000 arm64
```

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs