### PR TITLE
Fix potential panic in RDS instance selection

### DIFF
--- a/pkg/granted/rds/rds.go
+++ b/pkg/granted/rds/rds.go
@@ -103,6 +103,11 @@ var proxyCommand = cli.Command{
 				return err
 			}
 
+			// check here to avoid nil pointer errors later
+			if len(entitlements) == 0 {
+				return errors.New("You don't have access to any RDS databases")
+			}
+
 			type Column struct {
 				Title string
 				Width int
@@ -139,7 +144,13 @@ var proxyCommand = cli.Command{
 				return err
 			}
 
-			entitlement := selector.GetValue().(*accessv1alpha1.Entitlement)
+			selectorVal := selector.GetValue()
+
+			if selectorVal == nil {
+				return errors.New("No database selected")
+			}
+
+			entitlement := selectorVal.(*accessv1alpha1.Entitlement)
 
 			target = entitlement.Target.Eid.Display()
 			role = entitlement.Role.Eid.Display()


### PR DESCRIPTION
### What changed?
Fixes a panic if there are no databases to choose from in the RDS plugin.

### Why?
Prevents a panic.

### How did you test it?
Built and ran locally, overriding the API result to be an empty slice and confirmed working as expected
```
❯ dgranted rds proxy
[✘] You don't have access to any RDS databases
```


### Potential risks
Low as this is adding additional error handling checks. Only affects RDS plugin.

### Is patch release candidate?
Yes
