### PR TITLE
Open the common fate console

### DIFF
--- a/pkg/cfcfg/cfcfg.go
+++ b/pkg/cfcfg/cfcfg.go
@@ -10,7 +10,7 @@ import (
 	sdkconfig "github.com/common-fate/sdk/config"
 )
 
-func getCommonFateURL(profile *cfaws.Profile) (*url.URL, error) {
+func GetCommonFateURL(profile *cfaws.Profile) (*url.URL, error) {
 	if profile == nil {
 		clio.Debugw("skipping loading Common Fate SDK from URL", "reason", "profile was nil")
 		return nil, nil
@@ -37,7 +37,7 @@ func getCommonFateURL(profile *cfaws.Profile) (*url.URL, error) {
 }
 
 func Load(ctx context.Context, profile *cfaws.Profile) (*sdkconfig.Context, error) {
-	cfURL, err := getCommonFateURL(profile)
+	cfURL, err := GetCommonFateURL(profile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/granted/cf.go
+++ b/pkg/granted/cf.go
@@ -1,0 +1,54 @@
+package granted
+
+import (
+	"github.com/common-fate/clio"
+	"github.com/common-fate/granted/pkg/cfaws"
+	"github.com/common-fate/granted/pkg/cfcfg"
+	sdkconfig "github.com/common-fate/sdk/config"
+	"github.com/pkg/browser"
+	"github.com/urfave/cli/v2"
+)
+
+var CFCommand = cli.Command{
+	Name:  "cf",
+	Usage: "Open Common Fate in the browser",
+	Action: func(c *cli.Context) error {
+
+		ctx := c.Context
+		clio.Infof("Opening the Common Fate console in your browser...")
+		consoleURL := ""
+		cfFileConfig, err := sdkconfig.LoadDefault(ctx)
+		if err != nil {
+			// fall back to trying to find a common fate url from profiles
+			profiles, err := cfaws.LoadProfiles()
+			if err != nil {
+				return err
+			}
+
+			for _, profile := range profiles.ProfileNames {
+				p, err := profiles.Profile(profile)
+				if err != nil {
+					return err
+				}
+				u, err := cfcfg.GetCommonFateURL(p)
+				if err != nil {
+					clio.Debug(err)
+				} else {
+					consoleURL = u.String()
+					break
+				}
+			}
+			return err
+		} else {
+			consoleURL = cfFileConfig.APIURL
+		}
+
+		err = browser.OpenURL(consoleURL)
+		if err != nil {
+			// fail silently
+			clio.Debug(err.Error())
+		}
+
+		return nil
+	},
+}

--- a/pkg/granted/cf.go
+++ b/pkg/granted/cf.go
@@ -1,6 +1,10 @@
 package granted
 
 import (
+	"errors"
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/common-fate/clio"
 	"github.com/common-fate/granted/pkg/cfaws"
 	"github.com/common-fate/granted/pkg/cfcfg"
@@ -12,43 +16,74 @@ import (
 var CFCommand = cli.Command{
 	Name:  "cf",
 	Usage: "Open Common Fate in the browser",
+	Flags: []cli.Flag{&cli.StringFlag{Name: "profile", Usage: "open the console for a specific profile"}},
 	Action: func(c *cli.Context) error {
 
 		ctx := c.Context
-		clio.Infof("Opening the Common Fate console in your browser...")
 		consoleURL := ""
-		cfFileConfig, err := sdkconfig.LoadDefault(ctx)
+		profiles, err := cfaws.LoadProfiles()
 		if err != nil {
-			// fall back to trying to find a common fate url from profiles
-			profiles, err := cfaws.LoadProfiles()
+			return err
+		}
+
+		profileName := c.String("profile")
+		if profileName != "" {
+			p, err := profiles.Profile(profileName)
 			if err != nil {
 				return err
 			}
-
-			for _, profile := range profiles.ProfileNames {
-				p, err := profiles.Profile(profile)
-				if err != nil {
-					return err
-				}
-				u, err := cfcfg.GetCommonFateURL(p)
-				if err != nil {
-					clio.Debug(err)
-				} else {
-					consoleURL = u.String()
-					break
-				}
+			url, err := cfcfg.GetCommonFateURL(p)
+			if err != nil {
+				return err
 			}
-			return err
-		} else {
+			if url == nil {
+				return errors.New("the profile exists but it is not configured with with a Common Fate console url")
+			}
+			consoleURL = url.String()
+		}
+
+		foundStartURLs := map[string]bool{}
+		for _, profile := range profiles.ProfileNames {
+			p, err := profiles.Profile(profile)
+			if err != nil {
+				return err
+			}
+			url, err := cfcfg.GetCommonFateURL(p)
+			if err != nil {
+				clio.Debug(err)
+			}
+			if url != nil {
+				foundStartURLs[url.String()] = true
+			}
+		}
+		keys := make([]string, 0, len(foundStartURLs))
+		for k := range foundStartURLs {
+			keys = append(keys, k)
+		}
+		if len(keys) == 0 {
+			// fall back to the config file
+			cfFileConfig, err := sdkconfig.LoadDefault(ctx)
+			if err != nil {
+				clio.Debug(fmt.Errorf("could not load profile from config file: %w", err))
+				return errors.New("no Common Fate deployment urls found in your aws config or the default config file, you can setup now with 'granted login'")
+			}
 			consoleURL = cfFileConfig.APIURL
 		}
-
-		err = browser.OpenURL(consoleURL)
-		if err != nil {
-			// fail silently
-			clio.Debug(err.Error())
+		if len(keys) == 1 {
+			consoleURL = keys[0]
 		}
 
-		return nil
+		err = survey.AskOne(&survey.Select{
+			Message: "Please select which Common Fate deployment you would like to open: ",
+			Options: keys,
+		}, &consoleURL)
+		if err != nil {
+			return err
+		}
+
+		clio.Infof("Opening the Common Fate console (%s) in your default browser...", consoleURL)
+
+		// uses the default browser to open the console
+		return browser.OpenURL(consoleURL)
 	},
 }

--- a/pkg/granted/entrypoint.go
+++ b/pkg/granted/entrypoint.go
@@ -62,6 +62,7 @@ func GetCliApp() *cli.App {
 			&request.Command,
 			&doctor.Command,
 			&rds.Command,
+			&CFCommand,
 		},
 		EnableBashCompletion: true,
 		Before: func(c *cli.Context) error {


### PR DESCRIPTION
### What changed?
Adds `granted cf` which can be used to launch the Common Fate console from the cli.
It first tries to detect a console url from the aws config, if more than one is found, a select is shown.
If none is found in the profiles, falls back to the cf config file.

a `--profile` flag can be used to open the console for5 a specific profile

### Why?
convenient way to get to the console to make a request using the web when needed

### How did you test it?
Tested with more then one console URL in my config

### Potential risks
This does not respect any custom browser configuration

### Is patch release candidate?


### Link to relevant docs PRs