### PR TITLE
if we run into the issue with activation, print the diagnostics

### DIFF
--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"bufio"
-	"fmt"
+	"errors"
 	"os/exec"
 	"strings"
 
@@ -23,7 +23,7 @@ func Clone(repoURL string, repoDirPath string) error {
 	scanner := bufio.NewScanner(stderr)
 	for scanner.Scan() {
 		if strings.Contains(strings.ToLower(scanner.Text()), "error") || strings.Contains(strings.ToLower(scanner.Text()), "fatal") {
-			return fmt.Errorf(scanner.Text())
+			return errors.New(scanner.Text())
 		}
 
 		clio.Info(scanner.Text())

--- a/pkg/git/pull.go
+++ b/pkg/git/pull.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"bufio"
-	"fmt"
+	"errors"
 	"os/exec"
 	"strings"
 
@@ -25,7 +25,7 @@ func Pull(repoDirPath string, shouldSilentLogs bool) error {
 	scanner := bufio.NewScanner(stderr)
 	for scanner.Scan() {
 		if strings.Contains(scanner.Text(), "error") || strings.Contains(scanner.Text(), "fatal") {
-			return fmt.Errorf(scanner.Text())
+			return errors.New(scanner.Text())
 		}
 
 		if shouldSilentLogs {

--- a/pkg/granted/completion.go
+++ b/pkg/granted/completion.go
@@ -69,7 +69,7 @@ func installFishCompletions(c *cli.Context) error {
 	// Try to create a file
 	err := os.WriteFile(executableDir, []byte(combinedOutput), 0600)
 	if err != nil {
-		return fmt.Errorf("Something went wrong when saving fish autocompletions: " + err.Error())
+		return fmt.Errorf("Something went wrong when saving fish autocompletions: %s" + err.Error())
 	}
 	clio.Success("Fish autocompletions generated successfully")
 	clio.Info("To use these completions please run the executable:")

--- a/pkg/granted/completion.go
+++ b/pkg/granted/completion.go
@@ -69,7 +69,8 @@ func installFishCompletions(c *cli.Context) error {
 	// Try to create a file
 	err := os.WriteFile(executableDir, []byte(combinedOutput), 0600)
 	if err != nil {
-		return fmt.Errorf("Something went wrong when saving fish autocompletions: %s" + err.Error())
+
+		return fmt.Errorf("something went wrong when saving fish autocompletions: %s", err.Error())
 	}
 	clio.Success("Fish autocompletions generated successfully")
 	clio.Info("To use these completions please run the executable:")

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -331,6 +331,7 @@ func (h Hook) RetryNoEntitlementAccess(ctx context.Context, cfg *config.Context,
 		// if grant is approved but the change is unspecified then the user is not able to automatically activate
 		if g.Grant.Approved && g.Change == accessv1alpha1.GrantChange_GRANT_CHANGE_UNSPECIFIED && g.Grant.ProvisioningStatus != accessv1alpha1.ProvisioningStatus_PROVISIONING_STATUS_SUCCESSFUL {
 			clio.Infof("Request was approved but failed to activate, you might not have permission to activate. You can try and activate the access using the Common Fate web console. [%s elapsed]", elapsed)
+			printdiags.Print(res.Msg.Diagnostics, nil)
 		}
 
 		if !g.Grant.Approved {


### PR DESCRIPTION
### What changed?
When granted tries to activate a request automatically but fails it will now log the diagnostics from the batch ensure request

### Why?
Users found this diagnostic telling them it failed to activate without any information on why it is failing

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs