### PR TITLE
Fix success message when access request is closed

### DIFF
--- a/pkg/granted/request/close.go
+++ b/pkg/granted/request/close.go
@@ -201,7 +201,7 @@ var closeCommand = cli.Command{
 
 		haserrors := printdiags.Print(closeRes.Msg.Diagnostics, nil)
 		if !haserrors {
-			clio.Successf("access request %s is now closed", accessRequestID)
+			clio.Successf("access request %s is now closed", selectedAccessRequest)
 		}
 
 		return nil


### PR DESCRIPTION
### What changed?
Access request closed success message properly outputted

### Why?
Forgot to commit this small change to my previous PR https://github.com/common-fate/granted/pull/742

### How did you test it?
Tested in https://github.com/common-fate/granted/pull/742 but accidentally forgot to commit it.

### Potential risks
Low risk

### Is patch release candidate?


### Link to relevant docs PRs