### PR TITLE
Fix nil pointer error in registry sync when merging fails with an unknown error

### DIFF
--- a/pkg/granted/registry/sync.go
+++ b/pkg/granted/registry/sync.go
@@ -101,6 +101,9 @@ func SyncProfileRegistries(ctx context.Context, interactive bool) error {
 				return fmt.Errorf("error after trying to merge profiles again for registry %s: %w", r.Config.Name, err)
 			}
 		}
+		if err != nil {
+			return fmt.Errorf("error after trying to merge profiles for registry %s: %w", r.Config.Name, err)
+		}
 
 		configFile = merged
 	}


### PR DESCRIPTION
### What changed?
Return an error when merging fails with any error other than awsmerge.DuplicateProfileError

### Why?
In some cases when merging profiles fails with an error other than awsmerge.DuplicateProfileError the error was not logged and the code would continue, expecting the configFile to be non nil.

This would cause a nil pointer error

### How did you test it?
Locally

### Potential risks
Low, the registry sync is a non blocking task, it will now correctly log an error instead of panicing

### Is patch release candidate?
yes

### Link to relevant docs PRs