### PR TITLE
Granted login deprecation message should be clearer

### DIFF
--- a/pkg/granted/entrypoint.go
+++ b/pkg/granted/entrypoint.go
@@ -107,6 +107,7 @@ var login = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		clio.Warn("this command is deprecated and will be removed in a future release")
+		clio.Warn("use granted auth login if you are trying to authenticate with a Common Fate deployment")
 
 		k, err := securestorage.NewCF().Storage.Keyring()
 		if err != nil {


### PR DESCRIPTION
### What changed?
Added an extra warning message to inform the user to use granted auth login if they were trying authenticate with a Common Fate deployment

### Why?
To avoid confusion when users accidentally use `granted login` when they meant to use `granted auth login`.

### How did you test it?
```
dgranted login                                                        [9:55:06]
[!] this command is deprecated and will be removed in a future release
[!] use granted auth login if you are trying to authenticate with a Common Fate deployment
? Your Common Fate dashboard URL https://internal.commonfate.io/
[i] internal.commonfate.io
[i] logging in to https://internal.commonfate.io/
[✘] fetching deployment exports: decoding deployment exports: invalid character '<' looking for beginning of value
```

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs