### PR TITLE
Fix using default duration on auto approved requests

### DIFF
--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -167,23 +167,6 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 		}
 	}
 
-	for i := range req.Entitlements {
-
-		if input.Duration != nil {
-			req.Entitlements[i].Duration = input.Duration
-			continue
-		}
-
-		if result.DurationConfiguration != nil {
-			if result.DurationConfiguration.DefaultDuration != nil {
-				req.Entitlements[i].Duration = result.DurationConfiguration.DefaultDuration
-			} else {
-				req.Entitlements[i].Duration = result.DurationConfiguration.MaxDuration
-			}
-		}
-
-	}
-
 	// the spinner must be started after prompting for reason, otherwise the prompt gets hidden
 	si := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 	si.Suffix = " ensuring access..."

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -171,12 +171,17 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 
 		if input.Duration != nil {
 			req.Entitlements[i].Duration = input.Duration
-
-		} else if result.DurationConfiguration.DefaultDuration != nil {
-			req.Entitlements[i].Duration = result.DurationConfiguration.DefaultDuration
-		} else {
-			req.Entitlements[i].Duration = result.DurationConfiguration.MaxDuration
+			continue
 		}
+
+		if result.DurationConfiguration != nil {
+			if result.DurationConfiguration.DefaultDuration != nil {
+				req.Entitlements[i].Duration = result.DurationConfiguration.DefaultDuration
+			} else {
+				req.Entitlements[i].Duration = result.DurationConfiguration.MaxDuration
+			}
+		}
+
 	}
 
 	// the spinner must be started after prompting for reason, otherwise the prompt gets hidden

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -166,6 +166,15 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 			req.Justification.Reason = &customReason
 		}
 	}
+
+	for i := range req.Entitlements {
+		if result.DurationConfiguration.DefaultDuration != nil {
+			req.Entitlements[i].Duration = result.DurationConfiguration.DefaultDuration
+		} else {
+			req.Entitlements[i].Duration = result.DurationConfiguration.MaxDuration
+		}
+	}
+
 	// the spinner must be started after prompting for reason, otherwise the prompt gets hidden
 	si := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 	si.Suffix = " ensuring access..."

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -203,12 +203,16 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 
 		exp := "<invalid expiry>"
 
-		if res.Msg.DurationConfiguration != nil {
+		if req.Entitlements[0].Duration != nil {
+			exp = ShortDur(req.Entitlements[0].Duration.AsDuration())
+		} else if res.Msg.DurationConfiguration != nil {
 			exp = ShortDur(res.Msg.DurationConfiguration.MaxDuration.AsDuration())
 			if res.Msg.DurationConfiguration.DefaultDuration != nil {
 				exp = ShortDur(res.Msg.DurationConfiguration.DefaultDuration.AsDuration())
-
 			}
+		} else if g.Grant.ExpiresAt != nil {
+			//attempt to work out duration from expiry to preserve backwards compatability with older common fate versions
+			exp = ShortDur(time.Until(g.Grant.ExpiresAt.AsTime()))
 		}
 
 		switch g.Change {
@@ -407,7 +411,9 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 
 		exp := "<invalid expiry>"
 
-		if res.Msg.DurationConfiguration != nil {
+		if req.Entitlements[0].Duration != nil {
+			exp = ShortDur(req.Entitlements[0].Duration.AsDuration())
+		} else if res.Msg.DurationConfiguration != nil {
 			exp = ShortDur(res.Msg.DurationConfiguration.MaxDuration.AsDuration())
 			if res.Msg.DurationConfiguration.DefaultDuration != nil {
 				exp = ShortDur(res.Msg.DurationConfiguration.DefaultDuration.AsDuration())

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -168,7 +168,11 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 	}
 
 	for i := range req.Entitlements {
-		if result.DurationConfiguration.DefaultDuration != nil {
+
+		if input.Duration != nil {
+			req.Entitlements[i].Duration = input.Duration
+
+		} else if result.DurationConfiguration.DefaultDuration != nil {
 			req.Entitlements[i].Duration = result.DurationConfiguration.DefaultDuration
 		} else {
 			req.Entitlements[i].Duration = result.DurationConfiguration.MaxDuration


### PR DESCRIPTION
### What changed?
Updated the access request hooks to use the Duration returned by the batch ensure API to show how long access was requested for. Where a request is already active, the remaining duration is calculated.

### Why?
Access requests that required access to be assigned with Common Fate was returning incorrect values for the duration on the request.

### How did you test it?
Ran assume without the change and observed the bug present.
Reran the same command and got the expected output of the default duration. 

With specifying duration
```
dassume  dev.test/Billing -d 1h
[i] You don't currently have access to dev.test/Billing, checking if we can request access... [target=AWS::Account::"123456789012", role=Billing, url=http://localhost:9090]
[WILL ACTIVATE] Billing access to test will be activated for 1h: http://localhost:8080/access/requests/req_2mBcrs8p9mF9Y7ZqaCEQcaoF7ZR
? Apply proposed access changes Yes
[i] Attempting to grant access...
? Reason for access (Required) test
[ACTIVATED] Billing access to test was activated for 1h: http://localhost:8080/access/requests/req_2mBcsCc6S5C0Z0dPyHMdXRQRBYz
[✔] [dev.test/Billing](ap-southeast-2) session credentials will expire in 1 hour
```

When not specifying duration, defaults to using the default duration
```
dassume  dev.test/Billing 
[i] You don't currently have access to dev.test/Billing, checking if we can request access... [target=AWS::Account::"123456789012", role=Billing, url=http://localhost:9090]
[WILL ACTIVATE] Billing access to test will be activated for 5m: http://localhost:8080/access/requests/req_2mBcw1qVFNVrRfxVZ13nc8iuhj6
? Apply proposed access changes Yes
[i] Attempting to grant access...
? Reason for access (Required) test
[ACTIVATED] Billing access to test was activated for 5m: http://localhost:8080/access/requests/req_2mBcwLqKRDxTUaEKq53Lt8FoQj8
```

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs