### PR TITLE
implement custom templated launch for sso browser option

### DIFF
--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -116,6 +116,7 @@ func GetCliApp() *cli.App {
 			if err != nil {
 				return err
 			}
+
 			if !hasSetup {
 				browserName, err := browser.HandleBrowserWizard(c)
 				if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -285,7 +285,7 @@ func Load() (*Config, error) {
 	_, err = toml.NewDecoder(file).Decode(&c)
 	if err != nil {
 		// if there is an error just reset the file
-		return &c, nil
+		return nil, err
 	}
 	return &c, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	// and CustomBrowserPath fields.
 	AWSConsoleBrowserLaunchTemplate *BrowserLaunchTemplate `toml:",omitempty"`
 
-	// SOBrowserLaunchTemplate is an optional launch template to use
+	// SSOBrowserLaunchTemplate is an optional launch template to use
 	// for opening the SSO auth flow. If specified it overrides the DefaultBrowser
 	// and CustomSSOBrowserPath fields.
 	SSOBrowserLaunchTemplate *BrowserLaunchTemplate `toml:",omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,11 @@ type Config struct {
 	// and CustomBrowserPath fields.
 	AWSConsoleBrowserLaunchTemplate *BrowserLaunchTemplate `toml:",omitempty"`
 
+	// SOBrowserLaunchTemplate is an optional launch template to use
+	// for opening the SSO auth flow. If specified it overrides the DefaultBrowser
+	// and CustomSSOBrowserPath fields.
+	SSOBrowserLaunchTemplate *BrowserLaunchTemplate `toml:",omitempty"`
+
 	Keyring                *KeyringConfig `toml:",omitempty"`
 	Ordering               string
 	ExportCredentialSuffix string

--- a/pkg/granted/console.go
+++ b/pkg/granted/console.go
@@ -128,7 +128,7 @@ var ConsoleCommand = cli.Command{
 		}
 
 		if startErr != nil {
-			return clierr.New(fmt.Sprintf("Granted was unable to open a browser session automatically due to the following error: %s", err.Error()),
+			return clierr.New(fmt.Sprintf("Granted was unable to open a browser session automatically due to the following error: %s", startErr.Error()),
 				// allow them to try open the url manually
 				clierr.Info("You can open the browser session manually using the following url:"),
 				clierr.Info(consoleURL),

--- a/pkg/launcher/custom.go
+++ b/pkg/launcher/custom.go
@@ -3,6 +3,7 @@ package launcher
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -52,8 +53,29 @@ func (l Custom) LaunchCommand(url string, profile string) ([]string, error) {
 		return nil, fmt.Errorf("executing command template (check that your browser launch template is valid in your Granted config): %w", err)
 	}
 
-	commandParts := strings.Fields(renderedCommand.String())
+	commandParts := splitCommand(renderedCommand.String())
 	return commandParts, nil
+}
+
+// splits each component of the command. Anything within quotes will be handled as one component of the command
+// eg open -a "Google Chrome" <URL> returns ["open", "-a", "Google Chrome", "<URL>"]
+func splitCommand(command string) []string {
+
+	re := regexp.MustCompile(`"([^"]+)"|(\S+)`)
+	matches := re.FindAllStringSubmatch(command, -1)
+
+	var result []string
+	for _, match := range matches {
+
+		if match[1] != "" {
+			result = append(result, match[1])
+		} else {
+
+			result = append(result, match[2])
+		}
+	}
+
+	return result
 }
 
 func (l Custom) UseForkProcess() bool { return l.ForkProcess }


### PR DESCRIPTION
### What changed?
Custom browser launch templates were added in #731. This PR extends on the work done there to include this functionality in adding custom launch templates for the sso browser launch process.

The current logic added will prioritise a custom `SSOBrowserLaunchTemplate` being set, then `CustomSSOBrowserPath` and finally with os default `open()`
### Why?
Fixes/provides a builtin workaround for #602

### How did you test it?
- Set up custom template for new `SSOBrowserLaunchTemplate`
```
[SSOBrowserLaunchTemplate]
  Command = "open -a Safari {{ .URL }}"
```

Confirmed safari opened correctly when authenticating with SSO.

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs