### PR TITLE
update file permissions to read/write

### DIFF
--- a/pkg/accessrequest/role.go
+++ b/pkg/accessrequest/role.go
@@ -14,6 +14,11 @@ import (
 	"github.com/common-fate/granted/pkg/config"
 )
 
+const (
+	// permission for user to read/write.
+	USER_READ_WRITE_PERM = 0644
+)
+
 type Role struct {
 	Account string `json:"account"`
 	Role    string `json:"role"`
@@ -46,7 +51,7 @@ func (r Role) Save() error {
 	}
 
 	file := filepath.Join(configFolder, "latest-role")
-	return os.WriteFile(file, roleBytes, 0644)
+	return os.WriteFile(file, roleBytes, USER_READ_WRITE_PERM)
 }
 
 func LatestRole() (*Role, error) {
@@ -91,7 +96,7 @@ func (p Profile) Save() error {
 	}
 
 	file := filepath.Join(configFolder, "latest-profile")
-	return os.WriteFile(file, profileBytes, 0644)
+	return os.WriteFile(file, profileBytes, USER_READ_WRITE_PERM)
 }
 
 func LatestProfile() (*Profile, error) {

--- a/pkg/cfaws/ssotoken.go
+++ b/pkg/cfaws/ssotoken.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	// permission for user to read/write/execute.
-	USER_READ_WRITE_PERM = 0700
+	// permission for user to read/write.
+	USER_READ_WRITE_PERM = 0644
 )
 
 type SSOPlainTextOut struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,16 @@ import (
 	"github.com/common-fate/granted/internal/build"
 )
 
+const (
+	// permission for user to read/write.
+	USER_READ_WRITE_PERM = 0644
+)
+
+const (
+	// permission for user to read/write.
+	USER_READ_WRITE_EXECUTE_PERM = 0700
+)
+
 type BrowserLaunchTemplate struct {
 	// UseForkProcess specifies whether to use forkprocess to launch the browser.
 	//
@@ -137,7 +147,7 @@ func SetupConfigFolder() error {
 		return err
 	}
 	if _, err := os.Stat(grantedFolder); os.IsNotExist(err) {
-		err := os.Mkdir(grantedFolder, 0644)
+		err := os.Mkdir(grantedFolder, USER_READ_WRITE_PERM)
 		if err != nil {
 			return err
 		}
@@ -153,14 +163,14 @@ func SetupZSHAutoCompleteFolderAssume() (string, error) {
 	}
 	zshPath := path.Join(grantedFolder, "zsh_autocomplete")
 	if _, err := os.Stat(zshPath); os.IsNotExist(err) {
-		err := os.Mkdir(zshPath, 0700)
+		err := os.Mkdir(zshPath, USER_READ_WRITE_EXECUTE_PERM)
 		if err != nil {
 			return "", err
 		}
 	}
 	zshPath = path.Join(zshPath, build.AssumeScriptName())
 	if _, err := os.Stat(zshPath); os.IsNotExist(err) {
-		err := os.Mkdir(zshPath, 0700)
+		err := os.Mkdir(zshPath, USER_READ_WRITE_EXECUTE_PERM)
 		if err != nil {
 			return "", err
 		}
@@ -176,14 +186,14 @@ func SetupZSHAutoCompleteFolderGranted() (string, error) {
 	}
 	zshPath := path.Join(grantedFolder, "zsh_autocomplete")
 	if _, err := os.Stat(zshPath); os.IsNotExist(err) {
-		err := os.Mkdir(zshPath, 0700)
+		err := os.Mkdir(zshPath, USER_READ_WRITE_EXECUTE_PERM)
 		if err != nil {
 			return "", err
 		}
 	}
 	zshPath = path.Join(zshPath, build.GrantedBinaryName())
 	if _, err := os.Stat(zshPath); os.IsNotExist(err) {
-		err := os.Mkdir(zshPath, 0700)
+		err := os.Mkdir(zshPath, USER_READ_WRITE_EXECUTE_PERM)
 		if err != nil {
 			return "", err
 		}
@@ -269,7 +279,7 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 
-	file, err := os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE, 0600)
+	file, err := os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE, USER_READ_WRITE_PERM)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +301,7 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	file, err := os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	file, err := os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, USER_READ_WRITE_PERM)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,7 +137,7 @@ func SetupConfigFolder() error {
 		return err
 	}
 	if _, err := os.Stat(grantedFolder); os.IsNotExist(err) {
-		err := os.Mkdir(grantedFolder, 0700)
+		err := os.Mkdir(grantedFolder, 0644)
 		if err != nil {
 			return err
 		}

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -70,7 +70,7 @@ func Load(fecencyStoreKey string) (*FrecencyStore, error) {
 
 	// check if the providers file exists
 	if _, err = os.Stat(c.path); os.IsNotExist(err) {
-		err := os.MkdirAll(configFolder, 0700)
+		err := os.MkdirAll(configFolder, 0644)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -11,6 +11,11 @@ import (
 	"github.com/common-fate/granted/pkg/config"
 )
 
+const (
+	// permission for user to read/write.
+	USER_READ_WRITE_PERM = 0644
+)
+
 // change these to play with the weights
 // values between 0 and 1
 // 0 will exclude the metric all together from the ordering
@@ -70,14 +75,14 @@ func Load(fecencyStoreKey string) (*FrecencyStore, error) {
 
 	// check if the providers file exists
 	if _, err = os.Stat(c.path); os.IsNotExist(err) {
-		err := os.MkdirAll(configFolder, 0644)
+		err := os.MkdirAll(configFolder, USER_READ_WRITE_PERM)
 		if err != nil {
 			return nil, err
 		}
 		return &c, nil
 	}
 
-	file, err := os.OpenFile(c.path, os.O_RDWR|os.O_CREATE, 0600)
+	file, err := os.OpenFile(c.path, os.O_RDWR|os.O_CREATE, USER_READ_WRITE_PERM)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +191,7 @@ func (store *FrecencyStore) save() error {
 	// 	store.Entries = store.Entries[0 : len(store.Entries)-1]
 	// }
 
-	file, err := os.OpenFile(store.path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	file, err := os.OpenFile(store.path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, USER_READ_WRITE_PERM)
 	if err != nil {
 		return err
 	}

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -38,6 +38,11 @@ import (
 	"gopkg.in/ini.v1"
 )
 
+const (
+	// permission for user to read/write.
+	USER_READ_WRITE_PERM = 0644
+)
+
 var Command = cli.Command{
 	Name:  "request",
 	Usage: "Request access to a role",
@@ -726,7 +731,7 @@ func updateCachedAccessRule(ctx context.Context, opts updateCacheOpts) error {
 		return err
 	}
 
-	err = os.WriteFile(filename, ruleBytes, 0644)
+	err = os.WriteFile(filename, ruleBytes, USER_READ_WRITE_PERM)
 	if err != nil {
 		return err
 	}

--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -15,11 +15,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const (
-	// permission for user to read/write/execute.
-	USER_READ_WRITE_PERM = 0700
-)
-
 var AddCommand = cli.Command{
 	Name:        "add",
 	Description: "Add a Profile Registry that you want to sync with aws config file",

--- a/pkg/granted/registry/ini.go
+++ b/pkg/granted/registry/ini.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	// permission for user to read/write/execute.
+	// permission for user to read/write.
 	USER_READ_WRITE_PERM = 0644
 )
 

--- a/pkg/granted/registry/ini.go
+++ b/pkg/granted/registry/ini.go
@@ -10,6 +10,11 @@ import (
 	"gopkg.in/ini.v1"
 )
 
+const (
+	// permission for user to read/write/execute.
+	USER_READ_WRITE_PERM = 0644
+)
+
 // Find the ~/.aws/config absolute path based on OS.
 func getDefaultAWSConfigLocation() (string, error) {
 	h, err := os.UserHomeDir()

--- a/pkg/shells/file.go
+++ b/pkg/shells/file.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+const (
+	// permission for user to read/write.
+	USER_READ_WRITE_PERM = 0644
+)
+
 // AppendLine writes a line to a file if it does not already exist
 func AppendLine(file string, line string) error {
 	b, err := os.ReadFile(file)
@@ -19,7 +24,7 @@ func AppendLine(file string, line string) error {
 	}
 
 	// open the file for writing
-	out, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0644)
+	out, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, USER_READ_WRITE_PERM)
 	if err != nil {
 		return err
 	}
@@ -73,7 +78,7 @@ func RemoveLine(file string, lineToRemove string) error {
 	}
 
 	output := strings.Join(ignored, "\n")
-	err = os.WriteFile(file, []byte(output), 0644)
+	err = os.WriteFile(file, []byte(output), USER_READ_WRITE_PERM)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What changed?
Updated file permissions from 700 to 644

### Why?
Some of the files and folders that Granted created for config were using a file perm of 700 which is for read/write/execute. This is unnecessary for their use.

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs