### PR TITLE
Revert "update file permissions to read/write (#751)"

### DIFF
--- a/pkg/accessrequest/role.go
+++ b/pkg/accessrequest/role.go
@@ -14,11 +14,6 @@ import (
 	"github.com/common-fate/granted/pkg/config"
 )
 
-const (
-	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644
-)
-
 type Role struct {
 	Account string `json:"account"`
 	Role    string `json:"role"`
@@ -51,7 +46,7 @@ func (r Role) Save() error {
 	}
 
 	file := filepath.Join(configFolder, "latest-role")
-	return os.WriteFile(file, roleBytes, USER_READ_WRITE_PERM)
+	return os.WriteFile(file, roleBytes, 0644)
 }
 
 func LatestRole() (*Role, error) {
@@ -96,7 +91,7 @@ func (p Profile) Save() error {
 	}
 
 	file := filepath.Join(configFolder, "latest-profile")
-	return os.WriteFile(file, profileBytes, USER_READ_WRITE_PERM)
+	return os.WriteFile(file, profileBytes, 0644)
 }
 
 func LatestProfile() (*Profile, error) {

--- a/pkg/cfaws/ssotoken.go
+++ b/pkg/cfaws/ssotoken.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644
+	// permission for user to read/write/execute.
+	USER_READ_WRITE_PERM = 0700
 )
 
 type SSOPlainTextOut struct {

--- a/pkg/cfaws/ssotoken.go
+++ b/pkg/cfaws/ssotoken.go
@@ -15,11 +15,6 @@ import (
 	"github.com/common-fate/granted/pkg/securestorage"
 )
 
-const (
-	// permission for user to read/write/execute.
-	USER_READ_WRITE_PERM = 0700
-)
-
 type SSOPlainTextOut struct {
 	AccessToken    string `json:"accessToken"`
 	ExpiresAt      string `json:"expiresAt"`
@@ -93,13 +88,13 @@ func dumpTokenFile(jsonToken []byte, key string) error {
 	}
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		err := os.MkdirAll(path, USER_READ_WRITE_PERM)
+		err := os.MkdirAll(path, 0700)
 		if err != nil {
 			return fmt.Errorf("unable to create sso cache directory with err: %s", err)
 		}
 	}
 
-	err = os.WriteFile(filepath.Join(path, key), jsonToken, USER_READ_WRITE_PERM)
+	err = os.WriteFile(filepath.Join(path, key), jsonToken, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,16 +17,6 @@ import (
 	"github.com/common-fate/granted/internal/build"
 )
 
-const (
-	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644
-)
-
-const (
-	// permission for user to read/write.
-	USER_READ_WRITE_EXECUTE_PERM = 0700
-)
-
 type BrowserLaunchTemplate struct {
 	// UseForkProcess specifies whether to use forkprocess to launch the browser.
 	//
@@ -152,7 +142,7 @@ func SetupConfigFolder() error {
 		return err
 	}
 	if _, err := os.Stat(grantedFolder); os.IsNotExist(err) {
-		err := os.Mkdir(grantedFolder, USER_READ_WRITE_PERM)
+		err := os.Mkdir(grantedFolder, 0700)
 		if err != nil {
 			return err
 		}
@@ -168,14 +158,14 @@ func SetupZSHAutoCompleteFolderAssume() (string, error) {
 	}
 	zshPath := path.Join(grantedFolder, "zsh_autocomplete")
 	if _, err := os.Stat(zshPath); os.IsNotExist(err) {
-		err := os.Mkdir(zshPath, USER_READ_WRITE_EXECUTE_PERM)
+		err := os.Mkdir(zshPath, 0700)
 		if err != nil {
 			return "", err
 		}
 	}
 	zshPath = path.Join(zshPath, build.AssumeScriptName())
 	if _, err := os.Stat(zshPath); os.IsNotExist(err) {
-		err := os.Mkdir(zshPath, USER_READ_WRITE_EXECUTE_PERM)
+		err := os.Mkdir(zshPath, 0700)
 		if err != nil {
 			return "", err
 		}
@@ -191,14 +181,14 @@ func SetupZSHAutoCompleteFolderGranted() (string, error) {
 	}
 	zshPath := path.Join(grantedFolder, "zsh_autocomplete")
 	if _, err := os.Stat(zshPath); os.IsNotExist(err) {
-		err := os.Mkdir(zshPath, USER_READ_WRITE_EXECUTE_PERM)
+		err := os.Mkdir(zshPath, 0700)
 		if err != nil {
 			return "", err
 		}
 	}
 	zshPath = path.Join(zshPath, build.GrantedBinaryName())
 	if _, err := os.Stat(zshPath); os.IsNotExist(err) {
-		err := os.Mkdir(zshPath, USER_READ_WRITE_EXECUTE_PERM)
+		err := os.Mkdir(zshPath, 0700)
 		if err != nil {
 			return "", err
 		}
@@ -284,7 +274,7 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 
-	file, err := os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE, USER_READ_WRITE_PERM)
+	file, err := os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +296,7 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	file, err := os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, USER_READ_WRITE_PERM)
+	file, err := os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -11,11 +11,6 @@ import (
 	"github.com/common-fate/granted/pkg/config"
 )
 
-const (
-	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644
-)
-
 // change these to play with the weights
 // values between 0 and 1
 // 0 will exclude the metric all together from the ordering
@@ -75,14 +70,14 @@ func Load(fecencyStoreKey string) (*FrecencyStore, error) {
 
 	// check if the providers file exists
 	if _, err = os.Stat(c.path); os.IsNotExist(err) {
-		err := os.MkdirAll(configFolder, USER_READ_WRITE_PERM)
+		err := os.MkdirAll(configFolder, 0700)
 		if err != nil {
 			return nil, err
 		}
 		return &c, nil
 	}
 
-	file, err := os.OpenFile(c.path, os.O_RDWR|os.O_CREATE, USER_READ_WRITE_PERM)
+	file, err := os.OpenFile(c.path, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +186,7 @@ func (store *FrecencyStore) save() error {
 	// 	store.Entries = store.Entries[0 : len(store.Entries)-1]
 	// }
 
-	file, err := os.OpenFile(store.path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, USER_READ_WRITE_PERM)
+	file, err := os.OpenFile(store.path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -38,11 +38,6 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-const (
-	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644
-)
-
 var Command = cli.Command{
 	Name:  "request",
 	Usage: "Request access to a role",
@@ -731,7 +726,7 @@ func updateCachedAccessRule(ctx context.Context, opts updateCacheOpts) error {
 		return err
 	}
 
-	err = os.WriteFile(filename, ruleBytes, USER_READ_WRITE_PERM)
+	err = os.WriteFile(filename, ruleBytes, 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -15,6 +15,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	// permission for user to read/write/execute.
+	USER_READ_WRITE_PERM = 0700
+)
+
 var AddCommand = cli.Command{
 	Name:        "add",
 	Description: "Add a Profile Registry that you want to sync with aws config file",

--- a/pkg/granted/registry/ini.go
+++ b/pkg/granted/registry/ini.go
@@ -10,11 +10,6 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-const (
-	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644
-)
-
 // Find the ~/.aws/config absolute path based on OS.
 func getDefaultAWSConfigLocation() (string, error) {
 	h, err := os.UserHomeDir()

--- a/pkg/shells/file.go
+++ b/pkg/shells/file.go
@@ -6,11 +6,6 @@ import (
 	"strings"
 )
 
-const (
-	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644
-)
-
 // AppendLine writes a line to a file if it does not already exist
 func AppendLine(file string, line string) error {
 	b, err := os.ReadFile(file)
@@ -24,7 +19,7 @@ func AppendLine(file string, line string) error {
 	}
 
 	// open the file for writing
-	out, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, USER_READ_WRITE_PERM)
+	out, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
@@ -78,7 +73,7 @@ func RemoveLine(file string, lineToRemove string) error {
 	}
 
 	output := strings.Join(ignored, "\n")
-	err = os.WriteFile(file, []byte(output), USER_READ_WRITE_PERM)
+	err = os.WriteFile(file, []byte(output), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What changed?
Reverts the change made in #751.

### Why?
#751 incorrectly removed the executable flag on some of the directories created by Granted. The execute flag [is required](https://superuser.com/questions/168578/why-must-a-folder-be-executable). Additionally, the PR relaxed some of the permissions from `0600` to `0644` which allows users other than the current one to read the various config and frecency files. Given that we've never had a permissions issue opened due to a use case where `0644` is required, I think this is too permissive.

### How did you test it?

Build the CLI locally:

```
sudo make cli
```

Move the `~/.dgranted` folder:

```
mv ~/.dgranted ~/.dgranted.bak
```

Run `dassume`, which will run through the onboarding wizard.

Confirm that the `config` file is not executable and has the expected permissions:

```
❯ ls -al ~/.dgranted
drwx------ chrisnorman staff 128 B  Tue Sep 24 17:35:51 2024  .
drwxr-x--- chrisnorman staff 3.5 KB Tue Sep 24 17:35:51 2024  ..
.rw------- chrisnorman staff 200 B  Tue Sep 24 17:35:54 2024  config
.rw------- chrisnorman staff 1.7 KB Tue Sep 24 17:35:55 2024  log
```

### Potential risks

Low, as we are reverting a known issue in the new release. 


### Is patch release candidate?
Yes

### Link to relevant docs PRs
