### PR TITLE
Fix config folder permissions on create

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ const (
 )
 
 const (
-	// permission for user to read/write.
+	// permission for user to read/write/execute.
 	USER_READ_WRITE_EXECUTE_PERM = 0700
 )
 
@@ -152,7 +152,7 @@ func SetupConfigFolder() error {
 		return err
 	}
 	if _, err := os.Stat(grantedFolder); os.IsNotExist(err) {
-		err := os.Mkdir(grantedFolder, USER_READ_WRITE_PERM)
+		err := os.Mkdir(grantedFolder, USER_READ_WRITE_EXECUTE_PERM)
 		if err != nil {
 			return err
 		}

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -16,6 +16,11 @@ const (
 	USER_READ_WRITE_PERM = 0644
 )
 
+const (
+	// permission for user to read/write/execute.
+	USER_READ_WRITE_EXECUTE_PERM = 0700
+)
+
 // change these to play with the weights
 // values between 0 and 1
 // 0 will exclude the metric all together from the ordering
@@ -75,7 +80,7 @@ func Load(fecencyStoreKey string) (*FrecencyStore, error) {
 
 	// check if the providers file exists
 	if _, err = os.Stat(c.path); os.IsNotExist(err) {
-		err := os.MkdirAll(configFolder, USER_READ_WRITE_PERM)
+		err := os.MkdirAll(configFolder, USER_READ_WRITE_EXECUTE_PERM)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes #754

### What changed?
Updated config directory permissions to allow execute

### Why?
Allow directory to function

### How did you test it?
Verified locally

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs