### PR TITLE
Add RAM (Resource Access Manager)

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -45,6 +45,7 @@ var ServiceMap = map[string]string{
 	"mwaa":           "mwaa",
 	"param":          "systems-manager/parameters",
 	"r53":            "route53/v2",
+	"ram":		  "ram",
 	"rds":            "rds",
 	"redshift":       "redshiftv2",
 	"route53":        "route53/v2",


### PR DESCRIPTION
### What changed?
I added `ram` Resource Access Manager to the service map

### Why?
It is a service that exists and will get rid of this message ```[!] We don't recognize service ram but we'll try and open it anyway (you may receive a 404 page)```

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs