### PR TITLE
add fixes to setting custom browser

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -423,7 +423,7 @@ func AssumeCommand(c *cli.Context) error {
 		}
 
 		browserPath := cfg.CustomBrowserPath
-		if browserPath == "" {
+		if browserPath == "" && cfg.AWSConsoleBrowserLaunchTemplate == nil {
 			return errors.New("default browser not configured. run `granted browser set` to configure")
 		}
 

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -218,6 +218,12 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 	browserTitle := title.String(strings.ToLower(browserKey))
 	// We allow users to configure a custom install path if we cannot detect the installation
 	browserPath := path
+
+	//load config
+	conf, err := config.Load()
+	if err != nil {
+		return err
+	}
 	// detect installation
 	if browserKey != FirefoxStdoutKey && browserKey != StdoutKey && browserKey != CustomKey {
 
@@ -257,12 +263,15 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 			}
 		}
 	}
-	// save the detected browser as the default
-	conf, err := config.Load()
-	if err != nil {
-		return err
+
+	//if browser set to default but config does not include browser launch tempalate. add it.
+	if browserKey == CustomKey && conf.AWSConsoleBrowserLaunchTemplate == nil {
+		conf.AWSConsoleBrowserLaunchTemplate = &config.BrowserLaunchTemplate{
+			Command: "",
+		}
 	}
 
+	// save the detected browser as the default
 	conf.DefaultBrowser = browserKey
 	conf.CustomBrowserPath = browserPath
 	err = conf.Save()

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -41,7 +41,7 @@ func UserHasDefaultBrowser(ctx *cli.Context) (bool, error) {
 			return false, err
 		}
 	}
-	return conf.DefaultBrowser != "" && conf.CustomBrowserPath != "", nil
+	return conf.DefaultBrowser != "" && conf.CustomBrowserPath != "" || conf.AWSConsoleBrowserLaunchTemplate != nil, nil
 }
 
 func HandleManualBrowserSelection() (string, error) {
@@ -50,7 +50,7 @@ func HandleManualBrowserSelection() (string, error) {
 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 	in := survey.Select{
 		Message: "Select one of the browsers from the list",
-		Options: []string{"Chrome", "Brave", "Edge", "Firefox", "Waterfox", "Chromium", "Safari", "Stdout", "FirefoxStdout", "Firefox Developer Edition", "Firefox Nightly", "Arc"},
+		Options: []string{"Chrome", "Brave", "Edge", "Firefox", "Waterfox", "Chromium", "Safari", "Stdout", "FirefoxStdout", "Firefox Developer Edition", "Firefox Nightly", "Arc", "Custom"},
 	}
 	var selection string
 	clio.NewLine()
@@ -136,6 +136,9 @@ func GetBrowserKey(b string) string {
 	if strings.Contains(strings.ToLower(b), "arc") {
 		return ArcKey
 	}
+	if strings.Contains(strings.ToLower(b), "custom") {
+		return CustomKey
+	}
 
 	return StdoutKey
 }
@@ -216,7 +219,7 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 	// We allow users to configure a custom install path if we cannot detect the installation
 	browserPath := path
 	// detect installation
-	if browserKey != FirefoxStdoutKey && browserKey != StdoutKey {
+	if browserKey != FirefoxStdoutKey && browserKey != StdoutKey && browserKey != CustomKey {
 
 		if browserPath != "" {
 			_, err := os.Stat(browserPath)
@@ -385,7 +388,7 @@ func AskAndGetBrowserPath() (string, error) {
 	// We allow users to configure a custom install path is we cannot detect the installation
 	browserPath := ""
 	// detect installation
-	if browserKey != FirefoxStdoutKey && browserKey != StdoutKey {
+	if browserKey != FirefoxStdoutKey && browserKey != StdoutKey && browserKey != CustomKey {
 
 		customBrowserPath, detected := DetectInstallation(browserKey)
 		if !detected {

--- a/pkg/granted/browser.go
+++ b/pkg/granted/browser.go
@@ -12,11 +12,13 @@ var DefaultBrowserCommand = cli.Command{
 	Usage:       "View the web browser that Granted uses to open cloud consoles",
 	Subcommands: []*cli.Command{&SetBrowserCommand, &SetSSOBrowserCommand},
 	Action: func(c *cli.Context) error {
+
 		// return the default browser that is set
 		conf, err := config.Load()
 		if err != nil {
 			return err
 		}
+
 		clio.Infof("Granted is using %s. To change this run `granted browser set`", conf.DefaultBrowser)
 
 		return nil

--- a/pkg/granted/console.go
+++ b/pkg/granted/console.go
@@ -70,6 +70,9 @@ var ConsoleCommand = cli.Command{
 		if cfg.CustomBrowserPath == "" && cfg.DefaultBrowser != "" {
 			l = launcher.Open{}
 		} else if cfg.CustomBrowserPath == "" {
+			if cfg.AWSConsoleBrowserLaunchTemplate != nil {
+				return errors.New("custom launch template set but default browser not set to `CUSTOM`. run granted browser set --browser=custom to fix this")
+			}
 			return errors.New("default browser not configured. run `granted browser set` to configure")
 		} else {
 			switch cfg.DefaultBrowser {

--- a/pkg/granted/console.go
+++ b/pkg/granted/console.go
@@ -69,10 +69,7 @@ var ConsoleCommand = cli.Command{
 		var l assume.Launcher
 		if cfg.CustomBrowserPath == "" && cfg.DefaultBrowser != "" {
 			l = launcher.Open{}
-		} else if cfg.CustomBrowserPath == "" {
-			if cfg.AWSConsoleBrowserLaunchTemplate != nil {
-				return errors.New("custom launch template set but default browser not set to `CUSTOM`. run granted browser set --browser=custom to fix this")
-			}
+		} else if cfg.CustomBrowserPath == "" && cfg.AWSConsoleBrowserLaunchTemplate == nil {
 			return errors.New("default browser not configured. run `granted browser set` to configure")
 		} else {
 			switch cfg.DefaultBrowser {


### PR DESCRIPTION
### What changed?
Fixes for #731 
- `granted browser set` will now give an option for CUSTOM which will create the stub for AWSConsoleBrowserLaunchTemplate.
- CustomBrowserPath is no longer required when using AWSConsoleBrowserLaunchTemplate. Fixes #753

### Why?
#753
Other than manually editing the granted config there was no other way to add the AWSConsoleBrowserLaunchTemplate

### How did you test it?
Tested AWSConsoleBrowserLaunchTemplate with no CustomBrowserPath and observed issue. Tested again after applied fix and console worked as expected.

Removed all config relating to browsers and setup using Granteds browser onboarding by setting the custom browser type. Type was correctly set along with the AWSConsoleBrowserLaunchTemplate.
Switching browser type with `granted browser set` also worked fine after the change.

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs