### PR TITLE
Added support for manual setting of PassDir to avoid pass password pollution in default location

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,6 +94,7 @@ type KeyringConfig struct {
 	KeychainName            *string `toml:",omitempty"`
 	FileDir                 *string `toml:",omitempty"`
 	LibSecretCollectionName *string `toml:",omitempty"`
+	PassDir                 *string `toml:",omitempty"` // PassDir is the pass password-store directory, ~/ is resolved to the users' home dir
 }
 
 type Registry struct {

--- a/pkg/granted/settings/set.go
+++ b/pkg/granted/settings/set.go
@@ -36,6 +36,7 @@ var SetConfigCommand = cli.Command{
 		fieldMap["Keyring.KeychainName"] = keyringFields{&cfg.Keyring.KeychainName}
 		fieldMap["Keyring.FileDir"] = keyringFields{&cfg.Keyring.FileDir}
 		fieldMap["Keyring.LibSecretCollectionName"] = keyringFields{&cfg.Keyring.LibSecretCollectionName}
+		fieldMap["Keyring.PassDir"] = keyringFields{&cfg.Keyring.PassDir}
 
 		fields := make([]string, 0, len(fieldMap))
 		for k := range fieldMap {

--- a/pkg/securestorage/securestorage.go
+++ b/pkg/securestorage/securestorage.go
@@ -153,6 +153,9 @@ func (s *SecureStorage) openKeyring() (keyring.Keyring, error) {
 		if cfg.Keyring.LibSecretCollectionName != nil {
 			c.LibSecretCollectionName = *cfg.Keyring.LibSecretCollectionName
 		}
+		if cfg.Keyring.PassDir != nil {
+			c.PassDir = *cfg.Keyring.PassDir
+		}
 	}
 
 	k, err := keyring.Open(c)

--- a/pkg/securestorage/securestorage.go
+++ b/pkg/securestorage/securestorage.go
@@ -118,9 +118,6 @@ func (s *SecureStorage) openKeyring() (keyring.Keyring, error) {
 		KeychainName:             "login",
 		KeychainTrustApplication: true,
 
-		//Pass Dir
-		PassDir: grantedFolder,
-
 		// KDE Wallet
 		KWalletAppID:  name,
 		KWalletFolder: name,

--- a/pkg/securestorage/securestorage.go
+++ b/pkg/securestorage/securestorage.go
@@ -118,6 +118,9 @@ func (s *SecureStorage) openKeyring() (keyring.Keyring, error) {
 		KeychainName:             "login",
 		KeychainTrustApplication: true,
 
+		//Pass Dir
+		PassDir: grantedFolder,
+
 		// KDE Wallet
 		KWalletAppID:  name,
 		KWalletFolder: name,


### PR DESCRIPTION
### What changed?
Users are now able to manually set the PassDir when using Pass backend to store their session tokens

### Why?
#746 
Issue was raised by a user stating that their PassDir is getting polluted by granted keys, would like to have the option to manually set a different store

### How did you test it?
Tested locally by setting PassDir to desktop, verified after running dassume to find aws sso tokens stored inside intended folder in Desktop

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs
