### PR TITLE
Fix the version output when running `assume -v`

### DIFF
--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/common-fate/clio/cliolog"
 	"github.com/common-fate/granted/internal/build"
 	"github.com/common-fate/granted/pkg/alias"
+	"github.com/common-fate/granted/pkg/assumeprint"
 	"github.com/common-fate/granted/pkg/autosync"
 	"github.com/common-fate/granted/pkg/browser"
 	"github.com/common-fate/granted/pkg/config"
@@ -61,7 +62,8 @@ func GlobalFlags() []cli.Flag {
 
 func GetCliApp() *cli.App {
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Printf("Granted version: %s\n", build.Version)
+		ver := fmt.Sprintf("Granted version: %s\n", build.Version)
+		fmt.Print(assumeprint.SafeOutput(ver))
 	}
 
 	app := &cli.App{


### PR DESCRIPTION
### What changed?
The output of the CLI version printer is now wrapped in `assumeprint.SafeOutput`, so that `assume --version` and `assume -v` print the actual version rather than an empty string.

### Why?
Fixes #723.

We need to prefix text written to stdout with `GrantedOutput`, otherwise it is swallowed by the `assume` shell script. This wasn't implemented for the `assume` VersionPrinter, so no output was shown. 

### How did you test it?

```
sudo make cli 
dassume -v 
```

The version is printed now: 

```
❯ dassume -v
Granted version: dev
```

### Potential risks
Low risk as only the version printer is affected by the change.

### Is patch release candidate?
Yes

