### PR TITLE
Handle parsing of special comment characters in configuration

### DIFF
--- a/pkg/granted/registry/cfregistry/cfregistry.go
+++ b/pkg/granted/registry/cfregistry/cfregistry.go
@@ -91,7 +91,12 @@ func (r *Registry) AWSProfiles(ctx context.Context) (*ini.File, error) {
 		}
 	}
 
-	result := ini.Empty()
+	result := ini.Empty(
+		ini.LoadOptions{
+			SpaceBeforeInlineComment:    true,
+			UnescapeValueCommentSymbols: true,
+		},
+	)
 
 	for _, profile := range profiles {
 

--- a/pkg/granted/registry/gitregistry/gitregistry.go
+++ b/pkg/granted/registry/gitregistry/gitregistry.go
@@ -58,7 +58,12 @@ func (r Registry) AWSProfiles(ctx context.Context) (*ini.File, error) {
 
 	// load all cloned configs of a single repo into one ini object.
 	// this will overwrite if there are duplicate profiles with same name.
-	result := ini.Empty()
+	result := ini.Empty(
+		ini.LoadOptions{
+			SpaceBeforeInlineComment:    true,
+			UnescapeValueCommentSymbols: true,
+		},
+	)
 
 	for _, cfile := range cfg.AwsConfigPaths {
 		var filepath string

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -44,7 +44,7 @@ var SSOCommand = cli.Command{
 
 const (
 	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644 
+	USER_READ_WRITE_PERM = 0644
 )
 
 // in dev:


### PR DESCRIPTION
### What changed?
In order to fix issue https://github.com/common-fate/granted/issues/739, the ini client is loaded with the following options:

- SpaceBeforeInlineComment : Only interprets the inline comment if there is a space preceding the # character
- UnescapeValueCommentSymbols : Prevents the # from being automatically escaped (i.e. \#) as part of the output

### Why?
Users were unable to use URLs that included the # character, which was typically used for inline comments. A thorough description of the issue can be seen here https://github.com/common-fate/granted/issues/739.

Fixes https://github.com/common-fate/granted/issues/739.

### How did you test it?

Using the dummy configuration with # characters in git registry https://github.com/common-fate/granted-registry/blob/main/config2:
```
# this is a dummy config 
[profile demo-main_dummy]
granted_sso_start_url = https://d-976708da7d.awsapps.com/start\#0000000000042
granted_sso_region = ap-southeast-2
granted_sso_account_id = 632700053629
granted_sso_role_name = AWSAdministratorAccess
region = ap-southeast-2
session_name = {{ .Required.SessionName }}
credential_process = granted credential-process --profile {{ .Profile }} --url https://internal.prod.granted.run
```

We then generate the registries in `.aws/config` using `dgranted registry add -name test12 -url https://github.com/common-fate/granted-registry/ -prefix-duplicate-profiles`

The output observed in  `.aws/config` is:

```
...

[profile test12.demo-main_dummy]
granted_sso_start_url  = `https://d-976708da7d.awsapps.com/start#0000000000042`
granted_sso_region     = ap-southeast-2
granted_sso_account_id = 632700053629
granted_sso_role_name  = AWSAdministratorAccess
region                 = ap-southeast-2
session_name           =
credential_process     = granted credential-process --profile test12.demo-main_dummy --url https://internal.prod.granted.run

[granted_registry_end test12]
```

Furthermore, when creating a new profile registry from your local AWS config, this is the generated granted.yml:

```
[profile test12.demo-main_dummy]
granted_sso_start_url  = `https://d-976708da7d.awsapps.com/start#0000000000042`
granted_sso_region     = ap-southeast-2
granted_sso_account_id = 632700053629
granted_sso_role_name  = AWSAdministratorAccess
region                 = ap-southeast-2
session_name           =
credential_process     = granted credential-process --profile test12.demo-main_dummy --url https://internal.prod.granted.run
```


### Potential risks
Previous configurations that do not have a space before the inline comment will not have it recognised as an inline comment. Instead, it will be recognised as part of the value.

### Is patch release candidate?


### Link to relevant docs PRs