### PR TITLE
update asdf tool-versions golang to 1.22

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19
+golang 1.22


### PR DESCRIPTION
### What changed?
Updates the `.tool-versions` file used by [asdf](https://asdf-vm.com/) to Go v1.22.

### Why?
If any contributors use asdf, the current version is too early as we have upgraded the codebase to Go v1.22.

### How did you test it?
Untested locally but confirms adheres to the file format https://asdf-vm.com/manage/configuration.html

### Potential risks
Low, core team do not use asdf for Go version management

### Is patch release candidate?
N/A as it's a dev dependency

### Link to relevant docs PRs
N/A