### PR TITLE
Changes waf shortcut to use v2 home page, rather than WAF classic home.

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -62,7 +62,8 @@ var ServiceMap = map[string]string{
 	"trustedadvisor": "trustedadvisor",
 	"tra":            "trustedadvisor",
 	"vpc":            "vpc",
-	"waf":            "wafv2/homev2",
+	"waf":            "wafv2",
+	"wafv2":          "wafv2/homev2"
 }
 
 var globalServiceMap = map[string]bool{

--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -62,7 +62,7 @@ var ServiceMap = map[string]string{
 	"trustedadvisor": "trustedadvisor",
 	"tra":            "trustedadvisor",
 	"vpc":            "vpc",
-	"waf":            "wafv2",
+	"waf":            "wafv2/homev2",
 }
 
 var globalServiceMap = map[string]bool{


### PR DESCRIPTION
### What changed?

Added wafv2 service map

### Why?

Because the WAF v2 home page is actually at wafv2/homev2

### How did you test it?

### Potential risks

None

### Is patch release candidate?

Yes

### Link to relevant docs PRs
