### PR TITLE
Fix service map comma and formatting

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -46,7 +46,7 @@ var ServiceMap = map[string]string{
 	"mwaa":           "mwaa",
 	"param":          "systems-manager/parameters",
 	"r53":            "route53/v2",
-	"ram":		  "ram",
+	"ram":            "ram",
 	"rds":            "rds",
 	"redshift":       "redshiftv2",
 	"route53":        "route53/v2",
@@ -68,7 +68,7 @@ var ServiceMap = map[string]string{
 	"tra":            "trustedadvisor",
 	"vpc":            "vpc",
 	"waf":            "wafv2",
-	"wafv2":          "wafv2/homev2"
+	"wafv2":          "wafv2/homev2",
 }
 
 var globalServiceMap = map[string]bool{


### PR DESCRIPTION
### What changed?
Fixes the trailing comma and the formatting of the service map.

### Why?
I merged #775 before realising there was a missing trailing comma.


### How did you test it?
Confirmed build works locally

### Potential risks
None

### Is patch release candidate?
N/A - previous PR unreleased 

