### PR TITLE
fix: pass external_id for credential process and IAM

### DIFF
--- a/pkg/cfaws/assumer_aws_credential_process.go
+++ b/pkg/cfaws/assumer_aws_credential_process.go
@@ -76,6 +76,9 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *Prof
 				aro.TokenProvider = MfaTokenProvider
 			}
 			aro.Duration = configOpts.Duration
+			if c.AWSConfig.ExternalID != "" {
+				aro.ExternalID = &c.AWSConfig.ExternalID
+			}
 		})
 		return stsp.Retrieve(ctx)
 	}

--- a/pkg/cfaws/assumer_aws_iam.go
+++ b/pkg/cfaws/assumer_aws_iam.go
@@ -98,7 +98,9 @@ func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *Profile, config
 				aro.TokenProvider = MfaTokenProvider
 			}
 			aro.Duration = configOpts.Duration
-
+			if c.AWSConfig.ExternalID != "" {
+				aro.ExternalID = &c.AWSConfig.ExternalID
+			}
 			/**If the mfa_serial is defined on the root profile, we need to set it in this config so that the aws SDK knows to prompt for MFA token:
 			*[profile base]
 			*region             = us-west-2


### PR DESCRIPTION
### What changed?
Similar to #187, this enables passing of `ExternalId` from IAM and credential process

### Why?
Currently, `assume` does not pass `external_id` in profiles using credential process or IAM User source profiles. This causes trust policies with an `sts:ExternalId` 

### How did you test it?
1. Build and ran an `assume` build with `external_id` present
2. Ran unit tests

### Potential risks
N/A

### Is patch release candidate?
Yes

### Link to relevant docs PRs
N/A