### PR TITLE
Make leading/trailing spaces optional in templating

### DIFF
--- a/pkg/granted/awsmerge/merge_from_registry.go
+++ b/pkg/granted/awsmerge/merge_from_registry.go
@@ -303,7 +303,7 @@ func interpolateVariables(value string, profileName string) (string, error) {
 }
 
 func containsTemplate(text string) bool {
-	re := regexp.MustCompile(`{{\s+(.\w+){1,2}\s+}}`)
+	re := regexp.MustCompile(`{{\s*(.\w+){1,2}\s*}}`)
 
 	return re.MatchString(text)
 }


### PR DESCRIPTION
### What changed?

Allow templating in granted config file to contain lead/trailing spaces or not at all.

### Why?

The usage of templating in granted config files is more forgiving if the author doesn't have spaces in their go templating syntax. Without this it's unclear why template syntax is left un-rendered in the AWS config file.

### How did you test it?

Built CLI and tested using a registry containing a test profile config and granted config file:

#### Test profile config

<img width="581" alt="image" src="https://github.com/user-attachments/assets/5e376c25-243f-416c-bd5b-02caa71d384f">

#### Test granted config

<img width="385" alt="image" src="https://github.com/user-attachments/assets/3117ca1f-b5fc-4901-9605-57f5e3220e97">

#### Add test registry

<img width="1331" alt="image" src="https://github.com/user-attachments/assets/0cb8d447-8384-4028-a292-cfbd873e1dcd">

#### Observe rendered profiles

<img width="1316" alt="image" src="https://github.com/user-attachments/assets/a39aaed7-67e5-4079-906a-48a907268635">

### Potential risks

There shouldn't be risks given that the updated regular expression allows for zero or more spaces, which should be backwards compatible with all existing usages.

### Is patch release candidate?


### Link to relevant docs PRs

N/A