### PR TITLE
Add Vivaldi browser support

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -429,7 +429,7 @@ func AssumeCommand(c *cli.Context) error {
 
 		var l Launcher
 		switch cfg.DefaultBrowser {
-		case browser.ChromeKey, browser.BraveKey, browser.EdgeKey, browser.ChromiumKey:
+		case browser.ChromeKey, browser.BraveKey, browser.EdgeKey, browser.ChromiumKey, browser.VivaldiKey:
 			l = launcher.ChromeProfile{
 				BrowserType:    cfg.DefaultBrowser,
 				ExecutablePath: browserPath,

--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -58,6 +58,8 @@ var ChromiumPathLinux = []string{`/usr/bin/chromium`, `/../../mnt/c/Program File
 var ChromiumPathWindows = []string{`\Program Files\Chromium\chromium.exe`}
 
 var VivaldiPathMac = []string{"/Applications/Vivaldi.app/Contents/MacOS/Vivaldi"}
+var VivaldiPathLinux = []string{`/usr/bin/vivaldi`, `/../../mnt/c/Program Files/Vivaldi/vivaldi.exe`}
+var VivaldiPathWindows = []string{`\Program Files\Vivaldi\vivaldi.exe`}
 
 var SafariPathMac = []string{"/Applications/Safari.app/Contents/MacOS/Safari"}
 
@@ -215,8 +217,12 @@ func ChromiumPathDefaults() ([]string, error) {
 
 func VivaldiPathDefaults() ([]string, error) {
 	switch runtime.GOOS {
+	case "windows":
+		return VivaldiPathWindows, nil
 	case "darwin":
 		return VivaldiPathMac, nil
+	case "linux":
+		return VivaldiPathLinux, nil
 	default:
 		return nil, errors.New("os not supported")
 	}

--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -21,6 +21,7 @@ const (
 	FirefoxDevEditionKey string = "FIREFOX_DEV"
 	FirefoxNightlyKey    string = "FIREFOX_NIGHTLY"
 	CustomKey            string = "CUSTOM"
+	VivaldiKey           string = "VIVALDI"
 )
 
 // A few default paths to check for the browser
@@ -55,6 +56,8 @@ var WaterfoxPathWindows = []string{`\Program Files\Waterfox\waterfox.exe`}
 var ChromiumPathMac = []string{"/Applications/Chromium.app/Contents/MacOS/Chromium"}
 var ChromiumPathLinux = []string{`/usr/bin/chromium`, `/../../mnt/c/Program Files/Chromium/chromium.exe`}
 var ChromiumPathWindows = []string{`\Program Files\Chromium\chromium.exe`}
+
+var VivaldiPathMac = []string{"/Applications/Vivaldi.app/Contents/MacOS/Vivaldi"}
 
 var SafariPathMac = []string{"/Applications/Safari.app/Contents/MacOS/Safari"}
 
@@ -205,6 +208,15 @@ func ChromiumPathDefaults() ([]string, error) {
 		return ChromiumPathMac, nil
 	case "linux":
 		return ChromiumPathLinux, nil
+	default:
+		return nil, errors.New("os not supported")
+	}
+}
+
+func VivaldiPathDefaults() ([]string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return VivaldiPathMac, nil
 	default:
 		return nil, errors.New("os not supported")
 	}

--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -216,6 +216,11 @@ func ChromiumPathDefaults() ([]string, error) {
 }
 
 func VivaldiPathDefaults() ([]string, error) {
+	// check linuxpath for binary install
+	path, err := exec.LookPath("vivaldi")
+	if err == nil {
+		return []string{path}, nil
+	}
 	switch runtime.GOOS {
 	case "windows":
 		return VivaldiPathWindows, nil

--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -58,8 +58,8 @@ var ChromiumPathLinux = []string{`/usr/bin/chromium`, `/../../mnt/c/Program File
 var ChromiumPathWindows = []string{`\Program Files\Chromium\chromium.exe`}
 
 var VivaldiPathMac = []string{"/Applications/Vivaldi.app/Contents/MacOS/Vivaldi"}
-var VivaldiPathLinux = []string{`/usr/bin/vivaldi`, `/../../mnt/c/Program Files/Vivaldi/vivaldi.exe`}
-var VivaldiPathWindows = []string{`\Program Files\Vivaldi\vivaldi.exe`}
+var VivaldiPathLinux = []string{`/usr/bin/vivaldi`, `/../../mnt/c/Program Files/Vivaldi/Application/vivaldi.exe`}
+var VivaldiPathWindows = []string{`\Program Files\Vivaldi\Application\vivaldi.exe`}
 
 var SafariPathMac = []string{"/Applications/Safari.app/Contents/MacOS/Safari"}
 

--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -50,7 +50,7 @@ func HandleManualBrowserSelection() (string, error) {
 	withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 	in := survey.Select{
 		Message: "Select one of the browsers from the list",
-		Options: []string{"Chrome", "Brave", "Edge", "Firefox", "Waterfox", "Chromium", "Safari", "Stdout", "FirefoxStdout", "Firefox Developer Edition", "Firefox Nightly", "Arc", "Custom"},
+		Options: []string{"Chrome", "Brave", "Edge", "Vivaldi", "Firefox", "Waterfox", "Chromium", "Safari", "Stdout", "FirefoxStdout", "Firefox Developer Edition", "Firefox Nightly", "Arc", "Custom"},
 	}
 	var selection string
 	clio.NewLine()
@@ -130,6 +130,9 @@ func GetBrowserKey(b string) string {
 	if strings.Contains(strings.ToLower(b), "chromium") {
 		return ChromiumKey
 	}
+	if strings.Contains(strings.ToLower(b), "vivaldi") {
+		return VivaldiKey
+	}
 	if strings.Contains(strings.ToLower(b), "safari") {
 		return SafariKey
 	}
@@ -160,6 +163,8 @@ func DetectInstallation(browserKey string) (string, bool) {
 		bPath, _ = WaterfoxPathDefaults()
 	case ChromiumKey:
 		bPath, _ = ChromiumPathDefaults()
+	case VivaldiKey:
+		bPath, _ = VivaldiPathDefaults()
 	case SafariKey:
 		bPath, _ = SafariPathDefaults()
 	case ArcKey:

--- a/pkg/granted/console.go
+++ b/pkg/granted/console.go
@@ -89,6 +89,10 @@ var ConsoleCommand = cli.Command{
 				l = launcher.ChromeProfile{
 					ExecutablePath: cfg.CustomBrowserPath,
 				}
+			case browser.VivaldiKey:
+				l = launcher.ChromeProfile{
+					ExecutablePath: cfg.CustomBrowserPath,
+				}
 			case browser.FirefoxKey:
 				l = launcher.Firefox{
 					ExecutablePath: cfg.CustomBrowserPath,

--- a/pkg/launcher/chrome_profile.go
+++ b/pkg/launcher/chrome_profile.go
@@ -51,6 +51,8 @@ var ChromiumPathMac = "Library/Application Support/Chromium/Local State"
 var ChromiumPathLinux = ".config/chromium/Local State"
 var ChromiumPathWindows = `AppData\Local\Chromium\User Data/Local State`
 
+var VivaldiPathMac = "Library/Application Support/Vivaldi/Local State"
+
 // setProfileName attempts to rename an existing Chrome profile from 'Person 2', 'Person 3', etc
 // into the name of the AWS profile that we're launching.
 //
@@ -212,6 +214,9 @@ func getLocalStatePath(browserType string) (stateFile string, err error) {
 
 		case browser.ChromiumKey:
 			stateFile = path.Join(stateFile, ChromiumPathMac)
+
+		case browser.VivaldiKey:
+			stateFile = path.Join(stateFile, VivaldiPathMac)
 		}
 
 	case "linux":

--- a/pkg/launcher/chrome_profile.go
+++ b/pkg/launcher/chrome_profile.go
@@ -52,6 +52,8 @@ var ChromiumPathLinux = ".config/chromium/Local State"
 var ChromiumPathWindows = `AppData\Local\Chromium\User Data/Local State`
 
 var VivaldiPathMac = "Library/Application Support/Vivaldi/Local State"
+var VivaldiPathLinux = ".config/vivaldi/Local State"
+var VivaldiPathWindows = `AppData\Local\Vivaldi\User Data/Local State`
 
 // setProfileName attempts to rename an existing Chrome profile from 'Person 2', 'Person 3', etc
 // into the name of the AWS profile that we're launching.
@@ -199,6 +201,9 @@ func getLocalStatePath(browserType string) (stateFile string, err error) {
 
 		case browser.ChromiumKey:
 			stateFile = path.Join(stateFile, ChromiumPathWindows)
+
+		case browser.VivaldiKey:
+			stateFile = path.Join(stateFile, VivaldiPathWindows)
 		}
 
 	case "darwin":
@@ -232,6 +237,9 @@ func getLocalStatePath(browserType string) (stateFile string, err error) {
 
 		case browser.ChromiumKey:
 			stateFile = path.Join(stateFile, ChromiumPathLinux)
+
+		case browser.VivaldiKey:
+			stateFile = path.Join(stateFile, VivaldiPathLinux)
 		}
 
 	default:

--- a/scripts/assume
+++ b/scripts/assume
@@ -11,7 +11,7 @@ _this_type=$(type -- "${0##*/}" 2>&1)
 # In the case of zsh, the output will contain the word 'alias'.
 # shellcheck disable=SC3028
 if [ "${_this_type#*not found}" != "$_this_type" ] ||
-    [ "${_this_type#*alias}" != "$_this_type" ] || 
+    [ "${_this_type#*alias}" != "$_this_type" ] ||
     [ "${BASH_SOURCE:-$0}" != "${0}" ]; then
   GRANTED_RETURN_STATUS="true"
   export GRANTED_ALIAS_CONFIGURED="true"
@@ -148,7 +148,7 @@ fi
 if [ "$GRANTED_FLAG" = "GrantedExec" ]; then
   # Set GRANTED_12 with a command to execute, for example, "bash -c 'some_command'"
   # Make sure to properly escape quotes if needed and pass arguments.
-  
+
   # Set and export the AWS variables only for the duration of the 'sh -c' command
   AWS_ACCESS_KEY_ID="${GRANTED_1:-}" \
   AWS_SECRET_ACCESS_KEY="${GRANTED_2:-}" \
@@ -156,7 +156,7 @@ if [ "$GRANTED_FLAG" = "GrantedExec" ]; then
   AWS_REGION="${GRANTED_5:-}" \
   AWS_DEFAULT_REGION="${GRANTED_5:-}" \
   sh -c "$GRANTED_12"
-  
+
   # The variables will not affect the parent shell environment after the 'sh -c' command completes
 fi
 # The GrantedOutput flag should be followed by a newline, then the output.


### PR DESCRIPTION
### What changed?

Added support for Vivaldi browser

### Why?

Allows users to more easily select the browser.

### How did you test it?

1. `go build -ldflags='-w -s -X github.com/common-fate/granted/internal/build.ConfigFolderName=.granted' ./cmd/granted`
2. `granted browser set`
3. `assume <profile> -c`

Tested on MacOS and Linux. Windows path was inferred from [forum posts](https://forum.vivaldi.net/search?term=vivaldi.exe&in=titlesposts).

### Potential risks

None

### Is patch release candidate?

Yes, no breaking changes

### Link to relevant docs PRs