### PR TITLE
Re authenticate with common fate during registry sync if token is expired

### DIFF
--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -57,6 +57,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "wait", Usage: "When using Granted with Common Fate the assume will halt while waiting for the access request to be approved."},
 		&cli.BoolFlag{Name: "no-cache", Usage: "Disables caching of session credentials and forces a refresh", EnvVars: []string{"GRANTED_NO_CACHE"}},
 		&cli.StringSliceFlag{Name: "browser-launch-template-arg", Usage: "Additional arguments to provide to the browser launch template command in key=value format, e.g. '--browser-launch-template-arg foo=bar"},
+		&cli.BoolFlag{Name: "skip-profile-registry-sync", Usage: "You can use this to skip the automated profile registry sync process."},
 	}
 }
 
@@ -140,8 +141,13 @@ func GetCliApp() *cli.App {
 				// terminates the command with os.exit(0)
 				browser.GrantedIntroduction()
 			}
-			// Sync granted profile registries if enabled
-			autosync.Run(c.Context, true)
+
+			if !c.Bool("skip-profile-registry-sync") {
+				// Sync granted profile registries if enabled
+				autosync.Run(c.Context, true)
+			} else {
+				clio.Debug("skipping profile registry sync because --skip-profile-registry-sync flag was true")
+			}
 
 			// Setup the shell alias
 			if os.Getenv("FORCE_NO_ALIAS") != "true" {

--- a/pkg/granted/registry/add.go
+++ b/pkg/granted/registry/add.go
@@ -98,7 +98,7 @@ var AddCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-			src, err := registry.AWSProfiles(ctx)
+			src, err := registry.AWSProfiles(ctx, true)
 			if err != nil {
 				return err
 			}
@@ -174,7 +174,7 @@ var AddCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-			src, err := registry.AWSProfiles(ctx)
+			src, err := registry.AWSProfiles(ctx, true)
 			if err != nil {
 				return err
 			}

--- a/pkg/granted/registry/cfregistry/cfregistry.go
+++ b/pkg/granted/registry/cfregistry/cfregistry.go
@@ -49,7 +49,7 @@ func (r *Registry) getClient(interactive bool) (awsv1alpha1connect.ProfileRegist
 		// the OAuth2.0 token is expired so we should prompt the user to log in
 		if needsToRefreshLogin(err) {
 			if interactive {
-				clio.Infof("You need to log in to Common Fate to sync your profile registry")
+				clio.Infof("You need to log into Common Fate to sync your profile registry")
 				lf := loginflow.NewFromConfig(cfg)
 				err = lf.Login(context.Background())
 				if err != nil {
@@ -57,7 +57,7 @@ func (r *Registry) getClient(interactive bool) (awsv1alpha1connect.ProfileRegist
 				}
 			} else {
 				// in non interactive mode, just return a wrapped error
-				return nil, fmt.Errorf("you need to log in to Common Fate to sync your profile registry using `granted auth login`: %w", err)
+				return nil, fmt.Errorf("you need to log into Common Fate to sync your profile registry using `granted auth login`: %w", err)
 			}
 
 		} else {

--- a/pkg/granted/registry/gitregistry/gitregistry.go
+++ b/pkg/granted/registry/gitregistry/gitregistry.go
@@ -40,7 +40,7 @@ func New(opts Opts) (*Registry, error) {
 	return &p, nil
 }
 
-func (r Registry) AWSProfiles(ctx context.Context) (*ini.File, error) {
+func (r Registry) AWSProfiles(ctx context.Context, interactive bool) (*ini.File, error) {
 	err := r.pull()
 	if err != nil {
 		return nil, err

--- a/pkg/granted/registry/registry.go
+++ b/pkg/granted/registry/registry.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Registry interface {
-	AWSProfiles(ctx context.Context) (*ini.File, error)
+	AWSProfiles(ctx context.Context, interactive bool) (*ini.File, error)
 }
 
 type loadedRegistry struct {

--- a/pkg/granted/registry/sync.go
+++ b/pkg/granted/registry/sync.go
@@ -58,7 +58,7 @@ func SyncProfileRegistries(ctx context.Context, interactive bool) error {
 	m := awsmerge.Merger{}
 
 	for _, r := range registries {
-		src, err := r.Registry.AWSProfiles(ctx)
+		src, err := r.Registry.AWSProfiles(ctx, interactive)
 		if err != nil {
 			return fmt.Errorf("error retrieving AWS profiles for registry %s: %w", r.Config.Name, err)
 		}


### PR DESCRIPTION
### What changed?
Granted will now automatically start a login flow to Common Fate when syncing profile registries and the token is invalid.
Auto login will only happen in interactive mode, such as in the assume command, in credential process, an error message is displayed instead.

This PR also introduces a new flag `skip-profile-registry-sync` to skip the registry sync step in assume if desired.

### Why?
The existing behaviour is that if a token was expired or invalid, Granted would log a warning like `oauth2: "invalid_grant"` with no instructions on how to refresh the token or otherwise fix the issue.

Sometimes especially in development the registry sync can be problematic, the option to skip it sometimes is helpful.

### How did you test it?
I tested this by simulating a token error and testing using `granted registry sync` that it now prompts to login.

### Potential risks
Low risk

### Is patch release candidate?
yes

### Link to relevant docs PRs