### PR TITLE
Service flag support for AWS Organizations

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -45,8 +45,6 @@ var ServiceMap = map[string]string{
 	"l":              "lambda",
 	"lambda":         "lambda",
 	"mwaa":           "mwaa",
-	"orgs":           "organizations/v2",
-	"organizations":  "organizations/v2",
 	"param":          "systems-manager/parameters",
 	"r53":            "route53/v2",
 	"ram":            "ram",

--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -45,6 +45,8 @@ var ServiceMap = map[string]string{
 	"l":              "lambda",
 	"lambda":         "lambda",
 	"mwaa":           "mwaa",
+	"orgs":           "organizations/v2",
+	"organizations":  "organizations/v2",
 	"param":          "systems-manager/parameters",
 	"r53":            "route53/v2",
 	"ram":            "ram",


### PR DESCRIPTION
### What changed?

Added service flag support for AWS Organizations. Figured full name and shorthand should work best here. Could add "org" as well but the service name is in plural.

### Why?

It was missing.

### How did you test it?

Built the CLI locally using the make and tested using:

`dassume -c <my-profile> -s organizations`
`dassume -c <my-profile> -s orgs`

My browser, Chrome, opened at the expected location.

### Potential risks

None that I can think of.

### Is patch release candidate?

No idea.

### Link to relevant docs PRs