### PR TITLE
use sso role name from grant output for eks and rds access

### DIFF
--- a/pkg/granted/eks/eks.go
+++ b/pkg/granted/eks/eks.go
@@ -91,7 +91,7 @@ var proxyCommand = cli.Command{
 			err = proxy.WaitForSSMConnectionToProxyServer(ctx, proxy.WaitForSSMConnectionToProxyServerOpts{
 				AWSConfig: proxy.AWSConfig{
 					SSOAccountID:     ensuredAccess.GrantOutput.EksCluster.AccountId,
-					SSORoleName:      ensuredAccess.Grant.Id,
+					SSORoleName:      ensuredAccess.GrantOutput.SsoRoleName,
 					SSORegion:        ensuredAccess.GrantOutput.SsoRegion,
 					SSOStartURL:      ensuredAccess.GrantOutput.SsoStartUrl,
 					Region:           ensuredAccess.GrantOutput.EksCluster.Region,

--- a/pkg/granted/rds/rds.go
+++ b/pkg/granted/rds/rds.go
@@ -92,7 +92,7 @@ var proxyCommand = cli.Command{
 			err = proxy.WaitForSSMConnectionToProxyServer(ctx, proxy.WaitForSSMConnectionToProxyServerOpts{
 				AWSConfig: proxy.AWSConfig{
 					SSOAccountID:     ensuredAccess.GrantOutput.RdsDatabase.AccountId,
-					SSORoleName:      ensuredAccess.Grant.Id,
+					SSORoleName:      ensuredAccess.GrantOutput.SsoRoleName,
 					SSORegion:        ensuredAccess.GrantOutput.SsoRegion,
 					SSOStartURL:      ensuredAccess.GrantOutput.SsoStartUrl,
 					Region:           ensuredAccess.GrantOutput.RdsDatabase.Region,


### PR DESCRIPTION
### What changed?
Use the sso role name from the grant output instead of the grant ID directly

### Why?
To support some upcoming changes and make the role names more readable

### How did you test it?
tested against production Common Fate deployment

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs