### PR TITLE
Add gimme-aws-creds assumer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/invopop/yaml v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
 github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=

--- a/pkg/cfaws/assumer_aws_gimme_aws_creds.go
+++ b/pkg/cfaws/assumer_aws_gimme_aws_creds.go
@@ -1,0 +1,178 @@
+package cfaws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/common-fate/clio"
+	"github.com/common-fate/granted/pkg/securestorage"
+	"github.com/fatih/color"
+	"gopkg.in/ini.v1"
+)
+
+// https://github.com/common-fate/granted
+
+type AwsGimmeAwsCredsAssumer struct {
+}
+
+const GRANTED_OKTA_INI_ENABLE = "granted_okta"
+const GRANTED_OKTA_INI_OPEN_BROWSER = "granted_okta_open_browser"
+
+type AwsGimmeResult struct {
+	Credentials AwsGimmeCredentials `json:"credentials"`
+}
+
+type AwsGimmeCredentials struct {
+	AccessKeyID     string `json:"aws_access_key_id"`
+	SecretAccessKey string `json:"aws_secret_access_key"`
+	SessionToken    string `json:"aws_session_token"`
+	Expiration      string `json:"expiration"`
+}
+
+type CredentialCapture struct {
+	result *AwsGimmeResult
+}
+
+func (cc *CredentialCapture) Write(p []byte) (n int, err error) {
+	var dest AwsGimmeResult
+	err = json.Unmarshal(p, &dest)
+	if err != nil {
+		return fmt.Fprint(color.Error, string(p))
+	}
+	cc.result = &dest
+	return len(p), nil
+}
+
+func (cc *CredentialCapture) Creds() (aws.Credentials, error) {
+	if cc.result == nil {
+		return aws.Credentials{}, fmt.Errorf("no credential output from gimme-aws-creds")
+	}
+	c := aws.Credentials{
+		AccessKeyID:     cc.result.Credentials.AccessKeyID,
+		SecretAccessKey: cc.result.Credentials.SecretAccessKey,
+		SessionToken:    cc.result.Credentials.SessionToken,
+		Source:          "gimme-aws-creds",
+	}
+	if cc.result.Credentials.Expiration != "" {
+		c.CanExpire = true
+		t, err := time.Parse(time.RFC3339, cc.result.Credentials.Expiration)
+		if err != nil {
+			return aws.Credentials{}, fmt.Errorf("could not parse credentials expiry: %s", cc.result.Credentials.Expiration)
+		}
+		c.Expires = t
+	}
+	return c, nil
+}
+
+func (gimme *AwsGimmeAwsCredsAssumer) AssumeTerminal(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
+	// try cache
+	sessionCredStorage := securestorage.NewSecureSessionCredentialStorage()
+	creds, err := sessionCredStorage.GetCredentials(c.AWSConfig.Profile)
+
+	if err != nil {
+		clio.Debugw("error loading cached credentials", "error", err)
+	} else if creds != nil && !creds.Expired() {
+		clio.Debugw("credentials found in cache", "expires", creds.Expires.String(), "canExpire", creds.CanExpire, "timeNow", time.Now().String())
+		return *creds, nil
+	}
+
+	// if cred process fail
+	if configOpts.UsingCredentialProcess {
+		return aws.Credentials{}, fmt.Errorf("Cannot refresh Gimme AWS creds in credential_process")
+	}
+
+	clio.Debugw("refreshing credentials", "reason", "none cached")
+
+	// request for the creds if they are invalid
+	args := []string{
+		fmt.Sprintf("--profile=%s", c.Name),
+		"--output-format=json",
+	}
+
+	if c.RawConfig.HasKey(GRANTED_OKTA_INI_OPEN_BROWSER) {
+		ob, err := c.RawConfig.GetKey(GRANTED_OKTA_INI_OPEN_BROWSER)
+		if err != nil {
+			clio.Debugf("Error reading ini key %s: %w", GRANTED_OKTA_INI_OPEN_BROWSER, err)
+		}
+
+		if ob.MustBool(false) == true || ob.String() == "true" {
+			args = append(args, "--open-browser")
+		}
+	}
+
+	// add passthrough args
+	args = append(args, configOpts.Args...)
+
+	cmd := exec.Command("gimme-aws-creds", args...)
+
+	capture := &CredentialCapture{}
+	cmd.Stdout = capture
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	cleanEnv := []string{}
+	var disallowedVar bool
+	for _, env := range os.Environ() {
+		disallowedVar = false
+		for _, disallowed := range []string{
+			"AWS_PROFILE",
+			"AWS_ACCESS_KEY_ID",
+			"AWS_SECRET_ACCESS_KEY",
+			"AWS_SESSION_TOKEN",
+			"AWS_REGION",
+			"AWS_DEFAULT_REGION",
+		} {
+			if strings.HasPrefix(env, disallowed) {
+				clio.Debugw("removing from exec env", "var", env)
+				disallowedVar = true
+				break
+			}
+		}
+		if !disallowedVar {
+			cleanEnv = append(cleanEnv, env)
+		}
+	}
+	cmd.Env = cleanEnv
+
+	err = cmd.Run()
+	if err != nil {
+		return aws.Credentials{}, err
+	}
+
+	awscreds, err := capture.Creds()
+	if err != nil {
+		return aws.Credentials{}, err
+	}
+
+	// store cached creds
+	if err := sessionCredStorage.StoreCredentials(c.AWSConfig.Profile, awscreds); err != nil {
+		clio.Warnf("Error caching credentials, MFA token will be requested")
+	}
+
+	return awscreds, nil
+}
+
+func (gimme *AwsGimmeAwsCredsAssumer) AssumeConsole(ctx context.Context, c *Profile, configOpts ConfigOpts) (aws.Credentials, error) {
+	return gimme.AssumeTerminal(ctx, c, configOpts)
+}
+
+func (gimme *AwsGimmeAwsCredsAssumer) Type() string {
+	return "AWS_GIMME_AWS_CREDS"
+}
+
+// inspect for any items on the profile prefixed with "granted_okta"
+func (gimme *AwsGimmeAwsCredsAssumer) ProfileMatchesType(rawProfile *ini.Section, parsedProfile config.SharedConfig) bool {
+	for _, k := range rawProfile.KeyStrings() {
+		if strings.HasPrefix(k, GRANTED_OKTA_INI_ENABLE) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cfaws/assumer_aws_gimme_aws_creds.go
+++ b/pkg/cfaws/assumer_aws_gimme_aws_creds.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 	"time"
 
@@ -197,7 +198,6 @@ func (gimme *AwsGimmeAwsCredsAssumer) ProfileMatchesType(rawProfile *ini.Section
 		}
 	}
 
-	//clio.Debug("No gimme profile matched")
 	return false
 }
 
@@ -222,7 +222,7 @@ func (gimme *AwsGimmeAwsCredsAssumer) LoadGimmeConfig() error {
 		if err != nil {
 			clio.Error(err)
 		}
-		okta_config = fmt.Sprintf("%s/.okta_aws_login_config", home)
+		okta_config = path.Join(home, ".okta_aws_login_config")
 	}
 
 	_, err := os.Stat(okta_config)

--- a/pkg/cfaws/assumer_aws_gimme_aws_creds.go
+++ b/pkg/cfaws/assumer_aws_gimme_aws_creds.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/common-fate/clio"
 	"github.com/common-fate/granted/pkg/securestorage"
-	"github.com/fatih/color"
 	"github.com/hashicorp/go-version"
 	"gopkg.in/ini.v1"
 )
@@ -46,7 +45,7 @@ func (cc *CredentialCapture) Write(p []byte) (n int, err error) {
 	var dest AwsGimmeResult
 	err = json.Unmarshal(p, &dest)
 	if err != nil {
-		return fmt.Fprint(color.Error, string(p))
+		return 0, fmt.Errorf("Error unmarshalling gimme-aws-creds output")
 	}
 	cc.result = &dest
 	return len(p), nil

--- a/pkg/cfaws/assumer_aws_gimme_aws_creds.go
+++ b/pkg/cfaws/assumer_aws_gimme_aws_creds.go
@@ -87,6 +87,9 @@ func (gimme *AwsGimmeAwsCredsAssumer) AssumeTerminal(ctx context.Context, c *Pro
 
 	// if cred process, check we can do a non-interactive refresh
 	if configOpts.UsingCredentialProcess {
+		if !configOpts.CredentialProcessAutoLogin {
+			return aws.Credentials{}, fmt.Errorf("Failed to auto-refresh aws-gimme-creds, since auto-login is disabled")
+		}
 		err := gimme.LoadGimmeConfig()
 		if err != nil {
 			return aws.Credentials{}, fmt.Errorf("Failed to load gimme config file: %w", err)

--- a/pkg/cfaws/assumers.go
+++ b/pkg/cfaws/assumers.go
@@ -46,7 +46,7 @@ type Assumer interface {
 // List of assumers should be ordered by how they match type
 // specific types should be first, generic types like IAM should be last / the (default)
 // for sso profiles, the internal implementation takes precedence over credential processes
-var assumers []Assumer = []Assumer{&AwsGoogleAuthAssumer{}, &AwsAzureLoginAssumer{}, &AwsSsoAssumer{}, &CredentialProcessAssumer{}, &AwsIamAssumer{}}
+var assumers []Assumer = []Assumer{&AwsGimmeAwsCredsAssumer{}, &AwsGoogleAuthAssumer{}, &AwsAzureLoginAssumer{}, &AwsSsoAssumer{}, &CredentialProcessAssumer{}, &AwsIamAssumer{}}
 
 // RegisterAssumer allows assumers to be registered when using this library as a package in other projects
 // position = -1 will append the assumer


### PR DESCRIPTION
### What changed?

Add support for the [gimme-aws-creds](https://github.com/Nike-Inc/gimme-aws-creds) helper as an assumer, which supports AWS accounts integrated with Okta directly via SAML. The program supports multiple versions of Okta, MFA configurations etc. so we don't have to reimplement any of that logic.

On top of the basic support, it has the following features:
- caches obtained temporary credentials via the secure storage mechanism
- parses the gimme-aws-creds config file, so we can use other credential providers for non-matching profiles
- limited support for headless credential_process based refresh. It depends on an opt in from the user (using either the --auto-login flag or config file setting), and a compatible version of the tool and Okta flow. It's opt-in because the user can't verify the device code, since it's hidden by the calling program.

### Why?

Allows us to get credentials via Okta/SAML, which wasn't previously supported.

### How did you test it?

granted compiled with `go build -ldflags='-w -s -X github.com/common-fate/granted/internal/build.ConfigFolderName=.granted' ./cmd/granted`

Tested over the last few months on multiple AWS accounts/orgs, including a mixed config with Identity Centre and other credential providers.

### Potential risks

None

### Is patch release candidate?

Yes, no breaking changes

### Link to relevant docs PRs