### PR TITLE
Added ability to specify multiple services top be opened with the --console flag

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -415,7 +415,7 @@ func AssumeCommand(c *cli.Context) error {
 			return err
 		}
 
-		clio.Debugf(`number of console urls created`, "amount", len(consoleURLs))
+		clio.Debugf("number of console urls created", "amount", len(consoleURLs))
 		for _, consoleURL := range consoleURLs {
 
 			if cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.WaterfoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey || cfg.DefaultBrowser == browser.FirefoxDevEditionKey || cfg.DefaultBrowser == browser.FirefoxNightlyKey {

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -320,7 +320,7 @@ func AssumeCommand(c *cli.Context) error {
 
 	// if getConsoleURL is true, we'll use the AWS federated login to retrieve a URL to access the console.
 	// depending on how Granted is configured, this is then printed to the terminal or a browser is launched at the URL automatically.
-	getConsoleURL := !assumeFlags.Bool("env") && ((assumeFlags.Bool("console") || assumeFlags.String("console-destination") != "") || assumeFlags.Bool("active-role") || assumeFlags.String("service") != "" || assumeFlags.Bool("url") || assumeFlags.String("browser-profile") != "")
+	getConsoleURL := !assumeFlags.Bool("env") && ((assumeFlags.Bool("console") || assumeFlags.String("console-destination") != "") || assumeFlags.Bool("active-role") || assumeFlags.StringSlice("service") != nil || assumeFlags.Bool("url") || assumeFlags.String("browser-profile") != "")
 
 	// this makes it easy for users to copy the actual command and avoid needing to lookup profiles
 	if !cfg.DisableUsageTips && showRerunCommand {

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -31,7 +31,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "export-sso-token", Aliases: []string{"es"}, Usage: "Export sso token to ~/.aws/sso/cache"},
 		&cli.BoolFlag{Name: "unset", Aliases: []string{"un"}, Usage: "Unset all environment variables configured by Assume"},
 		&cli.BoolFlag{Name: "url", Aliases: []string{"u"}, Usage: "Get an active console session url"},
-		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Like --c, but opens to a specified service"},
+		&cli.StringSliceFlag{Name: "service", Aliases: []string{"s"}, Usage: "Like --c, but opens to a specified service"},
 		&cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "region to launch the console or export to the terminal"},
 		&cli.StringFlag{Name: "console-destination", Aliases: []string{"cd"}, Usage: "Open a web console at this destination"},
 		&cli.StringSliceFlag{Name: "pass-through", Aliases: []string{"pt"}, Usage: "Pass args to proxy assumer"},

--- a/pkg/console/aws.go
+++ b/pkg/console/aws.go
@@ -32,6 +32,7 @@ func (a AWS) URLs(creds aws.Credentials) ([]string, error) {
 
 	urls := []string{}
 
+	//if region and service were not specified create a single default url and return
 	if a.Region == "" && a.Service == nil {
 		url, err := a.URL(creds, "", "")
 		if err != nil {
@@ -41,13 +42,10 @@ func (a AWS) URLs(creds aws.Credentials) ([]string, error) {
 		return urls, nil
 	}
 
+	//if one or more services were specified in the assume command then create multiple urls to be opened up in the browser
 	if len(a.Service) > 0 {
-		var region string
-		if len(a.Region) > 0 {
-			region = a.Region
-		}
 		for _, service := range a.Service {
-			url, err := a.URL(creds, region, service)
+			url, err := a.URL(creds, a.Region, service)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/console/aws.go
+++ b/pkg/console/aws.go
@@ -33,7 +33,7 @@ func (a AWS) URLs(creds aws.Credentials) ([]string, error) {
 	urls := []string{}
 
 	//if region and service were not specified create a single default url and return
-	if a.Region == "" && a.Service == nil {
+	if a.Region == "" && len(a.Service) == 0 {
 		url, err := a.URL(creds, "", "")
 		if err != nil {
 			return nil, err

--- a/pkg/console/aws.go
+++ b/pkg/console/aws.go
@@ -13,7 +13,7 @@ import (
 type AWS struct {
 	Profile     string
 	Region      string
-	Service     string
+	Service     []string
 	Destination string
 }
 
@@ -28,11 +28,41 @@ type awsSession struct {
 	SessionToken string `json:"sessionToken"`
 }
 
+func (a AWS) URLs(creds aws.Credentials) ([]string, error) {
+
+	urls := []string{}
+
+	if a.Region == "" && a.Service == nil {
+		url, err := a.URL(creds, "", "")
+		if err != nil {
+			return nil, err
+		}
+		urls = append(urls, url)
+		return urls, nil
+	}
+
+	if len(a.Service) > 0 {
+		var region string
+		if len(a.Region) > 0 {
+			region = a.Region
+		}
+		for _, service := range a.Service {
+			url, err := a.URL(creds, region, service)
+			if err != nil {
+				return nil, err
+			}
+			urls = append(urls, url)
+		}
+	}
+
+	return urls, nil
+}
+
 // URL retrieves an authorised access URL for the AWS console. The URL includes a security token which is retrieved
 // by exchanging AWS session credentials using the AWS federation endpoint.
 //
 // see: https://docs.aws.amazon.com/IAM/latest/UserGuide/example_sts_Scenario_ConstructFederatedUrl_section.html
-func (a AWS) URL(creds aws.Credentials) (string, error) {
+func (a AWS) URL(creds aws.Credentials, region string, service string) (string, error) {
 	sess := awsSession{
 		SessionID:    creds.AccessKeyID,
 		SessionKey:   creds.SecretAccessKey,
@@ -43,12 +73,12 @@ func (a AWS) URL(creds aws.Credentials) (string, error) {
 		return "", err
 	}
 
-	partition := GetPartitionFromRegion(a.Region)
+	partition := GetPartitionFromRegion(region)
 	clio.Debugf("Partition is detected as %s for region %s...\n", partition, a.Region)
 
 	u := url.URL{
 		Scheme: "https",
-		Host:   partition.RegionalHostString(a.Region),
+		Host:   partition.RegionalHostString(region),
 		Path:   "/federation",
 	}
 	q := u.Query()
@@ -75,11 +105,11 @@ func (a AWS) URL(creds aws.Credentials) (string, error) {
 
 	u = url.URL{
 		Scheme: "https",
-		Host:   partition.RegionalHostString(a.Region),
+		Host:   partition.RegionalHostString(region),
 		Path:   "/federation",
 	}
 
-	dest, err := makeDestinationURL(a.Service, a.Region, a.Destination)
+	dest, err := makeDestinationURL(service, region, a.Destination)
 
 	if err != nil {
 		return "", err

--- a/pkg/granted/console.go
+++ b/pkg/granted/console.go
@@ -40,103 +40,107 @@ var ConsoleCommand = cli.Command{
 			return err
 		}
 		con := console.AWS{
-			Service:     c.String("service"),
+			Service:     []string{c.String("service")},
 			Region:      c.String("region"),
 			Destination: c.String("destination"),
 		}
 
-		consoleURL, err := con.URL(*credentials)
+		consoleURLs, err := con.URLs(*credentials)
 		if err != nil {
 			return err
 		}
 
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-		if c.Bool("firefox") || cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey {
-			// transform the URL into the Firefox Tab Container format.
-			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", c.String("container-name"), url.QueryEscape(consoleURL), c.String("color"), c.String("icon"))
-		}
+		for _, consoleURL := range consoleURLs {
 
-		justPrintURL := c.Bool("url") || cfg.DefaultBrowser == browser.StdoutKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey
-		if justPrintURL {
-			// return the url via stdout through the CLI wrapper script and return early.
-			fmt.Print(consoleURL)
-			return nil
-		}
-
-		var l assume.Launcher
-		if cfg.CustomBrowserPath == "" && cfg.DefaultBrowser != "" {
-			l = launcher.Open{}
-		} else if cfg.CustomBrowserPath == "" && cfg.AWSConsoleBrowserLaunchTemplate == nil {
-			return errors.New("default browser not configured. run `granted browser set` to configure")
-		} else {
-			switch cfg.DefaultBrowser {
-			case browser.ChromeKey:
-				l = launcher.ChromeProfile{
-					ExecutablePath: cfg.CustomBrowserPath,
-				}
-			case browser.BraveKey:
-				l = launcher.ChromeProfile{
-					ExecutablePath: cfg.CustomBrowserPath,
-				}
-			case browser.EdgeKey:
-				l = launcher.ChromeProfile{
-					ExecutablePath: cfg.CustomBrowserPath,
-				}
-			case browser.ChromiumKey:
-				l = launcher.ChromeProfile{
-					ExecutablePath: cfg.CustomBrowserPath,
-				}
-			case browser.VivaldiKey:
-				l = launcher.ChromeProfile{
-					ExecutablePath: cfg.CustomBrowserPath,
-				}
-			case browser.FirefoxKey:
-				l = launcher.Firefox{
-					ExecutablePath: cfg.CustomBrowserPath,
-				}
-			case browser.SafariKey:
-				l = launcher.Safari{}
-			case browser.CustomKey:
-				l, err = launcher.CustomFromLaunchTemplate(cfg.AWSConsoleBrowserLaunchTemplate, c.StringSlice("browser-launch-template-arg"))
-				if err == launcher.ErrLaunchTemplateNotConfigured {
-					return errors.New("error configuring custom browser, ensure that [AWSConsoleBrowserLaunchTemplate] is specified in your Granted config file")
-				}
-				if err != nil {
-					return err
-				}
-			default:
-				l = launcher.Open{}
-			}
-		}
-		// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
-		args, err := l.LaunchCommand(consoleURL, con.Profile)
-		if err != nil {
-			return fmt.Errorf("error building browser launch command: %w", err)
-		}
-
-		var startErr error
-		if l.UseForkProcess() {
-			clio.Debugf("running command using forkprocess: %s", args)
-			cmd, err := forkprocess.New(args...)
+			cfg, err := config.Load()
 			if err != nil {
 				return err
 			}
-			startErr = cmd.Start()
-		} else {
-			clio.Debugf("running command without forkprocess: %s", args)
-			cmd := exec.Command(args[0], args[1:]...)
-			startErr = cmd.Start()
-		}
+			if c.Bool("firefox") || cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey {
+				// transform the URL into the Firefox Tab Container format.
+				consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", c.String("container-name"), url.QueryEscape(consoleURL), c.String("color"), c.String("icon"))
+			}
 
-		if startErr != nil {
-			return clierr.New(fmt.Sprintf("Granted was unable to open a browser session automatically due to the following error: %s", startErr.Error()),
-				// allow them to try open the url manually
-				clierr.Info("You can open the browser session manually using the following url:"),
-				clierr.Info(consoleURL),
-			)
+			justPrintURL := c.Bool("url") || cfg.DefaultBrowser == browser.StdoutKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey
+			if justPrintURL {
+				// return the url via stdout through the CLI wrapper script and return early.
+				fmt.Print(consoleURL)
+				return nil
+			}
+
+			var l assume.Launcher
+			if cfg.CustomBrowserPath == "" && cfg.DefaultBrowser != "" {
+				l = launcher.Open{}
+			} else if cfg.CustomBrowserPath == "" && cfg.AWSConsoleBrowserLaunchTemplate == nil {
+				return errors.New("default browser not configured. run `granted browser set` to configure")
+			} else {
+				switch cfg.DefaultBrowser {
+				case browser.ChromeKey:
+					l = launcher.ChromeProfile{
+						ExecutablePath: cfg.CustomBrowserPath,
+					}
+				case browser.BraveKey:
+					l = launcher.ChromeProfile{
+						ExecutablePath: cfg.CustomBrowserPath,
+					}
+				case browser.EdgeKey:
+					l = launcher.ChromeProfile{
+						ExecutablePath: cfg.CustomBrowserPath,
+					}
+				case browser.ChromiumKey:
+					l = launcher.ChromeProfile{
+						ExecutablePath: cfg.CustomBrowserPath,
+					}
+				case browser.VivaldiKey:
+					l = launcher.ChromeProfile{
+						ExecutablePath: cfg.CustomBrowserPath,
+					}
+				case browser.FirefoxKey:
+					l = launcher.Firefox{
+						ExecutablePath: cfg.CustomBrowserPath,
+					}
+				case browser.SafariKey:
+					l = launcher.Safari{}
+				case browser.CustomKey:
+					l, err = launcher.CustomFromLaunchTemplate(cfg.AWSConsoleBrowserLaunchTemplate, c.StringSlice("browser-launch-template-arg"))
+					if err == launcher.ErrLaunchTemplateNotConfigured {
+						return errors.New("error configuring custom browser, ensure that [AWSConsoleBrowserLaunchTemplate] is specified in your Granted config file")
+					}
+					if err != nil {
+						return err
+					}
+				default:
+					l = launcher.Open{}
+				}
+			}
+			// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
+			args, err := l.LaunchCommand(consoleURL, con.Profile)
+			if err != nil {
+				return fmt.Errorf("error building browser launch command: %w", err)
+			}
+
+			var startErr error
+			if l.UseForkProcess() {
+				clio.Debugf("running command using forkprocess: %s", args)
+				cmd, err := forkprocess.New(args...)
+				if err != nil {
+					return err
+				}
+				startErr = cmd.Start()
+			} else {
+				clio.Debugf("running command without forkprocess: %s", args)
+				cmd := exec.Command(args[0], args[1:]...)
+				startErr = cmd.Start()
+			}
+
+			if startErr != nil {
+				return clierr.New(fmt.Sprintf("Granted was unable to open a browser session automatically due to the following error: %s", startErr.Error()),
+					// allow them to try open the url manually
+					clierr.Info("You can open the browser session manually using the following url:"),
+					clierr.Info(consoleURL),
+				)
+			}
+			return nil
 		}
 		return nil
 	},


### PR DESCRIPTION
### What changed?
Altered the services flag to now be a string slice flag which accepts multiple services (ie `assume -c -s s3 -s rds`) Which will then open up the console with two tabs one for each of the services.

To do this I altered the logic for creating URLs to now create a list of URL's even when just creating one.

It then loops through all urls created and runs the same browser logic previously used.

### Why?
I've been learning vim and have been looking for simple tasks to complete on Granted :D
For #807

### How did you test it?
Manually testing `assume -c` with and without the -s flag for one and multiple services

Running related commands like `assume --url` `assume` `granted console` to confirm no regressions made

### Potential risks
string -> stringSlice flag should have no usage changes but all code paths using .String() need to have been changed to ensure correct logic

Altering logic in the assume command has the potential to create regressions in some of the flags logic.

It might be worth noting here that the `assume.go` file is becoming quite complicated due to small additions over time and could use with a refactor to simplify it down. This would be a big task but could be useful to minimise any regressions being added.

### Is patch release candidate?


### Link to relevant docs PRs