### PR TITLE
Fix golangci-lint CI failure

### DIFF
--- a/pkg/cfaws/assumer_aws_gimme_aws_creds.go
+++ b/pkg/cfaws/assumer_aws_gimme_aws_creds.go
@@ -262,7 +262,7 @@ func (gimme *AwsGimmeAwsCredsAssumer) CanRefreshHeadless(profile string) bool {
 			clio.Warn(err)
 			return false
 		}
-		if key.MustBool(force_classic_default) == true {
+		if key.MustBool(force_classic_default) {
 			return false
 		}
 	}


### PR DESCRIPTION
### What changed?

No functionality change, fix golangci-lint failure.

### Why?


### How did you test it?
`go build -ldflags='-w -s -X github.com/common-fate/granted/internal/build.ConfigFolderName=.granted' ./cmd/granted`

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs