### PR TITLE
FIX: aws config directory permissions.

### DIFF
--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -44,7 +44,7 @@ var SSOCommand = cli.Command{
 
 const (
 	// permission for user to read/write.
-	USER_READ_WRITE_PERM = 0644 
+	USER_READ_WRITE_PERM = 0700
 )
 
 // in dev:


### PR DESCRIPTION
### What changed?

The USER_READ_WRITE_PERM constant in the granted package.

### Why?

The previous 0644 mask did not allowed the user to create files under the ~/.aws directory and allowed other users to read the directory content.

### How did you test it?

Locally built granted and used granted sso populate.

### Potential risks

None, but we may want to check the umask for the ~/.aws/config file and fix permissions thru the codebase.

### Is patch release candidate?
Yes.


### Link to relevant docs PRs

This is related to issue: https://github.com/common-fate/granted/issues/839