### PR TITLE
Fix lint errors

### DIFF
--- a/cmd/granted/main.go
+++ b/cmd/granted/main.go
@@ -29,7 +29,7 @@ func main() {
 		// https://github.com/apppackio/apppack/commit/a711e55238af2402b4b027a73fccc663ec7ba0f4
 		// https://github.com/briandowns/spinner/issues/122
 		if runtime.GOOS != "windows" {
-			fmt.Fprint(os.Stdin, "\033[?25h")
+			_, _ = fmt.Fprint(os.Stdin, "\033[?25h")
 		}
 		os.Exit(130)
 	}()

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -81,7 +81,7 @@ func GetCliApp() *cli.App {
 		BashComplete:         Completion,
 		Before: func(c *cli.Context) error {
 			if c.String("aws-config-file") != "" {
-				os.Setenv("AWS_CONFIG_FILE", c.String("aws-config-file"))
+				_ = os.Setenv("AWS_CONFIG_FILE", c.String("aws-config-file"))
 			}
 			// unsets the exported env vars
 			if c.Bool("unset") {

--- a/pkg/cfaws/assumer_aws_gimme_aws_creds.go
+++ b/pkg/cfaws/assumer_aws_gimme_aws_creds.go
@@ -85,11 +85,11 @@ func (gimme *AwsGimmeAwsCredsAssumer) AssumeTerminal(ctx context.Context, c *Pro
 	// if cred process, check we can do a non-interactive refresh
 	if configOpts.UsingCredentialProcess {
 		if !configOpts.CredentialProcessAutoLogin {
-			return aws.Credentials{}, fmt.Errorf("Failed to auto-refresh gimme-aws-creds, since auto-login is disabled")
+			return aws.Credentials{}, fmt.Errorf("failed to auto-refresh gimme-aws-creds, since auto-login is disabled")
 		}
 		err := gimme.LoadGimmeConfig()
 		if err != nil {
-			return aws.Credentials{}, fmt.Errorf("Failed to load gimme config file: %w", err)
+			return aws.Credentials{}, fmt.Errorf("failed to load gimme config file: %w", err)
 		}
 		if !gimme.CanRefreshHeadless(c.Name) {
 			return aws.Credentials{}, fmt.Errorf("Cannot use gimme-aws-creds in credential_process with force_classic or <2.6.0")

--- a/pkg/cfaws/assumer_aws_gimme_aws_creds.go
+++ b/pkg/cfaws/assumer_aws_gimme_aws_creds.go
@@ -92,7 +92,7 @@ func (gimme *AwsGimmeAwsCredsAssumer) AssumeTerminal(ctx context.Context, c *Pro
 			return aws.Credentials{}, fmt.Errorf("failed to load gimme config file: %w", err)
 		}
 		if !gimme.CanRefreshHeadless(c.Name) {
-			return aws.Credentials{}, fmt.Errorf("Cannot use gimme-aws-creds in credential_process with force_classic or <2.6.0")
+			return aws.Credentials{}, fmt.Errorf("cannot use gimme-aws-creds in credential_process with force_classic or <2.6.0")
 		}
 		gimme.forceOpenBrowser = true
 	}
@@ -196,7 +196,7 @@ func (gimme *AwsGimmeAwsCredsAssumer) ProfileMatchesType(rawProfile *ini.Section
 func (gimme *AwsGimmeAwsCredsAssumer) Version() (*version.Version, error) {
 	cmd, err := exec.Command("gimme-aws-creds", "--version").Output()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get gimme-aws-creds version %w", err)
+		return nil, fmt.Errorf("failed to get gimme-aws-creds version %w", err)
 	}
 
 	ver, err := version.NewVersion(strings.TrimSpace(strings.TrimPrefix(string(cmd), "gimme-aws-creds")))

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -473,7 +473,7 @@ func (p *Profile) init(ctx context.Context, profiles *Profiles, depth int) error
 					p.ProfileType = sourceProfile.ProfileType
 					p.Parents = append(sourceProfile.Parents, sourceProfile)
 				} else {
-					p.LoadingError = fmt.Errorf("failed to load a source-profile for profile: %s . You should fix the issue with the source profile before you can assume this profile.", p.Name)
+					p.LoadingError = fmt.Errorf("failed to load a source-profile for profile: %s . You should fix the issue with the source profile before you can assume this profile", p.Name)
 					return p.LoadingError
 				}
 			}

--- a/pkg/cfaws/region.go
+++ b/pkg/cfaws/region.go
@@ -33,10 +33,11 @@ func ExpandRegion(region string) (string, error) {
 	switch region[0] {
 	case 'u':
 		major = "us"
-		if region[1] == 'g' {
+		switch region[1] {
+		case 'g':
 			major = "us-gov"
 			idx += 1
-		} else if region[1] == 's' {
+		case 's':
 			// This will break if us-southeast-1 is ever created
 			idx += 1
 		}
@@ -47,18 +48,20 @@ func ExpandRegion(region string) (string, error) {
 		}
 	case 'a':
 		major = "ap"
-		if region[1] == 'f' {
+		switch region[1] {
+		case 'f':
 			major = "af"
 			idx += 1
-		} else if region[1] == 'p' {
+		case 'p':
 			idx += 1
 		}
 	case 'c':
 		major = "ca"
-		if region[1] == 'n' {
+		switch region[1] {
+		case 'n':
 			major = "cn"
 			idx += 1
-		} else if region[1] == 'a' {
+		case 'a':
 			idx += 1
 		}
 	case 'm':

--- a/pkg/cfaws/region.go
+++ b/pkg/cfaws/region.go
@@ -89,11 +89,11 @@ func ExpandRegion(region string) (string, error) {
 			minor = "south"
 		}
 		if len(region) > 1 {
-			if region[1] == 'w' {
+			switch region[1] {
+			case 'w':
 				minor += "west"
 				idx += 1
-
-			} else if region[1] == 'e' {
+			case 'e':
 				minor += "east"
 				idx += 1
 			}

--- a/pkg/cfaws/ssotoken.go
+++ b/pkg/cfaws/ssotoken.go
@@ -126,7 +126,7 @@ func SsoCredsAreInConfigCache() bool {
 	}
 
 	// close the folder
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return true
 }
 
@@ -157,7 +157,7 @@ func ReadPlaintextSsoCreds(startUrl string) (SSOPlainTextOut, error) {
 		return SSOPlainTextOut{}, err
 	}
 	// close the folder
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	for _, file := range files {
 		// check if the file is a json file
 		if filepath.Ext(file.Name()) == ".json" {
@@ -175,7 +175,7 @@ func ReadPlaintextSsoCreds(startUrl string) (SSOPlainTextOut, error) {
 			// if file doesn't start with botocore
 			if !strings.HasPrefix(file.Name(), "botocore") {
 				// close the file
-				defer f.Close()
+				defer func() { _ = f.Close() }()
 				// unmarshal the json
 				var sso SSOPlainTextOut
 				err = json.Unmarshal(data, &sso)

--- a/pkg/chromemsg/write_manifest.go
+++ b/pkg/chromemsg/write_manifest.go
@@ -49,7 +49,7 @@ func writeManifest(manifestPath string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	encoder := json.NewEncoder(file)
 	return encoder.Encode(manifest)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -279,7 +279,7 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	c := NewDefaultConfig()
 
@@ -301,6 +301,6 @@ func (c *Config) Save() error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	return toml.NewEncoder(file).Encode(c)
 }

--- a/pkg/forkprocess/forkprocess.go
+++ b/pkg/forkprocess/forkprocess.go
@@ -67,8 +67,8 @@ func (p *Process) Start() error {
 	if err != nil {
 		return errors.Wrap(err, "getting read and write files")
 	}
-	defer rpipe.Close()
-	defer wpipe.Close()
+	defer func() { _ = rpipe.Close() }()
+	defer func() { _ = wpipe.Close() }()
 
 	attr := os.ProcAttr{
 		Dir: p.Workdir,

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -81,7 +81,7 @@ func Load(fecencyStoreKey string) (*FrecencyStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	err = json.NewDecoder(file).Decode(&c)
 	if err != nil {

--- a/pkg/frecency/frecency.go
+++ b/pkg/frecency/frecency.go
@@ -190,6 +190,6 @@ func (store *FrecencyStore) save() error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	return json.NewEncoder(file).Encode(store)
 }

--- a/pkg/granted/cache.go
+++ b/pkg/granted/cache.go
@@ -30,7 +30,7 @@ var listCommand = cli.Command{
 
 		tw := tabwriter.NewWriter(os.Stderr, 10, 1, 5, ' ', 0)
 		headers := strings.Join([]string{"STORAGE TYPE", "KEY"}, "\t")
-		fmt.Fprintln(tw, headers)
+		_, _ = fmt.Fprintln(tw, headers)
 
 		for storageName, v := range storageToNameMap {
 
@@ -41,12 +41,12 @@ var listCommand = cli.Command{
 
 			for _, key := range keys {
 				tabbed := strings.Join([]string{storageName, key}, "\t")
-				fmt.Fprintln(tw, tabbed)
+				_, _ = fmt.Fprintln(tw, tabbed)
 			}
 
 		}
 
-		tw.Flush()
+		_ = tw.Flush()
 
 		return nil
 	},

--- a/pkg/granted/chrome_extension.go
+++ b/pkg/granted/chrome_extension.go
@@ -26,7 +26,7 @@ func HandleChromeExtensionCall(c *cli.Context) error {
 	}
 
 	if u.Host != build.ChromeExtensionID {
-		return fmt.Errorf("Chrome Extension ID %q did not match allowed ID %q", u.Host, build.ChromeExtensionID)
+		return fmt.Errorf("chrome Extension ID %q did not match allowed ID %q", u.Host, build.ChromeExtensionID)
 	}
 
 	// If we get here, the Granted CLI has been invoked from our browser extension.

--- a/pkg/granted/credential_process.go
+++ b/pkg/granted/credential_process.go
@@ -57,7 +57,7 @@ var CredentialProcess = cli.Command{
 		clio.Debugw("running credential process with config", "profile", profileName, "url", c.String("url"), "window", c.Duration("window"), "disableCredentialProcessCache", cfg.DisableCredentialProcessCache)
 
 		cliNoCache := c.Bool("no-cache")
-		useCache := !(cfg.DisableCredentialProcessCache || cliNoCache)
+		useCache := !cfg.DisableCredentialProcessCache && !cliNoCache
 
 		if useCache {
 			// try and look up session credentials from the secure storage cache.

--- a/pkg/granted/credentials.go
+++ b/pkg/granted/credentials.go
@@ -212,7 +212,7 @@ var ImportCredentialsCommand = cli.Command{
 		// if the same option is configured in the config file profile it takes precedence
 		for _, key := range items.Keys() {
 			// omit sensitive values from the merge
-			if !(key.Name() == "aws_access_key_id" || key.Name() == "aws_secret_access_key" || key.Name() == "aws_session_token") {
+			if key.Name() != "aws_access_key_id" && key.Name() != "aws_secret_access_key" && key.Name() != "aws_session_token" {
 				section, err := configFile.GetSection(sectionName)
 				if err != nil {
 					return err

--- a/pkg/granted/doctor/doctor.go
+++ b/pkg/granted/doctor/doctor.go
@@ -128,7 +128,7 @@ func (d *GrantedDoctor) CheckAllAWSCacheTokens(ctx context.Context) error {
 			return err
 		}
 		// close the folder
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		if len(files) == 0 {
 			clio.Info("No valid cached credentials found in `/.aws/sso/cache`")
@@ -151,7 +151,7 @@ func (d *GrantedDoctor) CheckAllAWSCacheTokens(ctx context.Context) error {
 				// if file doesn't start with botocore
 				if !strings.HasPrefix(file.Name(), "botocore") {
 					// close the file
-					defer f.Close()
+					defer func() { _ = f.Close() }()
 					// unmarshal the json
 					var cachedToken cfaws.SSOPlainTextOut
 					err = json.Unmarshal(data, &cachedToken)

--- a/pkg/granted/eks/eks.go
+++ b/pkg/granted/eks/eks.go
@@ -131,8 +131,8 @@ var proxyCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		defer underlyingProxyServerConn.Close()
-		defer yamuxStreamConnection.Close()
+		defer func() { _ = underlyingProxyServerConn.Close() }()
+		defer func() { _ = yamuxStreamConnection.Close() }()
 
 		err = AddContextToConfig(ensuredAccess, tempPort)
 		if err != nil {

--- a/pkg/granted/entrypoint.go
+++ b/pkg/granted/entrypoint.go
@@ -84,7 +84,7 @@ func GetCliApp() *cli.App {
 		EnableBashCompletion: true,
 		Before: func(c *cli.Context) error {
 			if c.String("aws-config-file") != "" {
-				os.Setenv("AWS_CONFIG_FILE", c.String("aws-config-file"))
+				_ = os.Setenv("AWS_CONFIG_FILE", c.String("aws-config-file"))
 			}
 			clio.SetLevelFromEnv("GRANTED_LOG")
 

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -462,7 +462,7 @@ func requestAccess(ctx context.Context, opts requestAccessOpts) error {
 		return err
 	}
 
-	err = grantedConfig.SaveTo(configFilename)
+	err = config.SaveTo(configFilename)
 	if err != nil {
 		return err
 	}

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -24,7 +24,6 @@ import (
 	"github.com/common-fate/granted/pkg/accessrequest"
 	"github.com/common-fate/granted/pkg/cache"
 	"github.com/common-fate/granted/pkg/cfaws"
-	"github.com/common-fate/granted/pkg/config"
 	grantedConfig "github.com/common-fate/granted/pkg/config"
 	"github.com/common-fate/granted/pkg/frecency"
 	"github.com/common-fate/granted/pkg/securestorage"
@@ -463,7 +462,7 @@ func requestAccess(ctx context.Context, opts requestAccessOpts) error {
 		return err
 	}
 
-	err = config.SaveTo(configFilename)
+	err = grantedConfig.SaveTo(configFilename)
 	if err != nil {
 		return err
 	}
@@ -735,7 +734,7 @@ func updateCachedAccessRule(ctx context.Context, opts updateCacheOpts) error {
 }
 
 func getCacheFolder(depID string) (string, error) {
-	configFolder, err := config.GrantedCacheFolder()
+	configFolder, err := grantedConfig.GrantedCacheFolder()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -24,7 +24,6 @@ import (
 	"github.com/common-fate/granted/pkg/accessrequest"
 	"github.com/common-fate/granted/pkg/cache"
 	"github.com/common-fate/granted/pkg/cfaws"
-	"github.com/common-fate/granted/pkg/config"
 	grantedConfig "github.com/common-fate/granted/pkg/config"
 	"github.com/common-fate/granted/pkg/frecency"
 	"github.com/common-fate/granted/pkg/securestorage"
@@ -735,7 +734,7 @@ func updateCachedAccessRule(ctx context.Context, opts updateCacheOpts) error {
 }
 
 func getCacheFolder(depID string) (string, error) {
-	configFolder, err := config.GrantedCacheFolder()
+	configFolder, err := grantedConfig.GrantedCacheFolder()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/granted/exp/request/request.go
+++ b/pkg/granted/exp/request/request.go
@@ -24,6 +24,7 @@ import (
 	"github.com/common-fate/granted/pkg/accessrequest"
 	"github.com/common-fate/granted/pkg/cache"
 	"github.com/common-fate/granted/pkg/cfaws"
+	"github.com/common-fate/granted/pkg/config"
 	grantedConfig "github.com/common-fate/granted/pkg/config"
 	"github.com/common-fate/granted/pkg/frecency"
 	"github.com/common-fate/granted/pkg/securestorage"
@@ -734,7 +735,7 @@ func updateCachedAccessRule(ctx context.Context, opts updateCacheOpts) error {
 }
 
 func getCacheFolder(depID string) (string, error) {
-	configFolder, err := grantedConfig.GrantedCacheFolder()
+	configFolder, err := config.GrantedCacheFolder()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/granted/rds/rds.go
+++ b/pkg/granted/rds/rds.go
@@ -125,8 +125,8 @@ var proxyCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		defer underlyingProxyServerConn.Close()
-		defer yamuxStreamConnection.Close()
+		defer func() { _ = underlyingProxyServerConn.Close() }()
+		defer func() { _ = yamuxStreamConnection.Close() }()
 
 		connectionString, cliString, clientConnectionPort, err := clientConnectionParameters(c, ensuredAccess)
 		if err != nil {

--- a/pkg/granted/registry/remove.go
+++ b/pkg/granted/registry/remove.go
@@ -95,7 +95,7 @@ var RemoveCommand = cli.Command{
 func remove(gConf *grantedConfig.Config, rName string) error {
 	registries := gConf.ProfileRegistry.Registries
 
-	var index int = -1
+	var index = -1
 	for i := 0; i < len(registries); i++ {
 		if registries[i].Name == rName {
 			index = i

--- a/pkg/granted/registry/setup.go
+++ b/pkg/granted/registry/setup.go
@@ -66,7 +66,7 @@ var SetupCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		// now initialize the git repo
 		err = git.Init(dir)
 		if err != nil {

--- a/pkg/granted/settings/set.go
+++ b/pkg/granted/settings/set.go
@@ -220,12 +220,13 @@ func FieldOptions(cfg any) map[string]Field {
 				}
 			}
 
-			if kind == reflect.Bool || kind == reflect.String || kind == reflect.Int {
+			switch kind {
+			case reflect.Bool, reflect.String, reflect.Int:
 				fieldMap[fieldName] = field{
 					ftype:  fieldType,
 					fvalue: fieldValue,
 				}
-			} else if kind == reflect.Struct {
+			case reflect.Struct:
 				traverseConfigFields(fieldValue.Type(), fieldValue, fieldName)
 			}
 		}

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -278,7 +278,7 @@ var LoginCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			// extract the region using a regex on the meta tag "region"
 			re := regexp.MustCompile(`<meta\s+name="region"\s+content="(.*?)"/>`)

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -294,7 +294,7 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 			return false, nil, justActivated, errors.New("grant was closed")
 
 		default:
-			color.New(color.FgWhite).Fprintf(os.Stderr, "[UNSPECIFIED] %s is in an unspecified status: %s\n. This is most likely due to an error in Common Fate and should be reported to our team: support@commonfate.io.", g.Grant.Name, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgWhite).Fprintf(os.Stderr, "[UNSPECIFIED] %s is in an unspecified status: %s\n. This is most likely due to an error in Common Fate and should be reported to our team: support@commonfate.io.", g.Grant.Name, requestURL(apiURL, g.Grant))
 			return false, nil, justActivated, errors.New("grant was in an unspecified state")
 		}
 
@@ -437,8 +437,8 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 
 		switch g.Change {
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_ACTIVATED:
-			color.New(color.BgHiGreen).Fprintf(os.Stderr, "[WILL ACTIVATE]")
-			color.New(color.FgGreen).Fprintf(os.Stderr, " %s will be activated for %s: %s\n", g.Grant.Name, exp, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.BgHiGreen).Fprintf(os.Stderr, "[WILL ACTIVATE]")
+			_, _ = color.New(color.FgGreen).Fprintf(os.Stderr, " %s will be activated for %s: %s\n", g.Grant.Name, exp, requestURL(apiURL, g.Grant))
 			continue
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_EXTENDED:

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -474,7 +474,7 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 			continue
 		}
 
-		color.New(color.FgWhite).Fprintf(os.Stderr, "[UNSPECIFIED] %s is in an unspecified status: %s\n. This is most likely due to an error in Common Fate and should be reported to our team: support@commonfate.io.", g.Grant.Name, requestURL(apiURL, g.Grant))
+		_, _ = color.New(color.FgWhite).Fprintf(os.Stderr, "[UNSPECIFIED] %s is in an unspecified status: %s\n. This is most likely due to an error in Common Fate and should be reported to our team: support@commonfate.io.", g.Grant.Name, requestURL(apiURL, g.Grant))
 	}
 
 	printdiags.Print(res.Msg.Diagnostics, names)

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -210,14 +210,14 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 	si := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 	si.Suffix = " ensuring access..."
 	si.Writer = os.Stderr
-	_ = si.Start()
+	si.Start()
 
 	res, err := accessclient.BatchEnsure(ctx, connect.NewRequest(&req))
 	if err != nil {
-		_ = si.Stop()
+		si.Stop()
 		return false, nil, justActivated, err
 	}
-	_ = si.Stop()
+	si.Stop()
 	//prints response diag messages
 	printdiags.Print(res.Msg.Diagnostics, nil)
 
@@ -399,15 +399,15 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 	si := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 	si.Suffix = " planning access changes..."
 	si.Writer = os.Stderr
-	_ = si.Start()
+	si.Start()
 
 	res, err := client.BatchEnsure(ctx, connect.NewRequest(req))
 	if err != nil {
-		_ = si.Stop()
+		si.Stop()
 		return false, nil, err
 	}
 
-	_ = si.Stop()
+	si.Stop()
 
 	clio.Debugw("BatchEnsure response", "response", res)
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -451,13 +451,13 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 			continue
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_REQUESTED:
-			color.New(color.BgHiYellow, color.FgBlack).Fprintf(os.Stderr, "[WILL REQUEST]")
-			color.New(color.FgYellow).Fprintf(os.Stderr, " %s will require approval\n", g.Grant.Name)
+			_, _ = color.New(color.BgHiYellow, color.FgBlack).Fprintf(os.Stderr, "[WILL REQUEST]")
+			_, _ = color.New(color.FgYellow).Fprintf(os.Stderr, " %s will require approval\n", g.Grant.Name)
 			continue
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_PROVISIONING_FAILED:
 			// shouldn't happen in the dry-run request but handle anyway
-			color.New(color.FgRed).Fprintf(os.Stderr, "[ERROR] %s will fail provisioning\n", g.Grant.Name)
+			_, _ = color.New(color.FgRed).Fprintf(os.Stderr, "[ERROR] %s will fail provisioning\n", g.Grant.Name)
 			continue
 		}
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -275,21 +275,21 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 		case accessv1alpha1.GrantStatus_GRANT_STATUS_ACTIVE:
 			// work out how long is remaining on the active grant
 			exp = ShortDur(time.Until(g.Grant.ExpiresAt.AsTime()))
-			color.New(color.FgGreen).Fprintf(os.Stderr, "[ACTIVE] %s is already active for the next %s: %s\n", g.Grant.Name, exp, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgGreen).Fprintf(os.Stderr, "[ACTIVE] %s is already active for the next %s: %s\n", g.Grant.Name, exp, requestURL(apiURL, g.Grant))
 
 			retry = true
 
 			continue
 
 		case accessv1alpha1.GrantStatus_GRANT_STATUS_PENDING:
-			color.New(color.FgWhite).Fprintf(os.Stderr, "[PENDING] %s is already pending: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgWhite).Fprintf(os.Stderr, "[PENDING] %s is already pending: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
 			if input.Wait {
 				return true, res.Msg, justActivated, nil
 			}
 			return false, nil, justActivated, errors.New("access is pending approval")
 
 		case accessv1alpha1.GrantStatus_GRANT_STATUS_CLOSED:
-			color.New(color.FgWhite).Fprintf(os.Stderr, "[CLOSED] %s is closed but was still returned: %s\n. This is most likely due to an error in Common Fate and should be reported to our team: support@commonfate.io.", g.Grant.Name, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgWhite).Fprintf(os.Stderr, "[CLOSED] %s is closed but was still returned: %s\n. This is most likely due to an error in Common Fate and should be reported to our team: support@commonfate.io.", g.Grant.Name, requestURL(apiURL, g.Grant))
 
 			return false, nil, justActivated, errors.New("grant was closed")
 
@@ -446,8 +446,8 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 			if g.Grant.Extension != nil {
 				extendedTime = ShortDur(g.Grant.Extension.ExtensionDurationSeconds.AsDuration())
 			}
-			color.New(color.BgBlue).Printf("[WILL EXTEND]")
-			color.New(color.FgBlue).Printf(" %s will be extended for another %s: %s\n", g.Grant.Name, extendedTime, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.BgBlue).Printf("[WILL EXTEND]")
+			_, _ = color.New(color.FgBlue).Printf(" %s will be extended for another %s: %s\n", g.Grant.Name, extendedTime, requestURL(apiURL, g.Grant))
 			continue
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_REQUESTED:
@@ -464,13 +464,13 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 		switch g.Grant.Status {
 		case accessv1alpha1.GrantStatus_GRANT_STATUS_ACTIVE:
 			exp = ShortDur(time.Until(g.Grant.ExpiresAt.AsTime()))
-			color.New(color.FgGreen).Fprintf(os.Stderr, "[ACTIVE] %s is already active for the next %s: %s\n", g.Grant.Name, exp, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgGreen).Fprintf(os.Stderr, "[ACTIVE] %s is already active for the next %s: %s\n", g.Grant.Name, exp, requestURL(apiURL, g.Grant))
 			continue
 		case accessv1alpha1.GrantStatus_GRANT_STATUS_PENDING:
-			color.New(color.FgWhite).Fprintf(os.Stderr, "[PENDING] %s is already pending: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgWhite).Fprintf(os.Stderr, "[PENDING] %s is already pending: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
 			continue
 		case accessv1alpha1.GrantStatus_GRANT_STATUS_CLOSED:
-			color.New(color.FgWhite).Fprintf(os.Stderr, "[CLOSED] %s is closed but was still returned: %s\n. This is most likely due to an error in Common Fate and should be reported to our team: support@commonfate.io.", g.Grant.Name, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgWhite).Fprintf(os.Stderr, "[CLOSED] %s is closed but was still returned: %s\n. This is most likely due to an error in Common Fate and should be reported to our team: support@commonfate.io.", g.Grant.Name, requestURL(apiURL, g.Grant))
 			continue
 		}
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -210,14 +210,14 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 	si := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 	si.Suffix = " ensuring access..."
 	si.Writer = os.Stderr
-	si.Start()
+	_ = si.Start()
 
 	res, err := accessclient.BatchEnsure(ctx, connect.NewRequest(&req))
 	if err != nil {
-		si.Stop()
+		_ = si.Stop()
 		return false, nil, justActivated, err
 	}
-	si.Stop()
+	_ = si.Stop()
 	//prints response diag messages
 	printdiags.Print(res.Msg.Diagnostics, nil)
 
@@ -246,8 +246,8 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 			if g.Grant.Extension != nil {
 				extendedTime = ShortDur(g.Grant.Extension.ExtensionDurationSeconds.AsDuration())
 			}
-			_, _ = color.New(color.BgBlue).Printf("[EXTENDED]")
-			_, _ = color.New(color.FgBlue).Printf(" %s was extended for another %s: %s\n", g.Grant.Name, extendedTime, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.BgBlue).Fprintf(os.Stderr, "[EXTENDED]")
+			_, _ = color.New(color.FgBlue).Fprintf(os.Stderr, " %s was extended for another %s: %s\n", g.Grant.Name, extendedTime, requestURL(apiURL, g.Grant))
 			_, _ = color.New(color.FgGreen).Printf(" %s will now expire in %s\n", g.Grant.Name, exp)
 
 			retry = true
@@ -256,7 +256,7 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_REQUESTED:
 			_, _ = color.New(color.BgHiYellow, color.FgBlack).Fprintf(os.Stderr, "[REQUESTED]")
-			color.New(color.FgYellow).Fprintf(os.Stderr, " %s requires approval: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgYellow).Fprintf(os.Stderr, " %s requires approval: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
 
 			if input.Wait {
 				return true, res.Msg, justActivated, nil
@@ -266,7 +266,7 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_PROVISIONING_FAILED:
 			// shouldn't happen in the dry-run request but handle anyway
-			color.New(color.FgRed).Fprintf(os.Stderr, "[ERROR] %s failed provisioning: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgRed).Fprintf(os.Stderr, "[ERROR] %s failed provisioning: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
 
 			return false, nil, justActivated, errors.New("access provisioning failed")
 		}
@@ -399,15 +399,15 @@ func DryRun(ctx context.Context, apiURL *url.URL, client accessv1alpha1connect.A
 	si := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 	si.Suffix = " planning access changes..."
 	si.Writer = os.Stderr
-	si.Start()
+	_ = si.Start()
 
 	res, err := client.BatchEnsure(ctx, connect.NewRequest(req))
 	if err != nil {
-		si.Stop()
+		_ = si.Stop()
 		return false, nil, err
 	}
 
-	si.Stop()
+	_ = si.Stop()
 
 	clio.Debugw("BatchEnsure response", "response", res)
 

--- a/pkg/hook/accessrequesthook/accessrequesthook.go
+++ b/pkg/hook/accessrequesthook/accessrequesthook.go
@@ -233,8 +233,8 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 
 		switch g.Change {
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_ACTIVATED:
-			color.New(color.BgHiGreen).Fprintf(os.Stderr, "[ACTIVATED]")
-			color.New(color.FgGreen).Fprintf(os.Stderr, " %s was activated for %s: %s\n", g.Grant.Name, exp, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.BgHiGreen).Fprintf(os.Stderr, "[ACTIVATED]")
+			_, _ = color.New(color.FgGreen).Fprintf(os.Stderr, " %s was activated for %s: %s\n", g.Grant.Name, exp, requestURL(apiURL, g.Grant))
 
 			retry = true
 			justActivated = true
@@ -246,16 +246,16 @@ func (h Hook) NoEntitlementAccess(ctx context.Context, cfg *config.Context, inpu
 			if g.Grant.Extension != nil {
 				extendedTime = ShortDur(g.Grant.Extension.ExtensionDurationSeconds.AsDuration())
 			}
-			color.New(color.BgBlue).Printf("[EXTENDED]")
-			color.New(color.FgBlue).Printf(" %s was extended for another %s: %s\n", g.Grant.Name, extendedTime, requestURL(apiURL, g.Grant))
-			color.New(color.FgGreen).Printf(" %s will now expire in %s\n", g.Grant.Name, exp)
+			_, _ = color.New(color.BgBlue).Printf("[EXTENDED]")
+			_, _ = color.New(color.FgBlue).Printf(" %s was extended for another %s: %s\n", g.Grant.Name, extendedTime, requestURL(apiURL, g.Grant))
+			_, _ = color.New(color.FgGreen).Printf(" %s will now expire in %s\n", g.Grant.Name, exp)
 
 			retry = true
 
 			continue
 
 		case accessv1alpha1.GrantChange_GRANT_CHANGE_REQUESTED:
-			color.New(color.BgHiYellow, color.FgBlack).Fprintf(os.Stderr, "[REQUESTED]")
+			_, _ = color.New(color.BgHiYellow, color.FgBlack).Fprintf(os.Stderr, "[REQUESTED]")
 			color.New(color.FgYellow).Fprintf(os.Stderr, " %s requires approval: %s\n", g.Grant.Name, requestURL(apiURL, g.Grant))
 
 			if input.Wait {
@@ -382,7 +382,7 @@ func (h Hook) RetryNoEntitlementAccess(ctx context.Context, cfg *config.Context,
 	// Note: the current behaviour of Common Fate BatchEnsure is that it only returns the grant that you asked for event when a request already exists with multiple
 	// grants, if this changes in the future, we would need to fix this logic to correctly identify the grant that the user requested
 	// for now this will work
-	if !(allGrantsApproved && allGrantsActivated) {
+	if !allGrantsApproved || !allGrantsActivated {
 		return res.Msg, errors.New("waiting on all grants to be approved and activated")
 	}
 	return res.Msg, nil

--- a/pkg/launcher/chrome_profile.go
+++ b/pkg/launcher/chrome_profile.go
@@ -119,7 +119,7 @@ func setProfileName(profile string, browserType string) {
 		return
 	}
 
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	encoder := json.NewEncoder(file)
 	err = encoder.Encode(f)
 	if err != nil {

--- a/pkg/shells/file.go
+++ b/pkg/shells/file.go
@@ -23,7 +23,7 @@ func AppendLine(file string, line string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 	// include newlines around the line
 	a := fmt.Sprintf("\n%s\n", line)
 	_, err = out.WriteString(a)

--- a/pkg/shells/find_config.go
+++ b/pkg/shells/find_config.go
@@ -26,7 +26,7 @@ func GetPosixConfigFile() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 	}
 	return file, nil
 }
@@ -44,7 +44,7 @@ func GetFishConfigFile() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 	}
 	return file, nil
 }
@@ -62,7 +62,7 @@ func GetTcshConfigFile() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 	}
 	return file, nil
 }
@@ -97,7 +97,7 @@ func GetBashConfigFile() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 	}
 
 	return file, nil
@@ -124,7 +124,7 @@ func GetZshConfigFile() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 	}
 	return file, nil
 }


### PR DESCRIPTION
Fixes all the lint errors that are now being thrown by golangci-lint after it was upgraded in #853.