### PR TITLE
Revert "Added ability to specify multiple services top be opened with the --console flag"

### DIFF
--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -30,7 +30,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "export-sso-token", Aliases: []string{"es"}, Usage: "Export sso token to ~/.aws/sso/cache"},
 		&cli.BoolFlag{Name: "unset", Aliases: []string{"un"}, Usage: "Unset all environment variables configured by Assume"},
 		&cli.BoolFlag{Name: "url", Aliases: []string{"u"}, Usage: "Get an active console session url"},
-		&cli.StringSliceFlag{Name: "service", Aliases: []string{"s"}, Usage: "Like --c, but opens to a specified service"},
+		&cli.StringFlag{Name: "service", Aliases: []string{"s"}, Usage: "Like --c, but opens to a specified service"},
 		&cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "region to launch the console or export to the terminal"},
 		&cli.StringFlag{Name: "console-destination", Aliases: []string{"cd"}, Usage: "Open a web console at this destination"},
 		&cli.StringSliceFlag{Name: "pass-through", Aliases: []string{"pt"}, Usage: "Pass args to proxy assumer"},

--- a/pkg/console/aws.go
+++ b/pkg/console/aws.go
@@ -13,7 +13,7 @@ import (
 type AWS struct {
 	Profile     string
 	Region      string
-	Service     []string
+	Service     string
 	Destination string
 }
 
@@ -28,39 +28,11 @@ type awsSession struct {
 	SessionToken string `json:"sessionToken"`
 }
 
-func (a AWS) URLs(creds aws.Credentials) ([]string, error) {
-
-	urls := []string{}
-
-	//if region and service were not specified create a single default url and return
-	if a.Region == "" && len(a.Service) == 0 {
-		url, err := a.URL(creds, "", "")
-		if err != nil {
-			return nil, err
-		}
-		urls = append(urls, url)
-		return urls, nil
-	}
-
-	//if one or more services were specified in the assume command then create multiple urls to be opened up in the browser
-	if len(a.Service) > 0 {
-		for _, service := range a.Service {
-			url, err := a.URL(creds, a.Region, service)
-			if err != nil {
-				return nil, err
-			}
-			urls = append(urls, url)
-		}
-	}
-
-	return urls, nil
-}
-
 // URL retrieves an authorised access URL for the AWS console. The URL includes a security token which is retrieved
 // by exchanging AWS session credentials using the AWS federation endpoint.
 //
 // see: https://docs.aws.amazon.com/IAM/latest/UserGuide/example_sts_Scenario_ConstructFederatedUrl_section.html
-func (a AWS) URL(creds aws.Credentials, region string, service string) (string, error) {
+func (a AWS) URL(creds aws.Credentials) (string, error) {
 	sess := awsSession{
 		SessionID:    creds.AccessKeyID,
 		SessionKey:   creds.SecretAccessKey,
@@ -71,12 +43,12 @@ func (a AWS) URL(creds aws.Credentials, region string, service string) (string, 
 		return "", err
 	}
 
-	partition := GetPartitionFromRegion(region)
+	partition := GetPartitionFromRegion(a.Region)
 	clio.Debugf("Partition is detected as %s for region %s...\n", partition, a.Region)
 
 	u := url.URL{
 		Scheme: "https",
-		Host:   partition.RegionalHostString(region),
+		Host:   partition.RegionalHostString(a.Region),
 		Path:   "/federation",
 	}
 	q := u.Query()
@@ -103,11 +75,11 @@ func (a AWS) URL(creds aws.Credentials, region string, service string) (string, 
 
 	u = url.URL{
 		Scheme: "https",
-		Host:   partition.RegionalHostString(region),
+		Host:   partition.RegionalHostString(a.Region),
 		Path:   "/federation",
 	}
 
-	dest, err := makeDestinationURL(service, region, a.Destination)
+	dest, err := makeDestinationURL(a.Service, a.Region, a.Destination)
 
 	if err != nil {
 		return "", err

--- a/pkg/granted/console.go
+++ b/pkg/granted/console.go
@@ -40,107 +40,103 @@ var ConsoleCommand = cli.Command{
 			return err
 		}
 		con := console.AWS{
-			Service:     []string{c.String("service")},
+			Service:     c.String("service"),
 			Region:      c.String("region"),
 			Destination: c.String("destination"),
 		}
 
-		consoleURLs, err := con.URLs(*credentials)
+		consoleURL, err := con.URL(*credentials)
 		if err != nil {
 			return err
 		}
 
-		for _, consoleURL := range consoleURLs {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		if c.Bool("firefox") || cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey {
+			// transform the URL into the Firefox Tab Container format.
+			consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", c.String("container-name"), url.QueryEscape(consoleURL), c.String("color"), c.String("icon"))
+		}
 
-			cfg, err := config.Load()
-			if err != nil {
-				return err
-			}
-			if c.Bool("firefox") || cfg.DefaultBrowser == browser.FirefoxKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey {
-				// transform the URL into the Firefox Tab Container format.
-				consoleURL = fmt.Sprintf("ext+granted-containers:name=%s&url=%s&color=%s&icon=%s", c.String("container-name"), url.QueryEscape(consoleURL), c.String("color"), c.String("icon"))
-			}
+		justPrintURL := c.Bool("url") || cfg.DefaultBrowser == browser.StdoutKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey
+		if justPrintURL {
+			// return the url via stdout through the CLI wrapper script and return early.
+			fmt.Print(consoleURL)
+			return nil
+		}
 
-			justPrintURL := c.Bool("url") || cfg.DefaultBrowser == browser.StdoutKey || cfg.DefaultBrowser == browser.FirefoxStdoutKey
-			if justPrintURL {
-				// return the url via stdout through the CLI wrapper script and return early.
-				fmt.Print(consoleURL)
-				return nil
-			}
-
-			var l assume.Launcher
-			if cfg.CustomBrowserPath == "" && cfg.DefaultBrowser != "" {
-				l = launcher.Open{}
-			} else if cfg.CustomBrowserPath == "" && cfg.AWSConsoleBrowserLaunchTemplate == nil {
-				return errors.New("default browser not configured. run `granted browser set` to configure")
-			} else {
-				switch cfg.DefaultBrowser {
-				case browser.ChromeKey:
-					l = launcher.ChromeProfile{
-						ExecutablePath: cfg.CustomBrowserPath,
-					}
-				case browser.BraveKey:
-					l = launcher.ChromeProfile{
-						ExecutablePath: cfg.CustomBrowserPath,
-					}
-				case browser.EdgeKey:
-					l = launcher.ChromeProfile{
-						ExecutablePath: cfg.CustomBrowserPath,
-					}
-				case browser.ChromiumKey:
-					l = launcher.ChromeProfile{
-						ExecutablePath: cfg.CustomBrowserPath,
-					}
-				case browser.VivaldiKey:
-					l = launcher.ChromeProfile{
-						ExecutablePath: cfg.CustomBrowserPath,
-					}
-				case browser.FirefoxKey:
-					l = launcher.Firefox{
-						ExecutablePath: cfg.CustomBrowserPath,
-					}
-				case browser.SafariKey:
-					l = launcher.Safari{}
-				case browser.CustomKey:
-					l, err = launcher.CustomFromLaunchTemplate(cfg.AWSConsoleBrowserLaunchTemplate, c.StringSlice("browser-launch-template-arg"))
-					if err == launcher.ErrLaunchTemplateNotConfigured {
-						return errors.New("error configuring custom browser, ensure that [AWSConsoleBrowserLaunchTemplate] is specified in your Granted config file")
-					}
-					if err != nil {
-						return err
-					}
-				default:
-					l = launcher.Open{}
+		var l assume.Launcher
+		if cfg.CustomBrowserPath == "" && cfg.DefaultBrowser != "" {
+			l = launcher.Open{}
+		} else if cfg.CustomBrowserPath == "" && cfg.AWSConsoleBrowserLaunchTemplate == nil {
+			return errors.New("default browser not configured. run `granted browser set` to configure")
+		} else {
+			switch cfg.DefaultBrowser {
+			case browser.ChromeKey:
+				l = launcher.ChromeProfile{
+					ExecutablePath: cfg.CustomBrowserPath,
 				}
-			}
-			// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
-			args, err := l.LaunchCommand(consoleURL, con.Profile)
-			if err != nil {
-				return fmt.Errorf("error building browser launch command: %w", err)
-			}
-
-			var startErr error
-			if l.UseForkProcess() {
-				clio.Debugf("running command using forkprocess: %s", args)
-				cmd, err := forkprocess.New(args...)
+			case browser.BraveKey:
+				l = launcher.ChromeProfile{
+					ExecutablePath: cfg.CustomBrowserPath,
+				}
+			case browser.EdgeKey:
+				l = launcher.ChromeProfile{
+					ExecutablePath: cfg.CustomBrowserPath,
+				}
+			case browser.ChromiumKey:
+				l = launcher.ChromeProfile{
+					ExecutablePath: cfg.CustomBrowserPath,
+				}
+			case browser.VivaldiKey:
+				l = launcher.ChromeProfile{
+					ExecutablePath: cfg.CustomBrowserPath,
+				}
+			case browser.FirefoxKey:
+				l = launcher.Firefox{
+					ExecutablePath: cfg.CustomBrowserPath,
+				}
+			case browser.SafariKey:
+				l = launcher.Safari{}
+			case browser.CustomKey:
+				l, err = launcher.CustomFromLaunchTemplate(cfg.AWSConsoleBrowserLaunchTemplate, c.StringSlice("browser-launch-template-arg"))
+				if err == launcher.ErrLaunchTemplateNotConfigured {
+					return errors.New("error configuring custom browser, ensure that [AWSConsoleBrowserLaunchTemplate] is specified in your Granted config file")
+				}
 				if err != nil {
 					return err
 				}
-				startErr = cmd.Start()
-			} else {
-				clio.Debugf("running command without forkprocess: %s", args)
-				cmd := exec.Command(args[0], args[1:]...)
-				startErr = cmd.Start()
+			default:
+				l = launcher.Open{}
 			}
+		}
+		// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
+		args, err := l.LaunchCommand(consoleURL, con.Profile)
+		if err != nil {
+			return fmt.Errorf("error building browser launch command: %w", err)
+		}
 
-			if startErr != nil {
-				return clierr.New(fmt.Sprintf("Granted was unable to open a browser session automatically due to the following error: %s", startErr.Error()),
-					// allow them to try open the url manually
-					clierr.Info("You can open the browser session manually using the following url:"),
-					clierr.Info(consoleURL),
-				)
+		var startErr error
+		if l.UseForkProcess() {
+			clio.Debugf("running command using forkprocess: %s", args)
+			cmd, err := forkprocess.New(args...)
+			if err != nil {
+				return err
 			}
-			return nil
+			startErr = cmd.Start()
+		} else {
+			clio.Debugf("running command without forkprocess: %s", args)
+			cmd := exec.Command(args[0], args[1:]...)
+			startErr = cmd.Start()
+		}
+
+		if startErr != nil {
+			return clierr.New(fmt.Sprintf("Granted was unable to open a browser session automatically due to the following error: %s", startErr.Error()),
+				// allow them to try open the url manually
+				clierr.Info("You can open the browser session manually using the following url:"),
+				clierr.Info(consoleURL),
+			)
 		}
 		return nil
 	},


### PR DESCRIPTION
Reverts common-fate/granted#827 - it's caused the linter to fail on the main branch and I suspect it's due to an inadvertent behavioral change the PR may have introduced.