### PR TITLE
Add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Features, Bug Reports, Questions
+    url: https://github.com/common-fate/granted/discussions/new/choose
+    about: Our preferred starting point if you have any questions or suggestions about configuration, features or behavior.

--- a/.github/ISSUE_TEMPLATE/preapproved.md
+++ b/.github/ISSUE_TEMPLATE/preapproved.md
@@ -1,0 +1,9 @@
+---
+name: Pre-Discussed and Approved Topics
+about: |-
+  Only for topics already discussed and approved in the GitHub Discussions section.
+---
+
+**DO NOT OPEN A NEW ISSUE. PLEASE USE THE DISCUSSIONS SECTION.**
+
+**I DIDN'T READ THE ABOVE LINE. PLEASE CLOSE THIS ISSUE.**


### PR DESCRIPTION
Inspired by https://github.com/ghostty-org/ghostty ❤️ encourages folks to use Discussions first, and then the Issues list will just become a todo list for the project.