### PR TITLE
fix: credential process ignores --mfa-token flag

### DIFF
--- a/pkg/cfaws/assumer_aws_credential_process.go
+++ b/pkg/cfaws/assumer_aws_credential_process.go
@@ -49,10 +49,22 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *Prof
 				}
 				if p.AWSConfig.MFASerial != "" {
 					aro.SerialNumber = &p.AWSConfig.MFASerial
-					aro.TokenProvider = MfaTokenProvider
+					if configOpts.MFATokenCode != "" {
+						aro.TokenProvider = func() (string, error) {
+							return configOpts.MFATokenCode, nil
+						}
+					} else {
+						aro.TokenProvider = MfaTokenProvider
+					}
 				} else if c.AWSConfig.MFASerial != "" {
 					aro.SerialNumber = &c.AWSConfig.MFASerial
-					aro.TokenProvider = MfaTokenProvider
+					if configOpts.MFATokenCode != "" {
+						aro.TokenProvider = func() (string, error) {
+							return configOpts.MFATokenCode, nil
+						}
+					} else {
+						aro.TokenProvider = MfaTokenProvider
+					}
 				}
 				aro.Duration = configOpts.Duration
 			})
@@ -69,7 +81,13 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *Prof
 			aro.RoleSessionName = getRoleSessionNameFromProfile(c)
 			if c.AWSConfig.MFASerial != "" {
 				aro.SerialNumber = &c.AWSConfig.MFASerial
-				aro.TokenProvider = MfaTokenProvider
+				if configOpts.MFATokenCode != "" {
+					aro.TokenProvider = func() (string, error) {
+						return configOpts.MFATokenCode, nil
+					}
+				} else {
+					aro.TokenProvider = MfaTokenProvider
+				}
 			}
 			aro.Duration = configOpts.Duration
 			if c.AWSConfig.ExternalID != "" {


### PR DESCRIPTION
Fixed #604

The `--mfa-token` CLI flag was being ignored when using `credential_process` with `source_profile` configurations, causing users to be prompted interactively for MFA tokens even when provided via the command line.

Updated `CredentialProcessAssumer.AssumeTerminal()` to check if `configOpts.MFATokenCode` is provided before falling back to `MfaTokenProvider`.
