### PR TITLE
fix(browser): correct help message for browser set command

### DIFF
--- a/pkg/browser/detect.go
+++ b/pkg/browser/detect.go
@@ -288,7 +288,7 @@ func ConfigureBrowserSelection(browserName string, path string) error {
 }
 
 func GrantedIntroduction() {
-	clio.Info("To change the web browser that Granted uses run: `granted browser -set`")
+	clio.Info("To change the web browser that Granted uses run: `granted browser set`")
 	clio.NewLine()
 	clio.Info("Here's how to use Granted to supercharge your cloud access:")
 	clio.Info("`assume`                   - search profiles to assume")


### PR DESCRIPTION
Fix typo in GrantedIntroduction: change `granted browser -set` to `granted browser set`.

This is a small docs/UX fix that corrects the help text shown in the interactive introduction (function `GrantedIntroduction` in `pkg/browser/detect.go`). No behavioural changes or tests are required.

Files changed:
- `pkg/browser/detect.go`: corrected message from `granted browser -set` to `granted browser set`.
