### PR TITLE
feat!: add GRANTED_BROWSER_PROFILE env var support for browser profile override

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -280,10 +280,11 @@ func AssumeCommand(c *cli.Context) error {
 	}
 
 	configOpts := cfaws.ConfigOpts{
-		Duration:     time.Hour,
-		MFATokenCode: assumeFlags.String("mfa-token"),
-		Args:         assumeFlags.StringSlice("pass-through"),
-		DisableCache: assumeFlags.Bool("no-cache"),
+		Duration:          time.Hour,
+		MFATokenCode:      assumeFlags.String("mfa-token"),
+		Args:              assumeFlags.StringSlice("pass-through"),
+		DisableCache:      assumeFlags.Bool("no-cache"),
+		SSOBrowserProfile: assumeFlags.String("sso-browser-profile"),
 	}
 
 	// attempt to get session duration from profile

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -46,6 +46,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.StringFlag{Name: "account-id", Usage: "Use this in conjunction with --sso, the account-id"},
 		&cli.StringFlag{Name: "role-name", Usage: "Use this in conjunction with --sso, the role-name"},
 		&cli.StringFlag{Name: "browser-profile", Aliases: []string{"bp"}, Usage: "Use a pre-existing profile in your browser", EnvVars: []string{"GRANTED_BROWSER_PROFILE"}},
+		&cli.StringFlag{Name: "sso-browser-profile", Usage: "Use a pre-existing profile in your browser for SSO login", EnvVars: []string{"GRANTED_SSO_BROWSER_PROFILE"}},
 		&cli.StringFlag{Name: "mfa-token", Usage: "Provide your current MFA token for the role you are assuming to skip being prompted"},
 		&cli.StringFlag{Name: "save-to", Usage: "Use this in conjunction with --sso, the profile name to save the role to in your AWS config file"},
 		&cli.BoolFlag{Name: "export-all-env-vars", Aliases: []string{"x"}, Usage: "Exports all available credentials to the terminal when used with a profile configured for credential-process. Without this flag, only the AWS_PROFILE will be configured"},

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -192,7 +192,7 @@ func (c *Profile) SSOLogin(ctx context.Context, configOpts ConfigOpts) (aws.Cred
 	if cachedToken == nil && plainTextToken == nil {
 		newCfg := aws.NewConfig()
 		newCfg.Region = rootProfile.SSORegion()
-		newSSOToken, err := idclogin.Login(ctx, *newCfg, rootProfile.SSOStartURL(), rootProfile.SSOScopes())
+		newSSOToken, err := idclogin.Login(ctx, *newCfg, rootProfile.SSOStartURL(), rootProfile.SSOScopes(), configOpts.SSOBrowserProfile)
 		if err != nil {
 			return aws.Credentials{}, err
 		}

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -27,6 +27,7 @@ type ConfigOpts struct {
 	ShouldRetryAssuming        *bool
 	MFATokenCode               string
 	DisableCache               bool
+	SSOBrowserProfile          string
 }
 
 type Profile struct {

--- a/pkg/idclogin/run.go
+++ b/pkg/idclogin/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"time"
 
@@ -20,7 +19,7 @@ import (
 )
 
 // Login contains all the steps to complete a device code flow to retrieve an SSO token
-func Login(ctx context.Context, cfg aws.Config, startUrl string, scopes []string) (*securestorage.SSOToken, error) {
+func Login(ctx context.Context, cfg aws.Config, startUrl string, scopes []string, browserProfile string) (*securestorage.SSOToken, error) {
 	ssooidcClient := ssooidc.NewFromConfig(cfg)
 
 	// If scopes aren't provided, default to the legacy non-refreshable configuration
@@ -79,10 +78,8 @@ func Login(ctx context.Context, cfg aws.Config, startUrl string, scopes []string
 			return nil, err
 		}
 
-		// Determine the browser profile to use for SSO login
-		ssoBrowserProfile := os.Getenv("GRANTED_SSO_BROWSER_PROFILE")
 		// now build the actual command to run - e.g. 'firefox --new-tab <URL>'
-		args, err := l.LaunchCommand(url, ssoBrowserProfile)
+		args, err := l.LaunchCommand(url, browserProfile)
 		if err != nil {
 			return nil, fmt.Errorf("error building browser launch command: %w", err)
 		}

--- a/pkg/launcher/custom_test.go
+++ b/pkg/launcher/custom_test.go
@@ -36,6 +36,17 @@ func TestCustom_LaunchCommand(t *testing.T) {
 			want: []string{"/usr/bin/firefox", "--url", "https://commonfate.io", "--profile", "example"},
 		},
 		{
+			name: "empty_profile",
+			fields: fields{
+				Command: "/usr/bin/firefox --url {{.URL}} --profile {{.Profile}}",
+			},
+			args: args{
+				url:     "https://commonfate.io",
+				profile: "",
+			},
+			want: []string{"/usr/bin/firefox", "--url", "https://commonfate.io", "--profile", ""},
+		},
+		{
 			name: "with_args",
 			fields: fields{
 				Command: "{{.Args.Foo}}",


### PR DESCRIPTION
# Details

Add support for `GRANTED_BROWSER_PROFILE` and `GRANTED_SSO_BROWSER_PROFILE` environment variables to override the browser profile used when opening AWS console and during SSO login flows.

Fixes #886

## Changes

### Browser Profile for Console Access (`GRANTED_BROWSER_PROFILE`)

- Add `EnvVars` to `--browser-profile` flag to automatically read from `GRANTED_BROWSER_PROFILE` environment variable
- Remove `browser-profile` from `getConsoleURL` condition to prevent env var from inadvertently triggering console URL generation
- Browser profile from env var is only used when actually launching browser (after all safety checks)

### SSO Browser Profile (`GRANTED_SSO_BROWSER_PROFILE`)

- Add `--sso-browser-profile` flag to `assume`, `granted sso login`, `granted sso generate`, and `granted sso populate` commands
- Add `SSOBrowserProfile` field to `ConfigOpts` to pass browser profile through SSO login flow
- Support `GRANTED_SSO_BROWSER_PROFILE` environment variable via flag `EnvVars`
- Add test case for empty browser profile in launcher tests

## Breaking Changes

The `--browser-profile` flag no longer triggers browser opening by itself.

Users must now explicitly use `-c` or `-s` flags along with `--browser-profile` to open a browser with the desired profile.

Previously, passing `--browser-profile` alone would open a browser window, but now it only sets which browser profile to use when a browser is opened via other flags. This prevents the `GRANTED_BROWSER_PROFILE` environment variable from inadvertently opening browsers.

## Usage

### Console Browser Profile

Users can now set a default browser profile via environment variable for console access:

```bash
export GRANTED_BROWSER_PROFILE="MyBrowserProfile"
assume -c my-aws-profile  # Will use "MyBrowserProfile" as the browser profile
```

The `--browser-profile` flag still takes precedence over the environment variable.

### SSO Browser Profile

Users can set a default browser profile for SSO login flows:

```bash
export GRANTED_SSO_BROWSER_PROFILE="MySSOProfile"
granted sso login  # Will use "MySSOProfile" for SSO authentication
assume --sso --sso-start-url https://example.awsapps.com/start  # Will use "MySSOProfile"
```

Or use the flag directly:

```bash
granted sso login --sso-browser-profile MySSOProfile
assume --sso --sso-browser-profile MySSOProfile --sso-start-url https://example.awsapps.com/start
```

The `--sso-browser-profile` flag takes precedence over the `GRANTED_SSO_BROWSER_PROFILE` environment variable.

## Testing

- Added test case for empty browser profile in launcher tests
- All existing tests continue to pass

BREAKING CHANGE: The `--browser-profile` flag no longer triggers browser opening by itself. Users must now explicitly use `-c` or `-s` flags along with `--browser-profile` to open a browser with the desired profile.
