### PR TITLE
Allow ExportCredentialSuffix to be nil

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -464,12 +464,13 @@ func AssumeCommand(c *cli.Context) error {
 				return err
 			}
 			var profileName string
-			if cfg.ExportCredentialSuffix != "" {
-				profileName = profile.Name + "-" + cfg.ExportCredentialSuffix
-
+			if cfg.ExportCredentialSuffix == nil {
+				profileName = profile.Name
+				clio.Warn("No credential suffix found. This can cause issues with using exported credentials if conflicting profiles exist. Run `granted settings export-suffix set` to set one. Set to empty string to supress this warning")
+			} else if *cfg.ExportCredentialSuffix != "" {
+				profileName = profile.Name + "-" + *cfg.ExportCredentialSuffix
 			} else {
 				profileName = profile.Name
-				clio.Warn("No credential suffix found. This can cause issues with using exported credentials if conflicting profiles exist. Run `granted settings export-suffix set` to set one.")
 			}
 
 			credentialsFilePath := cfaws.GetAWSCredentialsPath()

--- a/pkg/cfaws/cred_exporter.go
+++ b/pkg/cfaws/cred_exporter.go
@@ -45,8 +45,8 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 		return err
 	}
 
-	if cfg.ExportCredentialSuffix != "" {
-		profileName = profileName + "-" + cfg.ExportCredentialSuffix
+	if cfg.ExportCredentialSuffix != nil && *cfg.ExportCredentialSuffix!= "" {
+		profileName = profileName + "-" + *cfg.ExportCredentialSuffix
 	}
 
 	credentialsFile.DeleteSection(profileName)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,7 +49,7 @@ type Config struct {
 
 	Keyring                *KeyringConfig `toml:",omitempty"`
 	Ordering               string
-	ExportCredentialSuffix string
+	ExportCredentialSuffix *string
 	// AccessRequestURL is a Granted Approvals URL that users can visit
 	// to request access, in the event that we receive a ForbiddenException
 	// denying access to assume a particular role.

--- a/pkg/granted/settings/export.go
+++ b/pkg/granted/settings/export.go
@@ -20,7 +20,9 @@ var ExportSettingsCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println(cfg.ExportCredentialSuffix)
+		if cfg.ExportCredentialSuffix != nil {
+			fmt.Println(*cfg.ExportCredentialSuffix)
+		}
 		return nil
 	},
 }
@@ -44,7 +46,7 @@ var SetExportSettingsCommand = cli.Command{
 			return err
 		}
 
-		cfg.ExportCredentialSuffix = selection
+		cfg.ExportCredentialSuffix = &selection
 		err = cfg.Save()
 		if err != nil {
 			return err


### PR DESCRIPTION
Allow ExportCredentialSuffix to be nil and only warns if so. This allows users to set a blank suffix to quiet the warning.

Also updates the warning from:

`No credential suffix found. This can cause issues with using exported credentials if conflicting profiles exist. Run 'granted settings export-suffix set'`

to:

`No credential suffix found. This can cause issues with using exported credentials if conflicting profiles exist. Run 'granted settings export-suffix set' to set one. Set to empty string to supress this warning`

I am not a go developer but I was able to test new feature with `dassume` and tests still pass. :)

Addresses #617 