### PR TITLE
fix: silence SSO browser stdout

### DIFF
--- a/cmd/testing/browser/main.go
+++ b/cmd/testing/browser/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 )
 
 // This package is used to test browser features in tests
 func main() {
+	// Make sure we can handle a browser printing something stdout (like Chrome does)
+	fmt.Println("Opening in existing browser session.")
 	os.Exit(0)
 }

--- a/pkg/idclogin/run.go
+++ b/pkg/idclogin/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"time"
 
@@ -95,6 +96,8 @@ func Login(ctx context.Context, cfg aws.Config, startUrl string, scopes []string
 		} else {
 			clio.Debugf("running command without forkprocess: %s", args)
 			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Stdout = os.Stderr
+			cmd.Stderr = os.Stderr
 			startErr = cmd.Start()
 		}
 
@@ -108,6 +111,8 @@ func Login(ctx context.Context, cfg aws.Config, startUrl string, scopes []string
 
 	} else if config.CustomSSOBrowserPath != "" {
 		cmd := exec.Command(config.CustomSSOBrowserPath, url)
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
 		err = cmd.Start()
 		if err != nil {
 			// fail silently


### PR DESCRIPTION
## Summary
- discard browser stdout/stderr so SSO browser noise doesn't pollute credential_process JSON
- include the mock browser stdout change from #567

Fixes #208